### PR TITLE
fix: handle empty Kafka config when connection is disabled

### DIFF
--- a/api/config/kafka_settings.py
+++ b/api/config/kafka_settings.py
@@ -1,6 +1,8 @@
 # api/config/kafka_settings.py
 
 from pydantic_settings import BaseSettings
+from pydantic import field_validator
+from typing import Optional
 
 
 class KafkaSettings(BaseSettings):
@@ -9,6 +11,22 @@ class KafkaSettings(BaseSettings):
     kafka_port: int = 9092
     kafka_prefix: str = "data_stream_"
     max_streams: int = 10
+
+    @field_validator("kafka_port", mode="before")
+    @classmethod
+    def validate_kafka_port(cls, v):
+        """Handle empty string or None when Kafka is disabled."""
+        if v is None or v == "":
+            return 9092  # Return default value
+        return int(v)
+
+    @field_validator("kafka_host", mode="before")
+    @classmethod
+    def validate_kafka_host(cls, v):
+        """Handle empty string or None when Kafka is disabled."""
+        if v is None or v == "":
+            return "localhost"  # Return default value
+        return v
 
     @property
     def connection_details(self):


### PR DESCRIPTION
Add validators to handle empty strings for kafka_host and kafka_port when KAFKA_CONNECTION=False.

Previously, setting these to empty values would cause validation errors even though Kafka was disabled.

Fixes #59