### PR TITLE
fix(repositories): handle None values in resource_search filters (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.11] - 2026-04-13
+
+### Fixed
+- `/resources/search` crashed with `AttributeError: 'NoneType' object has no attribute 'lower'` when any resource had `None` values in fields used for filtering (`name`, `url`, `description`, `format`)
+  - `dict.get("key", "")` returns the default only when the key is missing; when the key exists with value `None` it returns `None`, breaking the subsequent `.lower()` call
+  - Replaced `resource.get("key", "")` with `(resource.get("key") or "")` in all filter branches of `DataCatalogRepository.resource_search`
+  - Added regression test covering resources with `None` values across all searchable fields
+
 ## [0.10.10] - 2026-04-08
 
 ### Fixed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.10.10"
+    swagger_version: str = "0.10.11"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/repositories/base_repository.py
+++ b/api/repositories/base_repository.py
@@ -315,26 +315,26 @@ class DataCatalogRepository(ABC):
                 if query:
                     query_lower = query.lower()
                     matches = (
-                        query_lower in resource.get("name", "").lower()
-                        or query_lower in resource.get("url", "").lower()
-                        or query_lower in resource.get("description", "").lower()
+                        query_lower in (resource.get("name") or "").lower()
+                        or query_lower in (resource.get("url") or "").lower()
+                        or query_lower in (resource.get("description") or "").lower()
                     )
                     if not matches:
                         continue
 
-                if name and name.lower() not in resource.get("name", "").lower():
+                if name and name.lower() not in (resource.get("name") or "").lower():
                     continue
 
-                if url and url.lower() not in resource.get("url", "").lower():
+                if url and url.lower() not in (resource.get("url") or "").lower():
                     continue
 
-                if format and format.lower() != resource.get("format", "").lower():
+                if format and format.lower() != (resource.get("format") or "").lower():
                     continue
 
                 if (
                     description
                     and description.lower()
-                    not in resource.get("description", "").lower()
+                    not in (resource.get("description") or "").lower()
                 ):
                     continue
 

--- a/tests/repositories/test_base_repository.py
+++ b/tests/repositories/test_base_repository.py
@@ -546,3 +546,47 @@ class TestDefaultResourceSearch:
 
         assert results["count"] == 1
         assert results["results"][0]["name"] == "temperature"
+
+    def test_search_with_none_fields_does_not_crash(self):
+        """Resources with None values in searchable fields must not crash the search.
+
+        Regression test: previously ``resource.get("key", "")`` returned ``None``
+        when the key existed with a ``None`` value, causing ``.lower()`` to raise
+        ``AttributeError`` and breaking the entire endpoint for the query.
+        """
+        packages = [
+            {
+                "id": "pkg-1",
+                "name": "pkg-none",
+                "title": "Package With None Fields",
+                "resources": [
+                    {
+                        "id": "res-none",
+                        "name": None,
+                        "url": None,
+                        "format": None,
+                        "description": None,
+                    },
+                    {
+                        "id": "res-ok",
+                        "name": "climate-series",
+                        "url": "https://example.com/climate.csv",
+                        "format": "csv",
+                        "description": "Climate time series",
+                    },
+                ],
+            }
+        ]
+        repo = ResourceSearchTestRepository(packages)
+
+        results = repo.resource_search(query="climate")
+        assert results["count"] == 1
+        assert results["results"][0]["id"] == "res-ok"
+
+        assert repo.resource_search(name="climate")["count"] == 1
+        assert repo.resource_search(url="example.com")["count"] == 1
+        assert repo.resource_search(format="csv")["count"] == 1
+        assert repo.resource_search(description="time series")["count"] == 1
+
+        all_results = repo.resource_search()
+        assert all_results["count"] == 2


### PR DESCRIPTION
## Summary
- Fix `AttributeError: 'NoneType' object has no attribute 'lower'` in `/resources/search` when a resource has `None` values in `name`, `url`, `description` or `format` (#101)
- Replace `resource.get(key, \"\")` with `(resource.get(key) or \"\")` in every filter branch of `DataCatalogRepository.resource_search` — the previous form only falls back to the default when the key is missing, not when it exists with value `None`
- Add a regression test covering `None` values across all searchable fields (query, name, url, format, description)
- Bump version to `0.10.11` and update `CHANGELOG.md`

## Test plan
- [x] `docker compose exec api python -m pytest tests/ -v` — 1012 passed
- [x] New regression test `test_search_with_none_fields_does_not_crash` passes and fails on the previous code
- [x] Manual reproduction in the running container: before the fix raises `AttributeError`, after the fix returns a valid result set
- [x] `black --check` and `flake8 --max-line-length=88` clean on the modified files

Closes #101