### PR TITLE
docs: Add Pelican Federation API tutorial notebook

### DIFF
--- a/docs/pelican_api_tutorial.ipynb
+++ b/docs/pelican_api_tutorial.ipynb
@@ -1,0 +1,642 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# NDP EP Tutorial: Pelican Federation Integration\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/sci-ndp/pop/blob/main/docs/pelican_api_tutorial.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/sci-ndp/pop/main?filepath=docs/pelican_api_tutorial.ipynb)\n",
+    "\n",
+    "> 🚀 **Run Online Options:**\n",
+    "> - **Google Colab**: Dependencies installed automatically in the first cell\n",
+    "> - **Binder**: Pre-configured environment, ready to run immediately\n",
+    "> - **Local**: Requires `pip install requests jupyter`\n",
+    "\n",
+    "This notebook demonstrates how to use the NDP EP API to interact with Pelican federations. You will learn how to:\n",
+    "\n",
+    "1. **List available federations** (OSDF, PATh-CC, etc.)\n",
+    "2. **Browse namespaces** and directories in federations\n",
+    "3. **Get file information** without downloading\n",
+    "4. **Download files** from federations\n",
+    "5. **Import external files** as resources in your local catalog\n",
+    "\n",
+    "## What is Pelican?\n",
+    "\n",
+    "**Pelican** is a federated data platform that enables sharing and accessing scientific data across institutions. Key federations include:\n",
+    "\n",
+    "- **OSDF** (Open Science Data Federation): Primary federation for scientific data sharing\n",
+    "- **PATh-CC**: PATh Facility data federation\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "- Python 3.7+\n",
+    "- `requests` library\n",
+    "- Access to a NDP EP API instance\n",
+    "\n",
+    "## API Overview\n",
+    "\n",
+    "| Endpoint | Method | Description |\n",
+    "|----------|--------|-------------|\n",
+    "| `/pelican/federations` | GET | List available federations |\n",
+    "| `/pelican/browse` | GET | Browse namespace directories |\n",
+    "| `/pelican/info` | GET | Get file metadata |\n",
+    "| `/pelican/download` | GET | Download file content |\n",
+    "| `/pelican/import-metadata` | POST | Import file to local catalog |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install required packages\n",
+    "!pip install requests -q"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Setup and Configuration\n",
+    "\n",
+    "First, let's import the necessary libraries and configure our API connection parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import json\n",
+    "from typing import Dict, Any, Optional\n",
+    "from pprint import pprint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configuration Variables\n",
+    "\n",
+    "**Important:** Replace `API_BASE_URL` with your actual NDP EP API endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# API Configuration\n",
+    "API_BASE_URL = \"http://localhost:8000\"  # Replace with your API URL\n",
+    "\n",
+    "# Default federation to use\n",
+    "DEFAULT_FEDERATION = \"osdf\"\n",
+    "\n",
+    "print(f\"API Base URL: {API_BASE_URL}\")\n",
+    "print(f\"Default Federation: {DEFAULT_FEDERATION}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Helper Functions\n",
+    "\n",
+    "Let's create utility functions for cleaner API interactions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_request(method: str, endpoint: str, params: Optional[Dict] = None, \n",
+    "                 json_data: Optional[Dict] = None) -> Dict:\n",
+    "    \"\"\"\n",
+    "    Make an API request and return the JSON response.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    method : str\n",
+    "        HTTP method (GET, POST, etc.)\n",
+    "    endpoint : str\n",
+    "        API endpoint (e.g., '/pelican/federations')\n",
+    "    params : dict, optional\n",
+    "        Query parameters\n",
+    "    json_data : dict, optional\n",
+    "        JSON body for POST requests\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    dict\n",
+    "        API response\n",
+    "    \"\"\"\n",
+    "    url = f\"{API_BASE_URL}{endpoint}\"\n",
+    "    \n",
+    "    try:\n",
+    "        response = requests.request(\n",
+    "            method=method,\n",
+    "            url=url,\n",
+    "            params=params,\n",
+    "            json=json_data,\n",
+    "            timeout=30\n",
+    "        )\n",
+    "        response.raise_for_status()\n",
+    "        return response.json()\n",
+    "    except requests.exceptions.RequestException as e:\n",
+    "        print(f\"❌ Request failed: {e}\")\n",
+    "        return {\"success\": False, \"error\": str(e)}\n",
+    "\n",
+    "\n",
+    "def download_file(path: str, federation: str = DEFAULT_FEDERATION, \n",
+    "                  stream: bool = False) -> bytes:\n",
+    "    \"\"\"\n",
+    "    Download a file from Pelican federation.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    path : str\n",
+    "        File path in the federation\n",
+    "    federation : str\n",
+    "        Federation name\n",
+    "    stream : bool\n",
+    "        If True, stream the file\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    bytes\n",
+    "        File contents\n",
+    "    \"\"\"\n",
+    "    url = f\"{API_BASE_URL}/pelican/download\"\n",
+    "    params = {\"path\": path, \"federation\": federation, \"stream\": stream}\n",
+    "    \n",
+    "    response = requests.get(url, params=params, timeout=60)\n",
+    "    response.raise_for_status()\n",
+    "    return response.content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. List Available Federations\n",
+    "\n",
+    "First, let's see what Pelican federations are available through the API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List available federations\n",
+    "federations = make_request(\"GET\", \"/pelican/federations\")\n",
+    "\n",
+    "if federations.get(\"success\"):\n",
+    "    print(\"✅ Available Federations:\\n\")\n",
+    "    for fed_id, fed_info in federations[\"federations\"].items():\n",
+    "        print(f\"  📡 {fed_info['name']} ({fed_id})\")\n",
+    "        print(f\"     URL: {fed_info['url']}\")\n",
+    "        print(f\"     {fed_info['description']}\")\n",
+    "        print()\n",
+    "else:\n",
+    "    print(\"❌ Failed to list federations\")\n",
+    "    pprint(federations)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Browse Namespaces\n",
+    "\n",
+    "Pelican organizes data into namespaces. Let's browse the directory structure.\n",
+    "\n",
+    "### 3.1 Browse Root Namespace"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Browse a namespace path\n",
+    "# Common OSDF paths: /ospool/uc-shared/public, /chtc/staging\n",
+    "\n",
+    "namespace_path = \"/ospool/uc-shared/public\"\n",
+    "\n",
+    "result = make_request(\n",
+    "    \"GET\", \n",
+    "    \"/pelican/browse\",\n",
+    "    params={\"path\": namespace_path, \"federation\": \"osdf\", \"detail\": False}\n",
+    ")\n",
+    "\n",
+    "if result.get(\"success\"):\n",
+    "    print(f\"✅ Contents of {namespace_path}:\\n\")\n",
+    "    \n",
+    "    files = result.get(\"files\", [])\n",
+    "    dirs = result.get(\"directories\", [])\n",
+    "    \n",
+    "    # Show directories first\n",
+    "    for d in dirs[:10]:\n",
+    "        print(f\"  📁 {d}\")\n",
+    "    \n",
+    "    # Show files\n",
+    "    for f in files[:10]:\n",
+    "        print(f\"  📄 {f}\")\n",
+    "    \n",
+    "    total = len(files) + len(dirs)\n",
+    "    if total > 20:\n",
+    "        print(f\"\\n  ... and {total - 20} more items\")\n",
+    "else:\n",
+    "    print(\"❌ Failed to browse namespace\")\n",
+    "    pprint(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.2 Browse with Detailed Information"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Browse with detailed file information\n",
+    "result = make_request(\n",
+    "    \"GET\", \n",
+    "    \"/pelican/browse\",\n",
+    "    params={\"path\": namespace_path, \"federation\": \"osdf\", \"detail\": True}\n",
+    ")\n",
+    "\n",
+    "if result.get(\"success\"):\n",
+    "    print(f\"✅ Detailed contents of {namespace_path}:\\n\")\n",
+    "    \n",
+    "    items = result.get(\"items\", [])\n",
+    "    for item in items[:10]:\n",
+    "        item_type = \"📁\" if item.get(\"is_directory\") else \"📄\"\n",
+    "        size = item.get(\"size\", 0)\n",
+    "        size_str = f\"{size:,} bytes\" if size else \"\"\n",
+    "        print(f\"  {item_type} {item['name']} {size_str}\")\n",
+    "else:\n",
+    "    print(\"❌ Failed to browse namespace\")\n",
+    "    pprint(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Get File Information\n",
+    "\n",
+    "Before downloading, you can get metadata about a specific file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get information about a specific file\n",
+    "file_path = \"/ospool/uc-shared/public/example.txt\"  # Replace with actual file path\n",
+    "\n",
+    "file_info = make_request(\n",
+    "    \"GET\",\n",
+    "    \"/pelican/info\",\n",
+    "    params={\"path\": file_path, \"federation\": \"osdf\"}\n",
+    ")\n",
+    "\n",
+    "if file_info.get(\"success\"):\n",
+    "    print(\"✅ File Information:\\n\")\n",
+    "    info = file_info.get(\"info\", {})\n",
+    "    print(f\"  Name: {info.get('name')}\")\n",
+    "    print(f\"  Size: {info.get('size', 0):,} bytes\")\n",
+    "    print(f\"  Type: {info.get('content_type', 'unknown')}\")\n",
+    "    print(f\"  Modified: {info.get('modified', 'unknown')}\")\n",
+    "else:\n",
+    "    print(\"❌ Failed to get file info (file may not exist)\")\n",
+    "    pprint(file_info)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Download Files\n",
+    "\n",
+    "Download files from Pelican federations.\n",
+    "\n",
+    "### 5.1 Download Small File"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download a file\n",
+    "file_path = \"/ospool/uc-shared/public/example.txt\"  # Replace with actual file path\n",
+    "\n",
+    "try:\n",
+    "    content = download_file(file_path, federation=\"osdf\")\n",
+    "    print(f\"✅ Downloaded {len(content):,} bytes\")\n",
+    "    \n",
+    "    # If it's a text file, show preview\n",
+    "    if len(content) < 1000:\n",
+    "        print(\"\\n--- File Preview ---\")\n",
+    "        print(content.decode('utf-8', errors='ignore'))\n",
+    "except Exception as e:\n",
+    "    print(f\"❌ Download failed: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.2 Save Downloaded File"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download and save to local file\n",
+    "import os\n",
+    "\n",
+    "file_path = \"/ospool/uc-shared/public/example.txt\"  # Replace with actual file path\n",
+    "local_filename = os.path.basename(file_path)\n",
+    "\n",
+    "try:\n",
+    "    content = download_file(file_path, federation=\"osdf\")\n",
+    "    \n",
+    "    with open(local_filename, 'wb') as f:\n",
+    "        f.write(content)\n",
+    "    \n",
+    "    print(f\"✅ Saved to {local_filename} ({len(content):,} bytes)\")\n",
+    "except Exception as e:\n",
+    "    print(f\"❌ Download failed: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Import Files to Local Catalog\n",
+    "\n",
+    "You can register external Pelican files in your local NDP EP catalog. This allows:\n",
+    "- Files to appear in searches\n",
+    "- Unified management with local resources\n",
+    "- Tracking of external data sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import a Pelican file as a resource in the local catalog\n",
+    "\n",
+    "import_data = {\n",
+    "    \"pelican_url\": \"pelican://osg-htc.org/ospool/uc-shared/public/example.txt\",\n",
+    "    \"package_id\": \"my-dataset-id\",  # The dataset where this resource will be added\n",
+    "    \"resource_name\": \"Example Data from OSDF\",\n",
+    "    \"resource_description\": \"Sample data file imported from Open Science Data Federation\"\n",
+    "}\n",
+    "\n",
+    "result = make_request(\"POST\", \"/pelican/import-metadata\", json_data=import_data)\n",
+    "\n",
+    "if result.get(\"success\"):\n",
+    "    print(\"✅ Successfully imported file as resource!\")\n",
+    "    print(f\"   Resource ID: {result.get('resource_id')}\")\n",
+    "else:\n",
+    "    print(\"❌ Import failed\")\n",
+    "    pprint(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Common Use Cases\n",
+    "\n",
+    "### 7.1 Search and Download Multiple Files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def list_files_recursive(path: str, federation: str = \"osdf\", max_depth: int = 2, \n",
+    "                         current_depth: int = 0) -> list:\n",
+    "    \"\"\"\n",
+    "    Recursively list files in a namespace.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    path : str\n",
+    "        Starting path\n",
+    "    federation : str\n",
+    "        Federation name\n",
+    "    max_depth : int\n",
+    "        Maximum recursion depth\n",
+    "    current_depth : int\n",
+    "        Current depth (internal)\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    list\n",
+    "        List of file paths\n",
+    "    \"\"\"\n",
+    "    if current_depth >= max_depth:\n",
+    "        return []\n",
+    "    \n",
+    "    all_files = []\n",
+    "    \n",
+    "    result = make_request(\n",
+    "        \"GET\",\n",
+    "        \"/pelican/browse\",\n",
+    "        params={\"path\": path, \"federation\": federation, \"detail\": False}\n",
+    "    )\n",
+    "    \n",
+    "    if not result.get(\"success\"):\n",
+    "        return []\n",
+    "    \n",
+    "    # Add files from current directory\n",
+    "    for f in result.get(\"files\", []):\n",
+    "        all_files.append(f\"{path}/{f}\")\n",
+    "    \n",
+    "    # Recurse into subdirectories\n",
+    "    for d in result.get(\"directories\", []):\n",
+    "        subpath = f\"{path}/{d}\"\n",
+    "        all_files.extend(\n",
+    "            list_files_recursive(subpath, federation, max_depth, current_depth + 1)\n",
+    "        )\n",
+    "    \n",
+    "    return all_files\n",
+    "\n",
+    "\n",
+    "# Example: List all files in a namespace (2 levels deep)\n",
+    "namespace = \"/ospool/uc-shared/public\"\n",
+    "files = list_files_recursive(namespace, max_depth=2)\n",
+    "\n",
+    "print(f\"Found {len(files)} files:\")\n",
+    "for f in files[:20]:\n",
+    "    print(f\"  📄 {f}\")\n",
+    "if len(files) > 20:\n",
+    "    print(f\"  ... and {len(files) - 20} more\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 7.2 Filter Files by Extension"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def find_files_by_extension(path: str, extension: str, federation: str = \"osdf\") -> list:\n",
+    "    \"\"\"\n",
+    "    Find files with a specific extension.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    path : str\n",
+    "        Namespace path to search\n",
+    "    extension : str\n",
+    "        File extension (e.g., '.csv', '.nc')\n",
+    "    federation : str\n",
+    "        Federation name\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    list\n",
+    "        Matching file paths\n",
+    "    \"\"\"\n",
+    "    all_files = list_files_recursive(path, federation, max_depth=3)\n",
+    "    return [f for f in all_files if f.endswith(extension)]\n",
+    "\n",
+    "\n",
+    "# Example: Find all CSV files\n",
+    "csv_files = find_files_by_extension(\"/ospool/uc-shared/public\", \".csv\")\n",
+    "print(f\"Found {len(csv_files)} CSV files\")\n",
+    "for f in csv_files[:10]:\n",
+    "    print(f\"  📄 {f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Error Handling\n",
+    "\n",
+    "Common errors and how to handle them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example: Handle common errors\n",
+    "\n",
+    "def safe_browse(path: str, federation: str = \"osdf\") -> dict:\n",
+    "    \"\"\"\n",
+    "    Safely browse a path with error handling.\n",
+    "    \"\"\"\n",
+    "    result = make_request(\n",
+    "        \"GET\",\n",
+    "        \"/pelican/browse\",\n",
+    "        params={\"path\": path, \"federation\": federation}\n",
+    "    )\n",
+    "    \n",
+    "    if not result.get(\"success\"):\n",
+    "        error = result.get(\"error\", \"Unknown error\")\n",
+    "        \n",
+    "        if \"not found\" in error.lower() or \"404\" in str(error):\n",
+    "            print(f\"⚠️ Path not found: {path}\")\n",
+    "            print(\"   Check that the path exists and you have access.\")\n",
+    "        elif \"timeout\" in error.lower():\n",
+    "            print(f\"⏱️ Request timed out for: {path}\")\n",
+    "            print(\"   The federation may be slow. Try again later.\")\n",
+    "        elif \"connection\" in error.lower():\n",
+    "            print(f\"🔌 Connection error for: {path}\")\n",
+    "            print(\"   Check your network and API endpoint.\")\n",
+    "        else:\n",
+    "            print(f\"❌ Error: {error}\")\n",
+    "    \n",
+    "    return result\n",
+    "\n",
+    "\n",
+    "# Test with a non-existent path\n",
+    "safe_browse(\"/this/path/does/not/exist\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this tutorial, you learned how to:\n",
+    "\n",
+    "1. ✅ List available Pelican federations\n",
+    "2. ✅ Browse namespaces and directories\n",
+    "3. ✅ Get file information without downloading\n",
+    "4. ✅ Download files from federations\n",
+    "5. ✅ Import external files to your local catalog\n",
+    "6. ✅ Handle common errors\n",
+    "\n",
+    "## Next Steps\n",
+    "\n",
+    "- Explore the [General Dataset API Tutorial](./general_dataset_api_tutorial.ipynb) to manage your datasets\n",
+    "- Check the [S3 API Tutorial](./s3_api_tutorial.ipynb) for local storage management\n",
+    "- Read the [NDP EP Documentation](https://github.com/sci-ndp/pop) for more features\n",
+    "\n",
+    "## Resources\n",
+    "\n",
+    "- [Pelican Platform](https://pelicanplatform.org/)\n",
+    "- [Open Science Data Federation](https://osg-htc.org/services/osdf.html)\n",
+    "- [NDP EP API Documentation](https://github.com/sci-ndp/pop)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Description

Add a new tutorial notebook documenting the Pelican Federation integration.

## Content included

- List available federations (OSDF, PATh-CC)
- Browse namespaces and directories
- Get file information
- Download files from federations
- Import external files as resources in local catalog
- Error handling examples
- Common use cases (recursive listing, filtering by extension)

## Location

`docs/pelican_api_tutorial.ipynb`

## Related endpoints

- `GET /pelican/federations`
- `GET /pelican/browse`
- `GET /pelican/info`
- `GET /pelican/download`
- `POST /pelican/import-metadata`

Closes #61