### PR TITLE
Fix version mismatch in swagger_settings.py

### DIFF
--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.6.0"
+    swagger_version: str = "0.9.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"


### PR DESCRIPTION
Updates `swagger_version` from `"0.6.0"` to `"0.9.0"` to match the current release v0.9.0.

Closes #72