### PR TITLE
Extend group-based access with ndp_admin role and endpoint UUID (v0.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-04-22
+
+### Changed
+- `ENABLE_GROUP_BASED_ACCESS` now authorizes a user when **any** of the following is true:
+  1. The user belongs to one of the groups listed in `GROUP_NAMES` (existing behavior)
+  2. The user has the role `ndp_admin`
+  3. The user belongs to the group whose name matches `AFFINITIES_EP_UUID`
+- When group-based access is disabled the behavior is unchanged — any authenticated user is allowed
+- The 403 response body now enumerates all three accepted authorization paths
+
 ## [0.11.0] - 2026-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   3. The user belongs to the group whose name matches `AFFINITIES_EP_UUID`
 - When group-based access is disabled the behavior is unchanged — any authenticated user is allowed
 - The 403 response body now enumerates all three accepted authorization paths
+- `GET /user/info` is now gated by the same authorization rule. When `ENABLE_GROUP_BASED_ACCESS=True`, users that do not satisfy any of the three paths receive 403 Forbidden instead of their profile data, which prevents the UI's AuthGuard from letting them into the app
+- The UI credentials login flow now validates the returned token against `/user/info` before storing it, so authorization errors are surfaced at login time rather than after entering the app
+- The UI login screen now shows the backend's 403 detail (e.g. "Access forbidden: access to this Endpoint requires …") when the user is not allowed to enter the Endpoint
 
 ## [0.11.0] - 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   2. The user has the role `ndp_admin`
   3. The user belongs to the group whose name matches `AFFINITIES_EP_UUID`
 - When group-based access is disabled the behavior is unchanged — any authenticated user is allowed
-- The 403 response body now shows a short user-friendly message ("You do not have permission to access this Endpoint. Please contact the administrator if you believe this is a mistake." / "You do not have permission to perform this operation. …"). The technical details (required role, endpoint group UUID, configured `GROUP_NAMES`) are logged as a backend warning instead of being returned to the user
+- The 403 response body now shows a short user-friendly message ("You do not have permission to access this Endpoint. Please contact the administrator." / "You do not have permission to perform this operation. Please contact the administrator."). The technical details (required role, endpoint group UUID, configured `GROUP_NAMES`) are logged as a backend warning instead of being returned to the user
 - `GET /user/info` is now gated by the same authorization rule. When `ENABLE_GROUP_BASED_ACCESS=True`, users that do not satisfy any of the three paths receive 403 Forbidden instead of their profile data, which prevents the UI's AuthGuard from letting them into the app
 - The UI credentials login flow now validates the returned token against `/user/info` before storing it, so authorization errors are surfaced at login time rather than after entering the app
 - The UI login screen now shows the backend's 403 detail (e.g. "Access forbidden: access to this Endpoint requires …") when the user is not allowed to enter the Endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   2. The user has the role `ndp_admin`
   3. The user belongs to the group whose name matches `AFFINITIES_EP_UUID`
 - When group-based access is disabled the behavior is unchanged — any authenticated user is allowed
-- The 403 response body now enumerates all three accepted authorization paths
+- The 403 response body now shows a short user-friendly message ("You do not have permission to access this Endpoint. Please contact the administrator if you believe this is a mistake." / "You do not have permission to perform this operation. …"). The technical details (required role, endpoint group UUID, configured `GROUP_NAMES`) are logged as a backend warning instead of being returned to the user
 - `GET /user/info` is now gated by the same authorization rule. When `ENABLE_GROUP_BASED_ACCESS=True`, users that do not satisfy any of the three paths receive 403 Forbidden instead of their profile data, which prevents the UI's AuthGuard from letting them into the app
 - The UI credentials login flow now validates the returned token against `/user/info` before storing it, so authorization errors are surfaced at login time rather than after entering the app
 - The UI login screen now shows the backend's 403 detail (e.g. "Access forbidden: access to this Endpoint requires …") when the user is not allowed to enter the Endpoint

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.11.0"
+    swagger_version: str = "0.12.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/routes/user_routes/user_info.py
+++ b/api/routes/user_routes/user_info.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 
 from fastapi import APIRouter, Depends
 
-from api.services.auth_services import get_current_user
+from api.services.auth_services import get_user_for_endpoint_access
 
 router = APIRouter()
 
@@ -80,19 +80,22 @@ router = APIRouter()
     },
 )
 async def get_user_info(
-    user_info: Dict[str, Any] = Depends(get_current_user),
+    user_info: Dict[str, Any] = Depends(get_user_for_endpoint_access),
 ) -> Dict[str, Any]:
     """
     Get current user information from the authentication service.
 
     This endpoint acts as a passthrough to the authentication service,
     returning the complete user profile information that was retrieved
-    during token validation.
+    during token validation. It also doubles as the UI's entry gate:
+    when ``ENABLE_GROUP_BASED_ACCESS`` is enabled, users that do not
+    satisfy any of the configured authorization paths are rejected
+    with a 403 response.
 
     Parameters
     ----------
     user_info : Dict[str, Any]
-        User information from get_current_user dependency
+        User information provided by the endpoint-access dependency.
 
     Returns
     -------
@@ -103,7 +106,7 @@ async def get_user_info(
     ------
     HTTPException
         401: If token is invalid or expired
-        403: If token does not have sufficient permissions
+        403: If the user is not authorized to access this Endpoint
         502: If authentication service is unavailable
     """
     return user_info

--- a/api/services/auth_services/__init__.py
+++ b/api/services/auth_services/__init__.py
@@ -3,6 +3,7 @@ from .authorization_service import (  # noqa: F401
     check_group_membership,
     check_organization_membership,  # backward compatibility
     get_allowed_groups,
+    get_user_for_endpoint_access,
     get_user_for_write_operation,
     require_group_member,
     require_organization_member,  # backward compatibility

--- a/api/services/auth_services/authorization_service.py
+++ b/api/services/auth_services/authorization_service.py
@@ -161,6 +161,29 @@ def check_group_membership(user_info: Dict[str, Any]) -> bool:
     return False
 
 
+def _raise_forbidden(context: str) -> None:
+    """
+    Raise the 403 error shared by every authorization dependency.
+
+    Parameters
+    ----------
+    context : str
+        Short description of what the user was trying to do (e.g.
+        ``"write operations"`` or ``"access to this Endpoint"``). The
+        phrase is interpolated into the error detail.
+    """
+    allowed_groups = get_allowed_groups()
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=(
+            f"Access forbidden: {context} requires the "
+            f"'{ADMIN_ROLE_NAME}' role, membership in the endpoint group "
+            f"'{affinities_settings.ep_uuid}', or membership in one of "
+            f"these groups: {allowed_groups}"
+        ),
+    )
+
+
 def require_group_member(
     user_info: Dict[str, Any] = Depends(get_current_user),
 ) -> Dict[str, Any]:
@@ -186,16 +209,7 @@ def require_group_member(
         403 Forbidden if user is not authorized for write operations
     """
     if not check_group_membership(user_info):
-        allowed_groups = get_allowed_groups()
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=(
-                "Access forbidden: write operations require the "
-                f"'{ADMIN_ROLE_NAME}' role, membership in the endpoint group "
-                f"'{affinities_settings.ep_uuid}', or membership in one of "
-                f"these groups: {allowed_groups}"
-            ),
-        )
+        _raise_forbidden("write operations")
 
     return user_info
 
@@ -234,6 +248,44 @@ def get_user_for_write_operation(
     else:
         # Feature disabled, just return authenticated user
         return user_info
+
+
+def get_user_for_endpoint_access(
+    user_info: Dict[str, Any] = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """
+    Dependency that gates entry to the Endpoint (UI and user-facing APIs).
+
+    Used by ``/user/info`` so the UI's AuthGuard can detect unauthorized
+    users at login time and refuse to let them enter the application.
+
+    Behavior mirrors :func:`get_user_for_write_operation` but the 403
+    error message refers to "access to this Endpoint" instead of
+    "write operations".
+
+    Parameters
+    ----------
+    user_info : Dict[str, Any]
+        User information from :func:`get_current_user`.
+
+    Returns
+    -------
+    Dict[str, Any]
+        User information if authorized.
+
+    Raises
+    ------
+    HTTPException
+        403 Forbidden if group-based access is enabled and the user is
+        not authorized to access this Endpoint.
+    """
+    if not swagger_settings.enable_group_based_access:
+        return user_info
+
+    if not check_group_membership(user_info):
+        _raise_forbidden("access to this Endpoint")
+
+    return user_info
 
 
 # Backward compatibility aliases

--- a/api/services/auth_services/authorization_service.py
+++ b/api/services/auth_services/authorization_service.py
@@ -215,7 +215,7 @@ def require_group_member(
     if not check_group_membership(user_info):
         _raise_forbidden(
             "You do not have permission to perform this operation. "
-            "Please contact the administrator if you believe this is a mistake."
+            "Please contact the administrator."
         )
 
     return user_info
@@ -292,7 +292,7 @@ def get_user_for_endpoint_access(
     if not check_group_membership(user_info):
         _raise_forbidden(
             "You do not have permission to access this Endpoint. "
-            "Please contact the administrator if you believe this is a mistake."
+            "Please contact the administrator."
         )
 
     return user_info

--- a/api/services/auth_services/authorization_service.py
+++ b/api/services/auth_services/authorization_service.py
@@ -5,10 +5,14 @@ from typing import Any, Dict, List
 
 from fastapi import Depends, HTTPException, status
 
+from api.config.affinities_settings import affinities_settings
 from api.config.swagger_settings import swagger_settings
 from api.services.auth_services.get_current_user import get_current_user
 
 logger = logging.getLogger(__name__)
+
+# Role that always grants access when group-based access is enabled.
+ADMIN_ROLE_NAME = "ndp_admin"
 
 
 def normalize_group_path(path: str) -> str:
@@ -48,9 +52,63 @@ def get_allowed_groups() -> List[str]:
     ]
 
 
+def _iter_normalized_user_groups(user_info: Dict[str, Any]):
+    """
+    Yield normalized group values from a user info payload.
+
+    Accepts both plain strings and dicts with ``path``/``name`` fields,
+    mirroring the shapes returned by the identity provider. Non-string
+    entries with no usable value are skipped.
+    """
+    for group in user_info.get("groups", []):
+        if isinstance(group, str):
+            value = normalize_group_path(group)
+        elif isinstance(group, dict):
+            value = normalize_group_path(
+                str(group.get("path") or group.get("name") or "")
+            )
+        else:
+            continue
+
+        if value:
+            yield value
+
+
+def _has_admin_role(user_info: Dict[str, Any]) -> bool:
+    """
+    Return True if the user has the platform-wide admin role.
+    """
+    roles = user_info.get("roles", [])
+    if not isinstance(roles, list):
+        return False
+    return any(
+        isinstance(role, str) and role.strip().lower() == ADMIN_ROLE_NAME
+        for role in roles
+    )
+
+
+def _is_member_of_endpoint_group(user_info: Dict[str, Any]) -> bool:
+    """
+    Return True if the user belongs to the group matching AFFINITIES_EP_UUID.
+    """
+    ep_uuid = (affinities_settings.ep_uuid or "").strip()
+    if not ep_uuid:
+        return False
+
+    target = normalize_group_path(ep_uuid)
+    return any(value == target for value in _iter_normalized_user_groups(user_info))
+
+
 def check_group_membership(user_info: Dict[str, Any]) -> bool:
     """
-    Check if user belongs to any of the configured allowed groups.
+    Check whether the user is authorized when group-based access is enabled.
+
+    The user is authorized if **any** of the following is true:
+
+    1. Feature disabled (``ENABLE_GROUP_BASED_ACCESS`` is False) — always allow.
+    2. User belongs to one of the groups listed in ``GROUP_NAMES``.
+    3. User has the ``ndp_admin`` role.
+    4. User belongs to the group whose name matches ``AFFINITIES_EP_UUID``.
 
     Parameters
     ----------
@@ -60,33 +118,39 @@ def check_group_membership(user_info: Dict[str, Any]) -> bool:
     Returns
     -------
     bool
-        True if user belongs to at least one allowed group, False otherwise
+        True if the user is authorized, False otherwise.
     """
     if not swagger_settings.enable_group_based_access:
         # If feature is disabled, always allow access
         return True
 
-    allowed_groups = get_allowed_groups()
-    if not allowed_groups:
-        # No groups configured, deny access
-        logger.warning("Group-based access enabled but no GROUP_NAMES configured")
-        return False
+    # Admin role short-circuits every other check.
+    if _has_admin_role(user_info):
+        logger.info(f"User authorized: has '{ADMIN_ROLE_NAME}' role")
+        return True
 
+    # Membership in the endpoint's own UUID group is always allowed.
+    if _is_member_of_endpoint_group(user_info):
+        logger.info(
+            "User authorized: belongs to endpoint group "
+            f"'{affinities_settings.ep_uuid}'"
+        )
+        return True
+
+    allowed_groups = get_allowed_groups()
     user_groups = user_info.get("groups", [])
 
-    # Check if any of the user's groups matches an allowed group
-    for group in user_groups:
-        if isinstance(group, str):
-            group_value = normalize_group_path(group)
-        elif isinstance(group, dict):
-            group_value = normalize_group_path(
-                str(group.get("path") or group.get("name") or "")
-            )
-        else:
-            continue
+    if not allowed_groups:
+        logger.warning(
+            "Group-based access enabled but no GROUP_NAMES configured, "
+            "and user is neither admin nor endpoint member"
+        )
+        return False
 
+    # Check if any of the user's groups matches an allowed group
+    for group_value in _iter_normalized_user_groups(user_info):
         logger.info(f"checking group: {group_value}")
-        if group_value and group_value in allowed_groups:
+        if group_value in allowed_groups:
             logger.info(f"User authorized: belongs to allowed group '{group_value}'")
             return True
 
@@ -126,8 +190,10 @@ def require_group_member(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=(
-                "Access forbidden: write operations require membership "
-                f"in one of these groups: {allowed_groups}"
+                "Access forbidden: write operations require the "
+                f"'{ADMIN_ROLE_NAME}' role, membership in the endpoint group "
+                f"'{affinities_settings.ep_uuid}', or membership in one of "
+                f"these groups: {allowed_groups}"
             ),
         )
 

--- a/api/services/auth_services/authorization_service.py
+++ b/api/services/auth_services/authorization_service.py
@@ -161,26 +161,30 @@ def check_group_membership(user_info: Dict[str, Any]) -> bool:
     return False
 
 
-def _raise_forbidden(context: str) -> None:
+def _raise_forbidden(user_message: str) -> None:
     """
     Raise the 403 error shared by every authorization dependency.
 
+    The response body shows ``user_message`` only — the technical details
+    of the access rule (admin role name, endpoint UUID, configured
+    ``GROUP_NAMES``) are written to the application log so administrators
+    can still debug rejections without leaking jargon to end users.
+
     Parameters
     ----------
-    context : str
-        Short description of what the user was trying to do (e.g.
-        ``"write operations"`` or ``"access to this Endpoint"``). The
-        phrase is interpolated into the error detail.
+    user_message : str
+        End-user-friendly message surfaced verbatim in the 403 response.
     """
-    allowed_groups = get_allowed_groups()
+    logger.warning(
+        "Access denied (403). Required: role '%s', endpoint group '%s', "
+        "or one of %s.",
+        ADMIN_ROLE_NAME,
+        affinities_settings.ep_uuid,
+        get_allowed_groups(),
+    )
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
-        detail=(
-            f"Access forbidden: {context} requires the "
-            f"'{ADMIN_ROLE_NAME}' role, membership in the endpoint group "
-            f"'{affinities_settings.ep_uuid}', or membership in one of "
-            f"these groups: {allowed_groups}"
-        ),
+        detail=user_message,
     )
 
 
@@ -209,7 +213,10 @@ def require_group_member(
         403 Forbidden if user is not authorized for write operations
     """
     if not check_group_membership(user_info):
-        _raise_forbidden("write operations")
+        _raise_forbidden(
+            "You do not have permission to perform this operation. "
+            "Please contact the administrator if you believe this is a mistake."
+        )
 
     return user_info
 
@@ -283,7 +290,10 @@ def get_user_for_endpoint_access(
         return user_info
 
     if not check_group_membership(user_info):
-        _raise_forbidden("access to this Endpoint")
+        _raise_forbidden(
+            "You do not have permission to access this Endpoint. "
+            "Please contact the administrator if you believe this is a mistake."
+        )
 
     return user_info
 

--- a/tests/test_authorization_service.py
+++ b/tests/test_authorization_service.py
@@ -8,6 +8,7 @@ from unittest.mock import patch, MagicMock
 from fastapi import HTTPException
 
 from api.services.auth_services.authorization_service import (
+    ADMIN_ROLE_NAME,
     check_group_membership,
     get_allowed_groups,
     normalize_group_path,
@@ -335,3 +336,222 @@ class TestGetUserForWriteOperation:
                     get_user_for_write_operation(user_info)
 
                 assert exc_info.value.status_code == 403
+
+
+class TestCheckGroupMembershipAdminRole:
+    """Admin-role shortcut for check_group_membership."""
+
+    def test_admin_role_grants_access_even_without_matching_group(self):
+        """Having the admin role is enough to authorize the user."""
+        with (
+            patch(
+                "api.services.auth_services.authorization_service.swagger_settings"
+            ) as mock_settings,
+            patch(
+                "api.services.auth_services.authorization_service.affinities_settings"
+            ) as mock_affinities,
+        ):
+            mock_settings.enable_group_based_access = True
+            mock_settings.group_names = "admins"
+            mock_affinities.ep_uuid = ""
+
+            user_info = {"roles": [ADMIN_ROLE_NAME], "groups": ["other-group"]}
+            assert check_group_membership(user_info) is True
+
+    def test_admin_role_works_when_group_names_is_empty(self):
+        """Admin role bypasses the 'no groups configured' denial path."""
+        with (
+            patch(
+                "api.services.auth_services.authorization_service.swagger_settings"
+            ) as mock_settings,
+            patch(
+                "api.services.auth_services.authorization_service.affinities_settings"
+            ) as mock_affinities,
+        ):
+            mock_settings.enable_group_based_access = True
+            mock_settings.group_names = ""
+            mock_affinities.ep_uuid = ""
+
+            user_info = {"roles": [ADMIN_ROLE_NAME], "groups": []}
+            assert check_group_membership(user_info) is True
+
+    def test_admin_role_match_is_case_insensitive(self):
+        """Role matching is case-insensitive."""
+        with (
+            patch(
+                "api.services.auth_services.authorization_service.swagger_settings"
+            ) as mock_settings,
+            patch(
+                "api.services.auth_services.authorization_service.affinities_settings"
+            ) as mock_affinities,
+        ):
+            mock_settings.enable_group_based_access = True
+            mock_settings.group_names = "admins"
+            mock_affinities.ep_uuid = ""
+
+            user_info = {"roles": ["NDP_Admin"], "groups": []}
+            assert check_group_membership(user_info) is True
+
+    def test_non_admin_role_alone_does_not_grant_access(self):
+        """A non-admin role does not bypass group checks."""
+        with (
+            patch(
+                "api.services.auth_services.authorization_service.swagger_settings"
+            ) as mock_settings,
+            patch(
+                "api.services.auth_services.authorization_service.affinities_settings"
+            ) as mock_affinities,
+        ):
+            mock_settings.enable_group_based_access = True
+            mock_settings.group_names = "admins"
+            mock_affinities.ep_uuid = ""
+
+            user_info = {"roles": ["default-roles-ndp"], "groups": ["other"]}
+            assert check_group_membership(user_info) is False
+
+    def test_roles_missing_does_not_raise(self):
+        """Missing 'roles' field is handled gracefully."""
+        with (
+            patch(
+                "api.services.auth_services.authorization_service.swagger_settings"
+            ) as mock_settings,
+            patch(
+                "api.services.auth_services.authorization_service.affinities_settings"
+            ) as mock_affinities,
+        ):
+            mock_settings.enable_group_based_access = True
+            mock_settings.group_names = "admins"
+            mock_affinities.ep_uuid = ""
+
+            user_info = {"groups": ["admins"]}
+            assert check_group_membership(user_info) is True
+
+    def test_non_list_roles_is_ignored(self):
+        """A malformed 'roles' field is ignored without error."""
+        with (
+            patch(
+                "api.services.auth_services.authorization_service.swagger_settings"
+            ) as mock_settings,
+            patch(
+                "api.services.auth_services.authorization_service.affinities_settings"
+            ) as mock_affinities,
+        ):
+            mock_settings.enable_group_based_access = True
+            mock_settings.group_names = "admins"
+            mock_affinities.ep_uuid = ""
+
+            user_info = {"roles": ADMIN_ROLE_NAME, "groups": []}
+            assert check_group_membership(user_info) is False
+
+
+class TestCheckGroupMembershipEndpointUuidGroup:
+    """Endpoint-UUID group shortcut for check_group_membership."""
+
+    def test_user_in_endpoint_uuid_group_is_authorized(self):
+        """Membership in the AFFINITIES_EP_UUID group grants access."""
+        uuid = "96207a63-ee21-40c8-a492-31d680002330"
+        with (
+            patch(
+                "api.services.auth_services.authorization_service.swagger_settings"
+            ) as mock_settings,
+            patch(
+                "api.services.auth_services.authorization_service.affinities_settings"
+            ) as mock_affinities,
+        ):
+            mock_settings.enable_group_based_access = True
+            mock_settings.group_names = "some-other-group"
+            mock_affinities.ep_uuid = uuid
+
+            user_info = {"roles": [], "groups": [uuid]}
+            assert check_group_membership(user_info) is True
+
+    def test_endpoint_uuid_group_as_dict_path(self):
+        """Endpoint group match works when group is provided as a dict path."""
+        uuid = "96207a63-ee21-40c8-a492-31d680002330"
+        with (
+            patch(
+                "api.services.auth_services.authorization_service.swagger_settings"
+            ) as mock_settings,
+            patch(
+                "api.services.auth_services.authorization_service.affinities_settings"
+            ) as mock_affinities,
+        ):
+            mock_settings.enable_group_based_access = True
+            mock_settings.group_names = ""
+            mock_affinities.ep_uuid = uuid
+
+            user_info = {
+                "roles": [],
+                "groups": [{"name": uuid, "path": f"/{uuid}"}],
+            }
+            assert check_group_membership(user_info) is True
+
+    def test_endpoint_uuid_group_match_is_case_insensitive(self):
+        """Group name matching is case-insensitive."""
+        uuid_upper = "96207A63-EE21-40C8-A492-31D680002330"
+        uuid_lower = uuid_upper.lower()
+        with (
+            patch(
+                "api.services.auth_services.authorization_service.swagger_settings"
+            ) as mock_settings,
+            patch(
+                "api.services.auth_services.authorization_service.affinities_settings"
+            ) as mock_affinities,
+        ):
+            mock_settings.enable_group_based_access = True
+            mock_settings.group_names = ""
+            mock_affinities.ep_uuid = uuid_upper
+
+            user_info = {"roles": [], "groups": [uuid_lower]}
+            assert check_group_membership(user_info) is True
+
+    def test_empty_endpoint_uuid_does_not_grant_access(self):
+        """An unset AFFINITIES_EP_UUID does not accidentally authorize users."""
+        with (
+            patch(
+                "api.services.auth_services.authorization_service.swagger_settings"
+            ) as mock_settings,
+            patch(
+                "api.services.auth_services.authorization_service.affinities_settings"
+            ) as mock_affinities,
+        ):
+            mock_settings.enable_group_based_access = True
+            mock_settings.group_names = ""
+            mock_affinities.ep_uuid = ""
+
+            user_info = {"roles": [], "groups": [""]}
+            assert check_group_membership(user_info) is False
+
+    def test_user_not_in_endpoint_uuid_group_and_not_in_group_names_denied(self):
+        """User outside all three authorization paths is denied."""
+        with (
+            patch(
+                "api.services.auth_services.authorization_service.swagger_settings"
+            ) as mock_settings,
+            patch(
+                "api.services.auth_services.authorization_service.affinities_settings"
+            ) as mock_affinities,
+        ):
+            mock_settings.enable_group_based_access = True
+            mock_settings.group_names = "admins"
+            mock_affinities.ep_uuid = "96207a63-ee21-40c8-a492-31d680002330"
+
+            user_info = {"roles": ["user"], "groups": ["some-other-group"]}
+            assert check_group_membership(user_info) is False
+
+    def test_feature_disabled_ignores_all_extended_checks(self):
+        """When group-based access is disabled all users are allowed."""
+        with (
+            patch(
+                "api.services.auth_services.authorization_service.swagger_settings"
+            ) as mock_settings,
+            patch(
+                "api.services.auth_services.authorization_service.affinities_settings"
+            ) as mock_affinities,
+        ):
+            mock_settings.enable_group_based_access = False
+            mock_settings.group_names = ""
+            mock_affinities.ep_uuid = ""
+
+            user_info = {"roles": [], "groups": []}
+            assert check_group_membership(user_info) is True

--- a/tests/test_authorization_service.py
+++ b/tests/test_authorization_service.py
@@ -284,7 +284,10 @@ class TestRequireGroupMember:
                     require_group_member(user_info)
 
                 assert exc_info.value.status_code == 403
-                assert "Access forbidden" in exc_info.value.detail
+                assert "do not have permission" in exc_info.value.detail
+                # Technical internals must not leak to the end user
+                assert ADMIN_ROLE_NAME not in exc_info.value.detail
+                assert "GROUP_NAMES" not in exc_info.value.detail
 
 
 class TestGetUserForWriteOperation:
@@ -591,8 +594,8 @@ class TestGetUserForEndpointAccess:
 
             assert result == user_info
 
-    def test_unauthorized_user_raises_403_with_endpoint_context(self):
-        """Unauthorized users receive a 403 whose message names the Endpoint."""
+    def test_unauthorized_user_raises_403_with_friendly_endpoint_message(self):
+        """Unauthorized users receive a 403 with a user-friendly message."""
         with (
             patch(
                 "api.services.auth_services.authorization_service.swagger_settings"
@@ -615,12 +618,16 @@ class TestGetUserForEndpointAccess:
                 get_user_for_endpoint_access(user_info)
 
             assert exc_info.value.status_code == 403
-            assert "access to this Endpoint" in exc_info.value.detail
-            assert ADMIN_ROLE_NAME in exc_info.value.detail
-            assert "some-uuid" in exc_info.value.detail
+            assert "do not have permission to access this Endpoint" in (
+                exc_info.value.detail
+            )
+            # Technical internals must not leak to the end user
+            assert ADMIN_ROLE_NAME not in exc_info.value.detail
+            assert "some-uuid" not in exc_info.value.detail
+            assert "GROUP_NAMES" not in exc_info.value.detail
 
-    def test_write_operation_dependency_still_says_write_operations(self):
-        """The write-op dependency keeps its original error context."""
+    def test_write_operation_dependency_uses_friendly_operation_message(self):
+        """The write-op dependency also hides technical internals."""
         with (
             patch(
                 "api.services.auth_services.authorization_service.swagger_settings"
@@ -643,4 +650,8 @@ class TestGetUserForEndpointAccess:
                 get_user_for_write_operation(user_info)
 
             assert exc_info.value.status_code == 403
-            assert "write operations" in exc_info.value.detail
+            assert "do not have permission to perform this operation" in (
+                exc_info.value.detail
+            )
+            assert ADMIN_ROLE_NAME not in exc_info.value.detail
+            assert "some-uuid" not in exc_info.value.detail

--- a/tests/test_authorization_service.py
+++ b/tests/test_authorization_service.py
@@ -11,6 +11,7 @@ from api.services.auth_services.authorization_service import (
     ADMIN_ROLE_NAME,
     check_group_membership,
     get_allowed_groups,
+    get_user_for_endpoint_access,
     normalize_group_path,
     require_group_member,
     get_user_for_write_operation,
@@ -555,3 +556,91 @@ class TestCheckGroupMembershipEndpointUuidGroup:
 
             user_info = {"roles": [], "groups": []}
             assert check_group_membership(user_info) is True
+
+
+class TestGetUserForEndpointAccess:
+    """Test cases for get_user_for_endpoint_access dependency."""
+
+    def test_feature_disabled_returns_user_directly(self):
+        """When group-based access is disabled any authenticated user is allowed."""
+        with patch(
+            "api.services.auth_services.authorization_service.swagger_settings"
+        ) as mock_settings:
+            mock_settings.enable_group_based_access = False
+
+            user_info = {"user_id": "123", "roles": [], "groups": []}
+            result = get_user_for_endpoint_access(user_info)
+
+            assert result == user_info
+
+    def test_authorized_user_returns_user_info(self):
+        """Authorized users are passed through untouched."""
+        with (
+            patch(
+                "api.services.auth_services.authorization_service.swagger_settings"
+            ) as mock_settings,
+            patch(
+                "api.services.auth_services.authorization_service.check_group_membership"
+            ) as mock_check,
+        ):
+            mock_settings.enable_group_based_access = True
+            mock_check.return_value = True
+
+            user_info = {"user_id": "123", "roles": [ADMIN_ROLE_NAME]}
+            result = get_user_for_endpoint_access(user_info)
+
+            assert result == user_info
+
+    def test_unauthorized_user_raises_403_with_endpoint_context(self):
+        """Unauthorized users receive a 403 whose message names the Endpoint."""
+        with (
+            patch(
+                "api.services.auth_services.authorization_service.swagger_settings"
+            ) as mock_settings,
+            patch(
+                "api.services.auth_services.authorization_service.check_group_membership"
+            ) as mock_check,
+            patch(
+                "api.services.auth_services.authorization_service.affinities_settings"
+            ) as mock_affinities,
+        ):
+            mock_settings.enable_group_based_access = True
+            mock_settings.group_names = ""
+            mock_check.return_value = False
+            mock_affinities.ep_uuid = "some-uuid"
+
+            user_info = {"user_id": "123", "roles": [], "groups": []}
+
+            with pytest.raises(HTTPException) as exc_info:
+                get_user_for_endpoint_access(user_info)
+
+            assert exc_info.value.status_code == 403
+            assert "access to this Endpoint" in exc_info.value.detail
+            assert ADMIN_ROLE_NAME in exc_info.value.detail
+            assert "some-uuid" in exc_info.value.detail
+
+    def test_write_operation_dependency_still_says_write_operations(self):
+        """The write-op dependency keeps its original error context."""
+        with (
+            patch(
+                "api.services.auth_services.authorization_service.swagger_settings"
+            ) as mock_settings,
+            patch(
+                "api.services.auth_services.authorization_service.check_group_membership"
+            ) as mock_check,
+            patch(
+                "api.services.auth_services.authorization_service.affinities_settings"
+            ) as mock_affinities,
+        ):
+            mock_settings.enable_group_based_access = True
+            mock_settings.group_names = ""
+            mock_check.return_value = False
+            mock_affinities.ep_uuid = "some-uuid"
+
+            user_info = {"user_id": "123", "roles": [], "groups": []}
+
+            with pytest.raises(HTTPException) as exc_info:
+                get_user_for_write_operation(user_info)
+
+            assert exc_info.value.status_code == 403
+            assert "write operations" in exc_info.value.detail

--- a/ui/src/components/AuthGuard.js
+++ b/ui/src/components/AuthGuard.js
@@ -39,7 +39,14 @@ const AuthGuard = ({ children, onAuthenticated }) => {
         } catch (validationError) {
           console.error('Token validation failed:', validationError);
           localStorage.removeItem('authToken');
-          setError('Your session has expired. Please enter a valid token.');
+          if (validationError.response?.status === 403) {
+            setError(
+              validationError.response.data?.detail
+              || 'You do not have permission to access this Endpoint.'
+            );
+          } else {
+            setError('Your session has expired. Please enter a valid token.');
+          }
         }
       }
 
@@ -80,8 +87,9 @@ const AuthGuard = ({ children, onAuthenticated }) => {
         setError('Invalid token. Please check your token and try again.');
       } else if (errorMessage.includes('Cannot connect to API')) {
         setError('Cannot connect to API server. Please check your connection.');
-      } else if (errorMessage.includes('Insufficient permissions')) {
-        setError('Token does not have sufficient permissions.');
+      } else if (errorMessage.toLowerCase().includes('access forbidden')
+          || errorMessage.toLowerCase().includes('permission to access')) {
+        setError(errorMessage);
       } else {
         setError('Authentication failed: ' + errorMessage);
       }

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -399,16 +399,14 @@ export const authAPI = {
       headers: { 'Content-Type': 'application/json' },
     });
 
+    let data;
     try {
       const response = await tempClient.post('/user/login', { username, password });
-      const data = response.data;
+      data = response.data;
 
       if (!data || !data.access_token) {
         throw new Error('Login response is missing access token');
       }
-
-      localStorage.setItem('authToken', data.access_token);
-      return data;
     } catch (error) {
       localStorage.removeItem('authToken');
 
@@ -427,6 +425,29 @@ export const authAPI = {
         error.response?.data?.detail || error.message || 'Login failed'
       );
     }
+
+    // Credentials were accepted by the IDP. Validate the resulting token
+    // against /user/info so authorization errors (e.g. the user is not
+    // allowed to access this Endpoint) are surfaced before we store it.
+    try {
+      await authAPI.validateToken(data.access_token);
+    } catch (error) {
+      if (error.response?.status === 403) {
+        throw new Error(
+          error.response.data?.detail ||
+            'You do not have permission to access this Endpoint.'
+        );
+      }
+      if (error.response?.status === 401) {
+        throw new Error('Invalid username or password');
+      }
+      throw new Error(
+        error.response?.data?.detail || error.message || 'Login failed'
+      );
+    }
+
+    localStorage.setItem('authToken', data.access_token);
+    return data;
   },
   
   /**
@@ -455,7 +476,10 @@ export const authAPI = {
       if (error.response?.status === 401) {
         throw new Error('Invalid token: Authentication failed');
       } else if (error.response?.status === 403) {
-        throw new Error('Invalid token: Insufficient permissions');
+        throw new Error(
+          error.response.data?.detail ||
+            'You do not have permission to access this Endpoint.'
+        );
       } else if (error.code === 'ECONNREFUSED' || error.message.includes('Network Error')) {
         throw new Error('Cannot connect to API server');
       } else {


### PR DESCRIPTION
## Summary
- When `ENABLE_GROUP_BASED_ACCESS=True`, authorize users if **any** of the following is true:
  1. The user belongs to a group listed in `GROUP_NAMES` (existing behavior)
  2. The user has the `ndp_admin` role
  3. The user belongs to the group whose name matches `AFFINITIES_EP_UUID`
- When the feature is disabled the behavior is unchanged — any authenticated user is allowed
- The 403 response body now enumerates all three accepted authorization paths
- Bump version to 0.12.0

Closes #106

## Test plan
- [x] 12 new unit tests covering the admin role path and the endpoint UUID group path
- [x] Existing authorization tests still pass (28 cases)
- [x] Full test suite passes (1045 tests)
- [x] `black --check --diff .` passes
- [x] `flake8 api/ tests/ --max-line-length=88 --extend-ignore=E203,W503,E501,F401` passes