### PR TITLE
fix(ui): use runtime ROOT_PATH for API base URL (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.8] - 2026-04-08
+
+### Fixed
+- UI did not use `ROOT_PATH` for API calls when deployed behind a reverse proxy
+  - Added `entrypoint.sh` that generates a runtime `config.js` with the `ROOT_PATH` value
+  - UI now reads the API base URL from `window.__EP_CONFIG__` instead of build-time env var
+  - No rebuild required — just change `ROOT_PATH` in `.env` and restart the container
+
 ## [0.10.7] - 2026-04-03
 
 ### Fixed

--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -84,5 +84,9 @@ EXPOSE 80
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=40s \
     CMD curl -f http://localhost/health || exit 1
 
-# Start supervisor (manages both nginx and uvicorn)
-CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
+# Copy entrypoint script
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+# Start via entrypoint (generates runtime config, then launches supervisord)
+CMD ["/app/entrypoint.sh"]

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.10.7"
+    swagger_version: str = "0.10.8"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Generate runtime config for the React UI
+# This injects ROOT_PATH into the frontend without requiring a rebuild
+cat > /app/ui/build/config.js <<EOF
+window.__EP_CONFIG__ = { rootPath: "${ROOT_PATH}" };
+EOF
+
+# Start supervisord
+exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -25,6 +25,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>EP Console</title>
+    <script src="/ui/config.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 // Base URL of your API - configurable via environment variable
-const BASE_URL = process.env.REACT_APP_API_BASE_URL ?? '';
+const BASE_URL = window.__EP_CONFIG__?.rootPath ?? '';
 
 // Create axios instance with default configuration
 const apiClient = axios.create({


### PR DESCRIPTION
## Summary

Fixes #95 — The React UI was not using `ROOT_PATH` when making API calls, causing 404 errors behind a reverse proxy with a path prefix (e.g., `/ep-api`).

### Changes
- **`entrypoint.sh`** (new): Generates `/app/ui/build/config.js` at container startup with the `ROOT_PATH` value from the environment
- **`ui/public/index.html`**: Loads `config.js` before the React app starts
- **`ui/src/services/api.js`**: Reads base URL from `window.__EP_CONFIG__.rootPath` instead of build-time `REACT_APP_API_BASE_URL`
- **`Dockerfile.allinone`**: Uses `entrypoint.sh` instead of launching supervisord directly

### How it works
1. Container starts → `entrypoint.sh` runs
2. Script writes `window.__EP_CONFIG__ = { rootPath: "/ep-api" };` to `/app/ui/build/config.js`
3. `index.html` loads this script before React boots
4. `api.js` picks up the rootPath as the axios base URL
5. Supervisord launches nginx + uvicorn as before

To change the prefix, just update `ROOT_PATH` in `.env` and restart — no rebuild needed.

## Test plan
- [x] All 1011 tests pass
- [x] Container starts correctly with `entrypoint.sh`
- [x] `config.js` is generated with correct `ROOT_PATH` value