### PR TITLE
fix(nginx): generate nginx.conf dynamically with ROOT_PATH (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.9] - 2026-04-08
+
+### Fixed
+- Nginx inside the container did not use `ROOT_PATH` for location prefixes
+  - `entrypoint.sh` now generates `nginx.conf` dynamically with `ROOT_PATH`-prefixed locations
+  - Locations `/ui/`, `/api/`, and `/` become `{ROOT_PATH}/ui/`, `{ROOT_PATH}/api/`, `{ROOT_PATH}/`
+  - Also updates the `config.js` script path in the built `index.html` at startup
+  - When `ROOT_PATH` is empty, behavior is identical to the previous static config
+
 ## [0.10.8] - 2026-04-08
 
 ### Fixed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.10.8"
+    swagger_version: str = "0.10.9"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,49 @@
 #!/bin/sh
 
 # Generate runtime config for the React UI
-# This injects ROOT_PATH into the frontend without requiring a rebuild
 cat > /app/ui/build/config.js <<EOF
 window.__EP_CONFIG__ = { rootPath: "${ROOT_PATH}" };
 EOF
+
+# Update config.js script path in the built index.html to include ROOT_PATH
+sed -i "s|src=\"/ui/config.js\"|src=\"${ROOT_PATH}/ui/config.js\"|g" /app/ui/build/index.html
+
+# Generate nginx config with ROOT_PATH-prefixed locations
+cat > /etc/nginx/sites-available/default <<NGINX
+server {
+    listen 80;
+    server_name _;
+
+    # UI - static files served from ${ROOT_PATH}/ui/
+    location ${ROOT_PATH}/ui/ {
+        alias /app/ui/build/;
+        try_files \$uri \$uri/ ${ROOT_PATH}/ui/index.html;
+    }
+
+    # Redirect ${ROOT_PATH}/ui to ${ROOT_PATH}/ui/
+    location = ${ROOT_PATH}/ui {
+        return 301 \$scheme://\$host\$request_uri/;
+    }
+
+    # Alternative API path (also works via ${ROOT_PATH}/api/)
+    location ${ROOT_PATH}/api/ {
+        proxy_pass http://127.0.0.1:8000/;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+
+    # Root = API
+    location ${ROOT_PATH}/ {
+        proxy_pass http://127.0.0.1:8000/;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+}
+NGINX
 
 # Start supervisord
 exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
## Summary

Fixes #97 — The nginx configuration inside the all-in-one container had hardcoded location paths (`/ui/`, `/api/`, `/`). When deployed behind a reverse proxy that forwards prefixed paths (e.g., `/ep-api/ui/...`), nginx returned 404.

### Changes
- **`entrypoint.sh`**: Now generates `/etc/nginx/sites-available/default` at startup using `ROOT_PATH` as prefix for all locations. Also updates the `config.js` script path in the built `index.html`.

### How it works
When `ROOT_PATH=/ep-api`, the generated nginx.conf has:
- `location /ep-api/ui/` → serves static UI files
- `location /ep-api/api/` → proxies to uvicorn (strips prefix)
- `location /ep-api/` → proxies to uvicorn (strips prefix)

When `ROOT_PATH` is empty, locations are `/ui/`, `/api/`, `/` — identical to the previous static config.

## Test plan
- [x] All 1011 tests pass
- [x] `curl localhost:8002/ep-api/ui/` → 200
- [x] `curl localhost:8002/ep-api/health` → 200
- [x] `curl localhost:8002/ep-api/ui/config.js` → 200
- [x] Generated nginx.conf has correct prefixed locations
- [x] Built index.html loads config.js from `/ep-api/ui/config.js`