### PR TITLE
Updated the logic to accept ws, wss urls

### DIFF
--- a/api/models/general_dataset_request_model.py
+++ b/api/models/general_dataset_request_model.py
@@ -22,7 +22,7 @@ class ResourceRequest(BaseModel):
         """Validate that URL is not empty and has a valid format."""
         if not v or not v.strip():
             raise ValueError("url cannot be empty")
-        # Basic URL validation - must start with http://, https://, s3://, or be a path
+        # Basic URL validation - must start with http://, https://, s3://, ws://, wss://, kafka://, or be a path
         if not re.match(r"^(https?://|s3://|wss?://|kafka://|/|\.)", v):
             raise ValueError(
                 "url must be a valid URL (http://, https://, s3://, ws://, wss://, kafka://) or a path"

--- a/api/models/general_dataset_request_model.py
+++ b/api/models/general_dataset_request_model.py
@@ -22,10 +22,10 @@ class ResourceRequest(BaseModel):
         """Validate that URL is not empty and has a valid format."""
         if not v or not v.strip():
             raise ValueError("url cannot be empty")
-        # Basic URL validation - must start with http://, https://, s3://, ws://, wss://, kafka://, or be a path
-        if not re.match(r"^(https?://|s3://|wss?://|kafka://|/|\.)", v):
+        # Basic URL validation - must start with http://, https://, s3://, ws://, wss://, or be a path
+        if not re.match(r"^(https?://|s3://|wss?://|/|\.)", v):
             raise ValueError(
-                "url must be a valid URL (http://, https://, s3://, ws://, wss://, kafka://) or a path"
+                "url must be a valid URL (http://, https://, s3://, ws://, wss://) or a path"
             )
         return v
 

--- a/api/models/general_dataset_request_model.py
+++ b/api/models/general_dataset_request_model.py
@@ -23,9 +23,9 @@ class ResourceRequest(BaseModel):
         if not v or not v.strip():
             raise ValueError("url cannot be empty")
         # Basic URL validation - must start with http://, https://, s3://, or be a path
-        if not re.match(r"^(https?://|s3://|/|\.)", v):
+        if not re.match(r"^(https?://|s3://|wss?://|kafka://|/|\.)", v):
             raise ValueError(
-                "url must be a valid URL (http://, https://, s3://) or a path"
+                "url must be a valid URL (http://, https://, s3://, ws://, wss://, kafka://) or a path"
             )
         return v
 

--- a/tests/test_general_dataset_request_model.py
+++ b/tests/test_general_dataset_request_model.py
@@ -48,6 +48,32 @@ class TestResourceRequest:
         assert resource.mimetype == "application/json"
         assert resource.size == 2048
 
+    def test_create_with_ws_url(self):
+        """Test creating ResourceRequest with a ws:// URL."""
+        resource = ResourceRequest(
+            url="ws://stream.example.com/data", name="websocket_resource"
+        )
+
+        assert resource.url == "ws://stream.example.com/data"
+        assert resource.name == "websocket_resource"
+
+    def test_create_with_wss_url(self):
+        """Test creating ResourceRequest with a wss:// URL."""
+        resource = ResourceRequest(
+            url="wss://stream.example.com/data", name="secure_websocket_resource"
+        )
+
+        assert resource.url == "wss://stream.example.com/data"
+        assert resource.name == "secure_websocket_resource"
+
+    def test_invalid_url_scheme_raises_error(self):
+        """Test that unsupported URL schemes raise ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            ResourceRequest(url="ftp://example.com/data.csv", name="ftp_resource")
+
+        errors = exc_info.value.errors()
+        assert any(e["loc"][0] == "url" for e in errors)
+
     def test_missing_required_field_raises_error(self):
         """Test that missing required fields raise ValidationError."""
         with pytest.raises(ValidationError) as exc_info:


### PR DESCRIPTION
## Summary

Adds test coverage for `ResourceRequest` URL validation to confirm that:

- `ws://` URLs are accepted
- `wss://` URLs are accepted
- unsupported schemes like `ftp://` are still rejected

## Why

Dataset resources may point to streaming sources, including WebSocket endpoints. These tests ensure the validator supports that use case while preserving rejection of unsupported URL schemes.

Closes #119 
