### PR TITLE
feat: modify group membership check to support dict-based group var

### DIFF
--- a/api/services/auth_services/authorization_service.py
+++ b/api/services/auth_services/authorization_service.py
@@ -53,8 +53,20 @@ def check_group_membership(user_info: Dict[str, Any]) -> bool:
 
     # Check if any of the user's groups matches an allowed group
     for group in user_groups:
-        if isinstance(group, str) and group.lower() in allowed_groups:
-            logger.info(f"User authorized: belongs to allowed group '{group}'")
+        if isinstance(group, str):
+            group_value = group.lower()
+        elif isinstance(group, dict):
+            group_value = str(
+                group.get("path")
+                or group.get("name")
+                or ""
+            ).lower()
+        else:
+            continue
+
+        logger.info(f"checking group: {group_value}")
+        if group_value and group_value in allowed_groups:
+            logger.info(f"User authorized: belongs to allowed group '{group_value}'")
             return True
 
     logger.warning(


### PR DESCRIPTION
In `ep-api/api/services/auth_services/authorization_service.py`, within the `check_group_membership` func:

line 53:
```python
user_groups = user_info.get("groups", [])
```

it looks like user_groups is not a list of strings but a list of dictionaries, for example:
```bash
ndp-ep-api  | 2025-12-29 19:49:53 [INFO] api.services.auth_services.authorization_service: user_groups: [{'id': 'fc3aa07b-4f72-40db-a8f1-684901bd3bd4', 'name': 'earthscope_user', 'path': '/earthscope_user'}, {'id': 'e2eb5b7e-2d1e-466a-874d-132e1048429f', 'name': 'ep-6949d811b60dd2c1dd26d7e8', 'path': '/ndp_ep/ep-6949d811b60dd2c1dd26d7e8'}, {'id': '9aa9acab-fa90-42fc-b56e-14989218a076', 'name': 'ep-694b12d8b60dd2c1dd26f669', 'path': '/ndp_ep/ep-694b12d8b60dd2c1dd26f669'}, {'id': '24398898-c2c4-4c2c-b9b4-53e4d8547f58', 'name': 'jhub_user', 'path': '/jhub_user'}, {'id': 'af34dd07-da6f-4a08-beea-2acce6dedb3a', 'name': 'yutianq', 'path': '/yutianq'}] 
```

however, the existing logic assumes groups are strings:
```python
# Check if any of the user's groups matches an allowed group
    for group in user_groups:
        if isinstance(group, str) and group.lower() in allowed_groups:
            logger.info(f"User authorized: belongs to allowed group '{group}'")
```

This PR updates the logic to support group entries provided either as strings or dictionaries (matching against name and/or path).

@rbardaji , please take a look. If you see a cleaner or more appropriate approach, feel free to ignore this PR. Thanks.
