### PR TITLE
fix(ui): rewrite all asset paths in index.html with ROOT_PATH (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.10] - 2026-04-08
+
+### Fixed
+- React asset paths in `index.html` were not rewritten with `ROOT_PATH` prefix
+  - Assets like favicon, JS bundles, CSS, and manifest were still referenced as `/ui/...` instead of `{ROOT_PATH}/ui/...`
+  - `entrypoint.sh` now rewrites all `"/ui/` references in the built `index.html` at startup
+  - Ensures the page loads correctly behind a reverse proxy with any path prefix
+
 ## [0.10.9] - 2026-04-08
 
 ### Fixed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.10.9"
+    swagger_version: str = "0.10.10"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,8 +5,8 @@ cat > /app/ui/build/config.js <<EOF
 window.__EP_CONFIG__ = { rootPath: "${ROOT_PATH}" };
 EOF
 
-# Update config.js script path in the built index.html to include ROOT_PATH
-sed -i "s|src=\"/ui/config.js\"|src=\"${ROOT_PATH}/ui/config.js\"|g" /app/ui/build/index.html
+# Rewrite all /ui/ asset references in the built index.html to include ROOT_PATH
+sed -i "s|\"/ui/|\"${ROOT_PATH}/ui/|g" /app/ui/build/index.html
 
 # Generate nginx config with ROOT_PATH-prefixed locations
 cat > /etc/nginx/sites-available/default <<NGINX

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -21,7 +21,7 @@ function App() {
   return (
     <div className="App">
       <AuthGuard>
-        <Router basename="/ui">
+        <Router basename={`${window.__EP_CONFIG__?.rootPath ?? ''}/ui`}>
           <Layout>
             <Routes>
               {/* Dashboard route - main overview page */}

--- a/ui/src/components/AuthStatus.js
+++ b/ui/src/components/AuthStatus.js
@@ -47,7 +47,7 @@ const AuthStatus = ({ onLoginClick }) => {
       setTokenPreview('');
 
       // Redirect to /ui/ so AuthGuard shows the login screen
-      window.location.href = '/ui/';
+      window.location.href = `${window.__EP_CONFIG__?.rootPath ?? ''}/ui/`;
     }
   };
 

--- a/ui/src/components/Navigation.js
+++ b/ui/src/components/Navigation.js
@@ -80,7 +80,7 @@ const Navigation = () => {
   const handleLogout = () => {
     if (window.confirm('Are you sure you want to logout?')) {
       localStorage.removeItem('authToken');
-      window.location.href = '/ui/';
+      window.location.href = `${window.__EP_CONFIG__?.rootPath ?? ''}/ui/`;
     }
   };
 


### PR DESCRIPTION
## Summary

Fixes #99 — The built React `index.html` had hardcoded `/ui/...` asset paths (favicon, JS bundles, CSS, manifest). Behind a reverse proxy with a prefix like `/ep-api`, the browser requested `/ui/static/js/main.xxx.js` but the resource was only available at `/ep-api/ui/static/js/main.xxx.js`.

### Changes
- **`entrypoint.sh`**: Replaced the specific `config.js` sed rewrite with a generic one that rewrites **all** `"/ui/` references to `"${ROOT_PATH}/ui/` in the built `index.html`.

### Result
All asset paths in `index.html` now include the `ROOT_PATH` prefix:
```
href="/ep-api/ui/favicon.ico"
href="/ep-api/ui/logo192.png"
href="/ep-api/ui/manifest.json"
src="/ep-api/ui/config.js"
src="/ep-api/ui/static/js/main.20709373.js"
href="/ep-api/ui/static/css/main.4159b21f.css"
```

## Test plan
- [x] All 1011 tests pass
- [x] `curl localhost:8002/ep-api/ui/` → 200
- [x] `curl localhost:8002/ep-api/ui/static/js/main.20709373.js` → 200
- [x] `curl localhost:8002/ep-api/ui/static/css/main.4159b21f.css` → 200
- [x] `curl localhost:8002/ep-api/ui/favicon.ico` → 200
- [x] `curl localhost:8002/ep-api/health` → 200