### PR TITLE
Add username/password login option on AuthGuard (v0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-04-22
+
+### Added
+- Username and password login option on the UI authentication screen
+  - New `POST /user/login` endpoint proxies credentials to the configured identity provider and returns the access token plus profile data
+  - `AuthGuard` now includes a link below the "Authenticate" button labeled "or use your login / password" that switches the screen to a credentials form (username, password, show/hide toggle); a reciprocal link returns to the access token form
+  - On successful login the token is stored in `localStorage` so subsequent requests are authenticated automatically
+  - Invalid credentials surface as 401 with the IDP message, IDP outages as 502
+
 ## [0.10.11] - 2026-04-13
 
 ### Fixed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.10.11"
+    swagger_version: str = "0.11.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/models/token_model.py
+++ b/api/models/token_model.py
@@ -23,3 +23,18 @@ class TokenData(BaseModel):
         description="The username associated with the token.",
         json_schema_extra={"example": "user123"},
     )
+
+
+class UserLoginRequest(BaseModel):
+    username: str = Field(
+        ...,
+        min_length=1,
+        description="The username for authentication.",
+        json_schema_extra={"example": "john.doe"},
+    )
+    password: str = Field(
+        ...,
+        min_length=1,
+        description="The password for authentication.",
+        json_schema_extra={"example": "s3cret"},
+    )

--- a/api/routes/user_routes/__init__.py
+++ b/api/routes/user_routes/__init__.py
@@ -3,7 +3,9 @@
 from fastapi import APIRouter
 
 from .user_info import router as user_info_router
+from .user_login import router as user_login_router
 
 router = APIRouter()
 
 router.include_router(user_info_router)
+router.include_router(user_login_router)

--- a/api/routes/user_routes/user_login.py
+++ b/api/routes/user_routes/user_login.py
@@ -1,0 +1,96 @@
+# api/routes/user_routes/user_login.py
+
+from typing import Any, Dict
+
+from fastapi import APIRouter
+
+from api.models.token_model import UserLoginRequest
+from api.services.auth_services import authenticate_with_credentials
+
+router = APIRouter()
+
+
+@router.post(
+    "/user/login",
+    response_model=Dict[str, Any],
+    summary="Authenticate user with username and password",
+    description=(
+        "Authenticate a user with username and password against the "
+        "identity provider.\n\n"
+        "On success, the endpoint returns the access token together with "
+        "any additional profile information provided by the authentication "
+        "service (roles, groups, token type, etc.).\n\n"
+        "### Example Request\n"
+        "```json\n"
+        "{\n"
+        '  "username": "john.doe",\n'
+        '  "password": "s3cret"\n'
+        "}\n"
+        "```\n\n"
+        "### Example Response\n"
+        "```json\n"
+        "{\n"
+        '  "access_token": "eyJhbGciOi...",\n'
+        '  "token_type": "Bearer",\n'
+        '  "roles": ["user"],\n'
+        '  "groups": []\n'
+        "}\n"
+        "```\n"
+    ),
+    responses={
+        200: {
+            "description": "Authentication successful",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                        "token_type": "Bearer",
+                        "roles": ["user"],
+                        "groups": [],
+                    }
+                }
+            },
+        },
+        401: {
+            "description": "Invalid credentials",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Invalid username or password"}
+                }
+            },
+        },
+        502: {
+            "description": "Authentication service unavailable",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Authentication service is unavailable."}
+                }
+            },
+        },
+    },
+)
+async def user_login(payload: UserLoginRequest) -> Dict[str, Any]:
+    """
+    Authenticate a user with username and password.
+
+    This endpoint proxies the credentials to the configured identity
+    provider and returns the resulting access token and profile data.
+
+    Parameters
+    ----------
+    payload : UserLoginRequest
+        The username and password to authenticate.
+
+    Returns
+    -------
+    Dict[str, Any]
+        The authentication response from the identity provider, including
+        the access token.
+
+    Raises
+    ------
+    HTTPException
+        401: If the credentials are invalid.
+        502: If the authentication service is unavailable.
+    """
+    return authenticate_with_credentials(payload.username, payload.password)

--- a/api/services/auth_services/__init__.py
+++ b/api/services/auth_services/__init__.py
@@ -8,3 +8,4 @@ from .authorization_service import (  # noqa: F401
     require_organization_member,  # backward compatibility
 )
 from .get_current_user import get_current_user  # noqa: F401
+from .user_login import authenticate_with_credentials  # noqa: F401

--- a/api/services/auth_services/user_login.py
+++ b/api/services/auth_services/user_login.py
@@ -1,0 +1,116 @@
+# api/services/auth_services/user_login.py
+import logging
+from typing import Any, Dict
+from urllib.parse import urlparse
+
+import requests
+from fastapi import HTTPException, status
+
+from api.config.swagger_settings import swagger_settings
+
+logger = logging.getLogger(__name__)
+
+
+def _build_login_url() -> str:
+    """
+    Derive the IDP login URL from the configured ``auth_api_url``.
+
+    The auth API URL points at the token-information endpoint (e.g.
+    ``https://idp.example.com/information``). The login endpoint lives on the
+    same server at ``/user/login``.
+    """
+    parsed = urlparse(swagger_settings.auth_api_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authentication service URL is not configured correctly.",
+        )
+    return f"{parsed.scheme}://{parsed.netloc}/user/login"
+
+
+def authenticate_with_credentials(username: str, password: str) -> Dict[str, Any]:
+    """
+    Authenticate a user with username and password against the IDP.
+
+    Parameters
+    ----------
+    username : str
+        The username to authenticate.
+    password : str
+        The password to authenticate.
+
+    Returns
+    -------
+    Dict[str, Any]
+        The IDP response, typically including ``access_token``, ``token_type``,
+        ``roles`` and ``groups``.
+
+    Raises
+    ------
+    HTTPException
+        401: If credentials are invalid.
+        502: If the authentication service is unreachable or misconfigured.
+    """
+    login_url = _build_login_url()
+
+    try:
+        response = requests.post(
+            login_url,
+            json={"username": username, "password": password},
+            timeout=10,
+        )
+    except requests.exceptions.RequestException as exc:
+        logger.error(f"Auth service unreachable at {login_url}: {exc}")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authentication service is unavailable.",
+        )
+
+    if response.status_code == 200:
+        try:
+            data = response.json()
+        except ValueError:
+            logger.error("Auth service returned non-JSON response")
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Authentication service returned an invalid response.",
+            )
+
+        if not isinstance(data, dict) or "access_token" not in data:
+            logger.error(
+                "Auth service response missing 'access_token' field: "
+                f"{list(data.keys()) if isinstance(data, dict) else type(data)}"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Authentication service response is missing access token.",
+            )
+
+        return data
+
+    if response.status_code in (400, 401, 403):
+        # Forward the IDP's reason when present, fall back to a generic message.
+        detail = "Invalid username or password"
+        try:
+            payload = response.json()
+            if isinstance(payload, dict):
+                detail = payload.get("error") or payload.get("detail") or detail
+        except ValueError:
+            pass
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=detail,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    logger.error(
+        f"Auth service returned unexpected status {response.status_code}: "
+        f"{response.text[:200]}"
+    )
+    raise HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail=(
+            "Authentication service returned an unexpected response "
+            f"(HTTP {response.status_code})."
+        ),
+    )

--- a/tests/test_user_login_route.py
+++ b/tests/test_user_login_route.py
@@ -1,0 +1,122 @@
+# tests/test_user_login_route.py
+"""
+Tests for the POST /user/login route.
+"""
+
+from unittest.mock import patch
+
+from fastapi import HTTPException, status
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+client = TestClient(app)
+
+
+class TestUserLoginRoute:
+    """Tests for the /user/login endpoint."""
+
+    @patch("api.routes.user_routes.user_login.authenticate_with_credentials")
+    def test_login_success_returns_idp_payload(self, mock_auth):
+        """A successful login returns the IDP payload with the access token."""
+        mock_auth.return_value = {
+            "access_token": "tok.en.value",
+            "token_type": "Bearer",
+            "roles": ["user"],
+            "groups": [],
+        }
+
+        response = client.post(
+            "/user/login",
+            json={"username": "john.doe", "password": "s3cret"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["access_token"] == "tok.en.value"
+        assert body["token_type"] == "Bearer"
+        mock_auth.assert_called_once_with("john.doe", "s3cret")
+
+    @patch("api.routes.user_routes.user_login.authenticate_with_credentials")
+    def test_login_invalid_credentials_returns_401(self, mock_auth):
+        """Invalid credentials surface as a 401 response."""
+        mock_auth.side_effect = HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid username or password",
+        )
+
+        response = client.post(
+            "/user/login",
+            json={"username": "john.doe", "password": "wrong"},
+        )
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid username or password"
+
+    @patch("api.routes.user_routes.user_login.authenticate_with_credentials")
+    def test_login_idp_unavailable_returns_502(self, mock_auth):
+        """IDP connectivity errors surface as a 502 response."""
+        mock_auth.side_effect = HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authentication service is unavailable.",
+        )
+
+        response = client.post(
+            "/user/login",
+            json={"username": "john.doe", "password": "s3cret"},
+        )
+
+        assert response.status_code == 502
+
+    def test_login_missing_username_returns_422(self):
+        """Omitting username triggers a validation error."""
+        response = client.post(
+            "/user/login",
+            json={"password": "s3cret"},
+        )
+
+        assert response.status_code == 422
+
+    def test_login_missing_password_returns_422(self):
+        """Omitting password triggers a validation error."""
+        response = client.post(
+            "/user/login",
+            json={"username": "john.doe"},
+        )
+
+        assert response.status_code == 422
+
+    def test_login_empty_username_returns_422(self):
+        """An empty username is rejected by the payload validator."""
+        response = client.post(
+            "/user/login",
+            json={"username": "", "password": "s3cret"},
+        )
+
+        assert response.status_code == 422
+
+    def test_login_empty_password_returns_422(self):
+        """An empty password is rejected by the payload validator."""
+        response = client.post(
+            "/user/login",
+            json={"username": "john.doe", "password": ""},
+        )
+
+        assert response.status_code == 422
+
+    def test_login_does_not_require_authentication(self):
+        """The login endpoint is reachable without an Authorization header."""
+        with patch(
+            "api.routes.user_routes.user_login.authenticate_with_credentials"
+        ) as mock_auth:
+            mock_auth.return_value = {
+                "access_token": "tok",
+                "token_type": "Bearer",
+            }
+
+            response = client.post(
+                "/user/login",
+                json={"username": "john.doe", "password": "s3cret"},
+            )
+
+            assert response.status_code == 200

--- a/tests/test_user_login_service.py
+++ b/tests/test_user_login_service.py
@@ -111,7 +111,9 @@ class TestAuthenticateWithCredentials:
 
         mock_response = MagicMock()
         mock_response.status_code = 400
-        mock_response.json.return_value = {"error": "username and password are required"}
+        mock_response.json.return_value = {
+            "error": "username and password are required"
+        }
         mock_post.return_value = mock_response
 
         with pytest.raises(HTTPException) as exc_info:

--- a/tests/test_user_login_service.py
+++ b/tests/test_user_login_service.py
@@ -1,0 +1,219 @@
+# tests/test_user_login_service.py
+"""
+Tests for the user_login authentication service.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from fastapi import HTTPException
+
+from api.services.auth_services.user_login import (
+    _build_login_url,
+    authenticate_with_credentials,
+)
+
+
+class TestBuildLoginUrl:
+    """Test cases for _build_login_url."""
+
+    @patch("api.services.auth_services.user_login.swagger_settings")
+    def test_builds_login_url_from_information_endpoint(self, mock_settings):
+        """Login URL is derived from the configured auth_api_url base."""
+        mock_settings.auth_api_url = "https://idp.example.com/information"
+
+        result = _build_login_url()
+
+        assert result == "https://idp.example.com/user/login"
+
+    @patch("api.services.auth_services.user_login.swagger_settings")
+    def test_builds_login_url_preserves_port(self, mock_settings):
+        """Login URL preserves scheme, host and port from the configured URL."""
+        mock_settings.auth_api_url = "http://10.0.0.1:5055/information"
+
+        result = _build_login_url()
+
+        assert result == "http://10.0.0.1:5055/user/login"
+
+    @patch("api.services.auth_services.user_login.swagger_settings")
+    def test_empty_auth_api_url_raises_502(self, mock_settings):
+        """An unconfigured auth_api_url raises a 502 HTTPException."""
+        mock_settings.auth_api_url = ""
+
+        with pytest.raises(HTTPException) as exc_info:
+            _build_login_url()
+
+        assert exc_info.value.status_code == 502
+
+    @patch("api.services.auth_services.user_login.swagger_settings")
+    def test_missing_scheme_raises_502(self, mock_settings):
+        """An auth_api_url without scheme raises a 502 HTTPException."""
+        mock_settings.auth_api_url = "idp.example.com/information"
+
+        with pytest.raises(HTTPException) as exc_info:
+            _build_login_url()
+
+        assert exc_info.value.status_code == 502
+
+
+class TestAuthenticateWithCredentials:
+    """Test cases for authenticate_with_credentials."""
+
+    @patch("api.services.auth_services.user_login.requests.post")
+    @patch("api.services.auth_services.user_login.swagger_settings")
+    def test_successful_login_returns_idp_payload(self, mock_settings, mock_post):
+        """A 200 response with access_token is forwarded to the caller."""
+        mock_settings.auth_api_url = "https://idp.example.com/information"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "abc.def.ghi",
+            "token_type": "Bearer",
+            "roles": ["user"],
+            "groups": [],
+        }
+        mock_post.return_value = mock_response
+
+        result = authenticate_with_credentials("john", "s3cret")
+
+        assert result["access_token"] == "abc.def.ghi"
+        assert result["token_type"] == "Bearer"
+        mock_post.assert_called_once_with(
+            "https://idp.example.com/user/login",
+            json={"username": "john", "password": "s3cret"},
+            timeout=10,
+        )
+
+    @patch("api.services.auth_services.user_login.requests.post")
+    @patch("api.services.auth_services.user_login.swagger_settings")
+    def test_invalid_credentials_raises_401(self, mock_settings, mock_post):
+        """A 401 response from the IDP is surfaced as a 401 HTTPException."""
+        mock_settings.auth_api_url = "https://idp.example.com/information"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.json.return_value = {"error": "Invalid username or password"}
+        mock_post.return_value = mock_response
+
+        with pytest.raises(HTTPException) as exc_info:
+            authenticate_with_credentials("john", "wrong")
+
+        assert exc_info.value.status_code == 401
+        assert "Invalid username or password" in exc_info.value.detail
+
+    @patch("api.services.auth_services.user_login.requests.post")
+    @patch("api.services.auth_services.user_login.swagger_settings")
+    def test_bad_request_response_is_401(self, mock_settings, mock_post):
+        """A 400 from the IDP is treated as an authentication failure."""
+        mock_settings.auth_api_url = "https://idp.example.com/information"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.json.return_value = {"error": "username and password are required"}
+        mock_post.return_value = mock_response
+
+        with pytest.raises(HTTPException) as exc_info:
+            authenticate_with_credentials("", "")
+
+        assert exc_info.value.status_code == 401
+        assert "username and password are required" in exc_info.value.detail
+
+    @patch("api.services.auth_services.user_login.requests.post")
+    @patch("api.services.auth_services.user_login.swagger_settings")
+    def test_forbidden_response_is_401(self, mock_settings, mock_post):
+        """A 403 from the IDP is treated as an authentication failure."""
+        mock_settings.auth_api_url = "https://idp.example.com/information"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.json.return_value = {"error": "account locked"}
+        mock_post.return_value = mock_response
+
+        with pytest.raises(HTTPException) as exc_info:
+            authenticate_with_credentials("john", "s3cret")
+
+        assert exc_info.value.status_code == 401
+        assert "account locked" in exc_info.value.detail
+
+    @patch("api.services.auth_services.user_login.requests.post")
+    @patch("api.services.auth_services.user_login.swagger_settings")
+    def test_network_error_raises_502(self, mock_settings, mock_post):
+        """Network errors talking to the IDP surface as 502."""
+        mock_settings.auth_api_url = "https://idp.example.com/information"
+        mock_post.side_effect = requests.exceptions.ConnectionError("boom")
+
+        with pytest.raises(HTTPException) as exc_info:
+            authenticate_with_credentials("john", "s3cret")
+
+        assert exc_info.value.status_code == 502
+        assert "unavailable" in exc_info.value.detail.lower()
+
+    @patch("api.services.auth_services.user_login.requests.post")
+    @patch("api.services.auth_services.user_login.swagger_settings")
+    def test_unexpected_status_raises_502(self, mock_settings, mock_post):
+        """Unexpected IDP status codes surface as 502."""
+        mock_settings.auth_api_url = "https://idp.example.com/information"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "internal error"
+        mock_post.return_value = mock_response
+
+        with pytest.raises(HTTPException) as exc_info:
+            authenticate_with_credentials("john", "s3cret")
+
+        assert exc_info.value.status_code == 502
+
+    @patch("api.services.auth_services.user_login.requests.post")
+    @patch("api.services.auth_services.user_login.swagger_settings")
+    def test_missing_access_token_raises_502(self, mock_settings, mock_post):
+        """A 200 response without access_token is considered a bad gateway."""
+        mock_settings.auth_api_url = "https://idp.example.com/information"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"roles": ["user"]}
+        mock_post.return_value = mock_response
+
+        with pytest.raises(HTTPException) as exc_info:
+            authenticate_with_credentials("john", "s3cret")
+
+        assert exc_info.value.status_code == 502
+        assert "access token" in exc_info.value.detail.lower()
+
+    @patch("api.services.auth_services.user_login.requests.post")
+    @patch("api.services.auth_services.user_login.swagger_settings")
+    def test_non_json_success_response_raises_502(self, mock_settings, mock_post):
+        """A 200 response with a non-JSON body surfaces as 502."""
+        mock_settings.auth_api_url = "https://idp.example.com/information"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = ValueError("not json")
+        mock_post.return_value = mock_response
+
+        with pytest.raises(HTTPException) as exc_info:
+            authenticate_with_credentials("john", "s3cret")
+
+        assert exc_info.value.status_code == 502
+
+    @patch("api.services.auth_services.user_login.requests.post")
+    @patch("api.services.auth_services.user_login.swagger_settings")
+    def test_auth_error_without_json_body_uses_default_message(
+        self, mock_settings, mock_post
+    ):
+        """A 401 whose body is not JSON still surfaces as 401 with a default."""
+        mock_settings.auth_api_url = "https://idp.example.com/information"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.json.side_effect = ValueError("not json")
+        mock_post.return_value = mock_response
+
+        with pytest.raises(HTTPException) as exc_info:
+            authenticate_with_credentials("john", "s3cret")
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Invalid username or password"

--- a/ui/src/components/AuthGuard.js
+++ b/ui/src/components/AuthGuard.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Lock, AlertCircle, Eye, EyeOff } from 'lucide-react';
+import { Lock, AlertCircle, Eye, EyeOff, User } from 'lucide-react';
 import { authAPI } from '../services/api';
 
 /**
@@ -13,6 +13,12 @@ const AuthGuard = ({ children, onAuthenticated }) => {
   const [showToken, setShowToken] = useState(false);
   const [token, setToken] = useState('');
   const [validatingToken, setValidatingToken] = useState(false);
+
+  // Credentials mode state
+  const [authMode, setAuthMode] = useState('token'); // 'token' | 'credentials'
+  const [credentials, setCredentials] = useState({ username: '', password: '' });
+  const [showPassword, setShowPassword] = useState(false);
+  const [loggingIn, setLoggingIn] = useState(false);
 
   /**
    * Check if user is already authenticated using proper token validation
@@ -89,6 +95,50 @@ const AuthGuard = ({ children, onAuthenticated }) => {
    */
   const handleToggleTokenVisibility = () => {
     setShowToken(!showToken);
+  };
+
+  /**
+   * Handle credentials input changes.
+   */
+  const handleCredentialsChange = (e) => {
+    const { name, value } = e.target;
+    setCredentials((prev) => ({ ...prev, [name]: value }));
+  };
+
+  /**
+   * Handle login with username and password.
+   */
+  const handleCredentialsSubmit = async (e) => {
+    e.preventDefault();
+
+    if (!credentials.username.trim() || !credentials.password) {
+      setError('Please enter both username and password');
+      return;
+    }
+
+    try {
+      setError(null);
+      setLoggingIn(true);
+
+      await authAPI.login(credentials.username.trim(), credentials.password);
+
+      setIsAuthenticated(true);
+      onAuthenticated && onAuthenticated();
+      setCredentials({ username: '', password: '' });
+    } catch (err) {
+      console.error('Credentials login error:', err);
+      setError(err.message || 'Login failed');
+    } finally {
+      setLoggingIn(false);
+    }
+  };
+
+  /**
+   * Switch between token and credentials authentication modes.
+   */
+  const switchAuthMode = (mode) => {
+    setAuthMode(mode);
+    setError(null);
   };
 
   /**
@@ -214,6 +264,7 @@ const AuthGuard = ({ children, onAuthenticated }) => {
           )}
 
           {/* Token Form */}
+          {authMode === 'token' && (
           <form onSubmit={handleTokenSubmit}>
             <div style={{ marginBottom: '1rem' }}>
               <label style={{
@@ -369,7 +420,221 @@ const AuthGuard = ({ children, onAuthenticated }) => {
                 </>
               )}
             </button>
+
+            {/* Switch to credentials mode */}
+            <div style={{
+              textAlign: 'center',
+              marginTop: '1rem',
+              fontSize: '0.85rem',
+              color: '#64748b'
+            }}>
+              <button
+                type="button"
+                onClick={() => switchAuthMode('credentials')}
+                disabled={validatingToken}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  color: '#2563eb',
+                  cursor: validatingToken ? 'not-allowed' : 'pointer',
+                  padding: 0,
+                  fontSize: '0.85rem',
+                  textDecoration: 'underline',
+                  opacity: validatingToken ? 0.5 : 1
+                }}
+              >
+                or use your login / password
+              </button>
+            </div>
           </form>
+          )}
+
+          {/* Credentials Form */}
+          {authMode === 'credentials' && (
+          <form onSubmit={handleCredentialsSubmit}>
+            <div style={{ marginBottom: '1rem' }}>
+              <label style={{
+                display: 'block',
+                fontWeight: '600',
+                color: '#374151',
+                marginBottom: '0.5rem',
+                fontSize: '0.9rem'
+              }}>
+                <User size={14} style={{ marginRight: '0.35rem', verticalAlign: 'middle' }} />
+                Username
+              </label>
+              <input
+                type="text"
+                name="username"
+                value={credentials.username}
+                onChange={handleCredentialsChange}
+                placeholder="Enter your username"
+                required
+                disabled={loggingIn}
+                autoComplete="username"
+                style={{
+                  width: '100%',
+                  padding: '0.75rem',
+                  border: '2px solid #e2e8f0',
+                  borderRadius: '6px',
+                  fontSize: '0.875rem',
+                  transition: 'border-color 0.3s ease',
+                  backgroundColor: loggingIn ? '#f3f4f6' : 'white',
+                  opacity: loggingIn ? 0.6 : 1,
+                  boxSizing: 'border-box'
+                }}
+                onFocus={(e) => {
+                  if (!loggingIn) {
+                    e.target.style.borderColor = '#2563eb';
+                    e.target.style.boxShadow = '0 0 0 3px rgba(37, 99, 235, 0.1)';
+                  }
+                }}
+                onBlur={(e) => {
+                  e.target.style.borderColor = '#e2e8f0';
+                  e.target.style.boxShadow = 'none';
+                }}
+              />
+            </div>
+
+            <div style={{ marginBottom: '1rem' }}>
+              <label style={{
+                display: 'block',
+                fontWeight: '600',
+                color: '#374151',
+                marginBottom: '0.5rem',
+                fontSize: '0.9rem'
+              }}>
+                <Lock size={14} style={{ marginRight: '0.35rem', verticalAlign: 'middle' }} />
+                Password
+              </label>
+              <div style={{ position: 'relative' }}>
+                <input
+                  type={showPassword ? 'text' : 'password'}
+                  name="password"
+                  value={credentials.password}
+                  onChange={handleCredentialsChange}
+                  placeholder="Enter your password"
+                  required
+                  disabled={loggingIn}
+                  autoComplete="current-password"
+                  style={{
+                    width: '100%',
+                    padding: '0.75rem',
+                    paddingRight: '2.5rem',
+                    border: '2px solid #e2e8f0',
+                    borderRadius: '6px',
+                    fontSize: '0.875rem',
+                    transition: 'border-color 0.3s ease',
+                    backgroundColor: loggingIn ? '#f3f4f6' : 'white',
+                    opacity: loggingIn ? 0.6 : 1,
+                    boxSizing: 'border-box'
+                  }}
+                  onFocus={(e) => {
+                    if (!loggingIn) {
+                      e.target.style.borderColor = '#2563eb';
+                      e.target.style.boxShadow = '0 0 0 3px rgba(37, 99, 235, 0.1)';
+                    }
+                  }}
+                  onBlur={(e) => {
+                    e.target.style.borderColor = '#e2e8f0';
+                    e.target.style.boxShadow = 'none';
+                  }}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  disabled={loggingIn}
+                  style={{
+                    position: 'absolute',
+                    top: '50%',
+                    right: '0.75rem',
+                    transform: 'translateY(-50%)',
+                    background: 'none',
+                    border: 'none',
+                    color: loggingIn ? '#9ca3af' : '#64748b',
+                    cursor: loggingIn ? 'not-allowed' : 'pointer',
+                    padding: '0.25rem'
+                  }}
+                  title={showPassword ? 'Hide password' : 'Show password'}
+                >
+                  {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                </button>
+              </div>
+            </div>
+
+            <button
+              type="submit"
+              disabled={loggingIn}
+              style={{
+                width: '100%',
+                padding: '0.75rem 1rem',
+                backgroundColor: loggingIn ? '#9ca3af' : '#2563eb',
+                color: 'white',
+                border: 'none',
+                borderRadius: '6px',
+                fontSize: '0.9rem',
+                fontWeight: '600',
+                cursor: loggingIn ? 'not-allowed' : 'pointer',
+                transition: 'all 0.3s ease',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: '0.5rem',
+                opacity: loggingIn ? 0.6 : 1
+              }}
+              onMouseOver={(e) => {
+                if (!loggingIn) {
+                  e.target.style.backgroundColor = '#1d4ed8';
+                  e.target.style.transform = 'translateY(-1px)';
+                }
+              }}
+              onMouseOut={(e) => {
+                if (!loggingIn) {
+                  e.target.style.backgroundColor = '#2563eb';
+                  e.target.style.transform = 'translateY(0)';
+                }
+              }}
+            >
+              {loggingIn ? (
+                <>
+                  <div className="loading-spinner" style={{ width: '16px', height: '16px' }} />
+                  Signing in...
+                </>
+              ) : (
+                <>
+                  <Lock size={18} />
+                  Sign in
+                </>
+              )}
+            </button>
+
+            {/* Switch back to token mode */}
+            <div style={{
+              textAlign: 'center',
+              marginTop: '1rem',
+              fontSize: '0.85rem',
+              color: '#64748b'
+            }}>
+              <button
+                type="button"
+                onClick={() => switchAuthMode('token')}
+                disabled={loggingIn}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  color: '#2563eb',
+                  cursor: loggingIn ? 'not-allowed' : 'pointer',
+                  padding: 0,
+                  fontSize: '0.85rem',
+                  textDecoration: 'underline',
+                  opacity: loggingIn ? 0.5 : 1
+                }}
+              >
+                or use an access token
+              </button>
+            </div>
+          </form>
+          )}
 
           {/* Help Text */}
           <div style={{

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -375,10 +375,58 @@ export const authAPI = {
         'Authorization': `Bearer ${token}`
       },
     });
-    
+
     // Try to get user info with the provided token
     const response = await tempClient.get('/user/info');
     return response.data;
+  },
+
+  /**
+   * Authenticate with username and password.
+   * On success, the returned access token is stored in localStorage so that
+   * subsequent requests pick it up via the axios request interceptor.
+   *
+   * @param {string} username
+   * @param {string} password
+   * @returns {Promise<Object>} The identity provider response (access_token, etc.)
+   */
+  login: async (username, password) => {
+    // Use a bare axios instance so the request interceptor does not require
+    // an existing token for this public, pre-authentication endpoint.
+    const tempClient = axios.create({
+      baseURL: BASE_URL,
+      timeout: 60000,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    try {
+      const response = await tempClient.post('/user/login', { username, password });
+      const data = response.data;
+
+      if (!data || !data.access_token) {
+        throw new Error('Login response is missing access token');
+      }
+
+      localStorage.setItem('authToken', data.access_token);
+      return data;
+    } catch (error) {
+      localStorage.removeItem('authToken');
+
+      if (error.response?.status === 401) {
+        throw new Error(
+          error.response.data?.detail || 'Invalid username or password'
+        );
+      }
+      if (error.response?.status === 502) {
+        throw new Error('Authentication service is unavailable');
+      }
+      if (error.code === 'ECONNREFUSED' || error.message?.includes('Network Error')) {
+        throw new Error('Cannot connect to API server');
+      }
+      throw new Error(
+        error.response?.data?.detail || error.message || 'Login failed'
+      );
+    }
   },
   
   /**


### PR DESCRIPTION
## Summary
- Add a new `POST /user/login` endpoint that forwards `username`/`password` to the configured identity provider and returns the access token plus profile data
- Add a toggle link below the "Authenticate" button on the UI login screen so users can switch to a credentials form (username + password, with show/hide toggle) instead of pasting an access token; a reciprocal link returns to the token form
- Bump version to 0.11.0

Closes #104

## Test plan
- [x] Unit tests for `authenticate_with_credentials` (happy path, 400/401/403, network error, 5xx, non-JSON body, missing access_token)
- [x] Route tests for `POST /user/login` (success, 401, 502, validation errors, public access)
- [x] Full test suite passes (1033 tests)
- [x] `black --check --diff .` passes
- [x] `flake8 api/ tests/ --max-line-length=88 --extend-ignore=E203,W503,E501,F401` passes
- [x] Manual end-to-end verification on local stack (token form and credentials form both work)