### PR TITLE
Access request workflow backend (v0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-04-23
+
+### Added
+- Access-request workflow (backend only — the UI follow-up lands in a later release)
+  - New `ENABLE_ACCESS_REQUESTS` flag (off by default) so deployments without MongoDB boot unchanged
+  - `POST /user/access-requests` lets an authenticated user submit a request with an optional justification; duplicates (existing pending request for the same user) are rejected with 409
+  - `GET /user/access-requests` lists pending requests for administrators, with `?status=pending|approved|rejected|all` filter
+  - `POST /user/access-requests/{id}/approve` performs the IDP grant using the administrator's own bearer token — either adding the requester to the endpoint group (`grant_type=member`) or also assigning the endpoint admin role (`grant_type=admin`) — and records the decision
+  - `POST /user/access-requests/{id}/reject` marks the request as rejected without touching the IDP
+  - A new `require_admin` dependency that admits users with either the `ndp_admin` role or the endpoint-specific `{AFFINITIES_EP_UUID}_admin` role
+  - A thin client for the NDP AAI API (`add_user_to_group`, `assign_role`, `list_group_members`) so the grant step reuses the administrator's session and no service account is introduced
+  - MongoDB-backed persistence in the `access_requests` collection, with the connection string and database name reused from `CatalogSettings` (no new env vars)
+
 ## [0.12.0] - 2026-04-22
 
 ### Changed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.12.0"
+    swagger_version: str = "0.13.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -26,6 +26,13 @@ class Settings(BaseSettings):
     enable_group_based_access: bool = False
     group_names: str = ""  # Comma-separated list of allowed groups
 
+    # Access-request workflow (user requests entry → admin approves/rejects).
+    # Requires a MongoDB instance reachable via MONGODB_CONNECTION_STRING
+    # (reused from CatalogSettings) when turned on. Kept off by default
+    # so existing deployments without MongoDB keep booting as before.
+    enable_access_requests: bool = False
+    access_requests_collection: str = "access_requests"
+
     model_config = {
         "env_file": ".env",
         "extra": "allow",

--- a/api/models/access_request_model.py
+++ b/api/models/access_request_model.py
@@ -1,0 +1,78 @@
+# api/models/access_request_model.py
+"""
+Models for the access-request workflow.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class AccessRequestCreate(BaseModel):
+    """Payload submitted by a user that wants Endpoint access."""
+
+    justification: Optional[str] = Field(
+        None,
+        max_length=2000,
+        description="Optional note explaining why the user needs access.",
+        json_schema_extra={"example": "I need access to work on project X."},
+    )
+
+
+class AccessRequestDecision(BaseModel):
+    """Shared bits of an approve/reject decision."""
+
+    notes: Optional[str] = Field(
+        None,
+        max_length=2000,
+        description="Optional note attached to the decision.",
+        json_schema_extra={"example": "Welcome aboard."},
+    )
+
+
+class AccessRequestApproveDecision(AccessRequestDecision):
+    """Payload sent by an admin to approve a pending request."""
+
+    grant_type: Literal["member", "admin"] = Field(
+        ...,
+        description=(
+            "What to grant the user. 'member' adds the user to the endpoint "
+            "group; 'admin' assigns the endpoint admin role in addition."
+        ),
+        json_schema_extra={"example": "member"},
+    )
+
+
+class AccessRequestRejectDecision(AccessRequestDecision):
+    """Payload sent by an admin to reject a pending request."""
+
+    pass
+
+
+class AccessRequest(BaseModel):
+    """Representation of a stored access request."""
+
+    id: str = Field(..., description="Opaque request identifier.")
+    user_sub: str = Field(..., description="Requester's IDP subject (uuid).")
+    username: str = Field(..., description="Requester's username.")
+    email: Optional[str] = Field(
+        None, description="Requester's email, if provided by the IDP."
+    )
+    status: Literal["pending", "approved", "rejected"] = Field(...)
+    justification: Optional[str] = None
+    created_at: datetime = Field(...)
+
+    # Present when status != pending
+    decided_at: Optional[datetime] = None
+    decided_by_sub: Optional[str] = None
+    decided_by_username: Optional[str] = None
+    grant_type: Optional[Literal["member", "admin"]] = None
+    decision_notes: Optional[str] = None
+
+    @classmethod
+    def from_document(cls, doc: Dict[str, Any]) -> "AccessRequest":
+        """Build an :class:`AccessRequest` from a MongoDB document."""
+        payload = {k: v for k, v in doc.items() if k != "_id"}
+        payload["id"] = str(doc.get("_id") or doc.get("id"))
+        return cls.model_validate(payload)

--- a/api/repositories/access_request_repository.py
+++ b/api/repositories/access_request_repository.py
@@ -1,0 +1,124 @@
+# api/repositories/access_request_repository.py
+"""
+MongoDB-backed repository for the access-request workflow.
+
+The repository is intentionally narrow: a handful of CRUD operations tailored
+to the request lifecycle (create pending, list, load, mark decided). It does
+not reuse :class:`MongoDBRepository` because that class implements the catalog
+contract and carries unrelated collection handling.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Literal, Optional
+
+from pymongo import DESCENDING, MongoClient, ReturnDocument
+from pymongo.collection import Collection
+
+
+def _utcnow() -> datetime:
+    """Return the current UTC timestamp."""
+    return datetime.now(timezone.utc)
+
+
+class AccessRequestRepository:
+    """CRUD helper for the ``access_requests`` collection."""
+
+    def __init__(
+        self,
+        connection_string: str,
+        database_name: str,
+        collection_name: str,
+    ):
+        self._client = MongoClient(connection_string)
+        self._collection: Collection = self._client[database_name][collection_name]
+        self._ensure_indexes()
+
+    def _ensure_indexes(self) -> None:
+        # Lookups by requester and by status dominate the list endpoint.
+        self._collection.create_index([("status", 1), ("created_at", DESCENDING)])
+        self._collection.create_index("user_sub")
+
+    def close(self) -> None:
+        self._client.close()
+
+    def create_pending(
+        self,
+        user_sub: str,
+        username: str,
+        email: Optional[str],
+        justification: Optional[str],
+    ) -> Dict[str, Any]:
+        """
+        Insert a new pending request.
+
+        Returns
+        -------
+        Dict[str, Any]
+            The inserted document (with ``_id`` set).
+        """
+        doc = {
+            "_id": str(uuid.uuid4()),
+            "user_sub": user_sub,
+            "username": username,
+            "email": email,
+            "status": "pending",
+            "justification": justification,
+            "created_at": _utcnow(),
+            "decided_at": None,
+            "decided_by_sub": None,
+            "decided_by_username": None,
+            "grant_type": None,
+            "decision_notes": None,
+        }
+        self._collection.insert_one(doc)
+        return doc
+
+    def find_pending_by_user_sub(self, user_sub: str) -> Optional[Dict[str, Any]]:
+        """Return the current pending request for a user, if any."""
+        return self._collection.find_one({"user_sub": user_sub, "status": "pending"})
+
+    def find_by_id(self, request_id: str) -> Optional[Dict[str, Any]]:
+        return self._collection.find_one({"_id": request_id})
+
+    def list(
+        self,
+        status: Optional[Literal["pending", "approved", "rejected"]] = "pending",
+    ) -> List[Dict[str, Any]]:
+        """List requests, newest first. ``None`` returns every status."""
+        query: Dict[str, Any] = {}
+        if status is not None:
+            query["status"] = status
+        cursor = self._collection.find(query).sort("created_at", DESCENDING)
+        return list(cursor)
+
+    def mark_decided(
+        self,
+        request_id: str,
+        status: Literal["approved", "rejected"],
+        decided_by_sub: str,
+        decided_by_username: str,
+        grant_type: Optional[Literal["member", "admin"]],
+        decision_notes: Optional[str],
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Record the admin's decision on a pending request.
+
+        Returns the updated document, or ``None`` if the request is not in
+        ``pending`` state (or does not exist).
+        """
+        result = self._collection.find_one_and_update(
+            {"_id": request_id, "status": "pending"},
+            {
+                "$set": {
+                    "status": status,
+                    "decided_at": _utcnow(),
+                    "decided_by_sub": decided_by_sub,
+                    "decided_by_username": decided_by_username,
+                    "grant_type": grant_type,
+                    "decision_notes": decision_notes,
+                }
+            },
+            return_document=ReturnDocument.AFTER,
+        )
+        return result

--- a/api/routes/user_routes/__init__.py
+++ b/api/routes/user_routes/__init__.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter
 
+from .access_requests import router as access_requests_router
 from .user_info import router as user_info_router
 from .user_login import router as user_login_router
 
@@ -9,3 +10,4 @@ router = APIRouter()
 
 router.include_router(user_info_router)
 router.include_router(user_login_router)
+router.include_router(access_requests_router)

--- a/api/routes/user_routes/access_requests.py
+++ b/api/routes/user_routes/access_requests.py
@@ -1,0 +1,147 @@
+# api/routes/user_routes/access_requests.py
+"""
+REST endpoints for the access-request workflow.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, Query, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from api.models.access_request_model import (
+    AccessRequest,
+    AccessRequestApproveDecision,
+    AccessRequestCreate,
+    AccessRequestRejectDecision,
+)
+from api.services.access_request_services import (
+    approve_access_request,
+    create_access_request,
+    list_access_requests,
+    reject_access_request,
+    require_feature_enabled,
+)
+from api.services.auth_services import get_current_user, require_admin
+
+router = APIRouter()
+security = HTTPBearer()
+
+
+@router.post(
+    "/user/access-requests",
+    response_model=AccessRequest,
+    status_code=status.HTTP_201_CREATED,
+    summary="Submit an access request",
+    description=(
+        "Authenticated user asks to be granted access to this Endpoint. "
+        "Only one pending request per user is allowed."
+    ),
+    responses={
+        201: {"description": "Access request created"},
+        400: {"description": "Cannot identify the user from their token"},
+        409: {"description": "The user already has a pending request"},
+        503: {"description": "Access-request workflow is disabled"},
+    },
+)
+async def create_request(
+    payload: AccessRequestCreate,
+    user_info: Dict[str, Any] = Depends(get_current_user),
+) -> AccessRequest:
+    require_feature_enabled()
+    doc = create_access_request(user_info, payload.justification)
+    return AccessRequest.from_document(doc)
+
+
+@router.get(
+    "/user/access-requests",
+    response_model=List[AccessRequest],
+    summary="List access requests (admin only)",
+    description=(
+        "Return pending access requests by default. Use `status=all` to "
+        "include approved and rejected, or pass a specific status."
+    ),
+    responses={
+        200: {"description": "Access requests returned"},
+        403: {"description": "Administrator role required"},
+        503: {"description": "Access-request workflow is disabled"},
+    },
+)
+async def list_requests(
+    status_filter: Optional[str] = Query(
+        None,
+        alias="status",
+        pattern="^(pending|approved|rejected|all)$",
+    ),
+    _admin: Dict[str, Any] = Depends(require_admin),
+) -> List[AccessRequest]:
+    require_feature_enabled()
+    docs = list_access_requests(status_filter)  # type: ignore[arg-type]
+    return [AccessRequest.from_document(doc) for doc in docs]
+
+
+@router.post(
+    "/user/access-requests/{request_id}/approve",
+    response_model=AccessRequest,
+    summary="Approve an access request (admin only)",
+    description=(
+        "Approve a pending access request. The administrator chooses what to "
+        "grant via `grant_type`: `member` adds the user to the endpoint "
+        "group, `admin` also assigns the endpoint admin role.\n\n"
+        "The IDP write is performed using the administrator's own bearer "
+        "token, so no service account is involved."
+    ),
+    responses={
+        200: {"description": "Request approved"},
+        403: {"description": "Administrator role required"},
+        404: {"description": "Request not found"},
+        409: {"description": "Request is not pending"},
+        502: {"description": "IDP rejected or could not perform the grant"},
+        503: {"description": "Access-request workflow is disabled"},
+    },
+)
+async def approve_request(
+    request_id: str,
+    decision: AccessRequestApproveDecision,
+    request: Request,
+    admin_info: Dict[str, Any] = Depends(require_admin),
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> AccessRequest:
+    require_feature_enabled()
+    # `request` kept in the signature so an Authorization-less caller would
+    # hit the HTTPBearer dependency before reaching this body.
+    _ = request
+    doc = approve_access_request(
+        request_id=request_id,
+        admin_info=admin_info,
+        admin_token=credentials.credentials,
+        grant_type=decision.grant_type,
+        notes=decision.notes,
+    )
+    return AccessRequest.from_document(doc)
+
+
+@router.post(
+    "/user/access-requests/{request_id}/reject",
+    response_model=AccessRequest,
+    summary="Reject an access request (admin only)",
+    description="Reject a pending access request. The IDP is not touched.",
+    responses={
+        200: {"description": "Request rejected"},
+        403: {"description": "Administrator role required"},
+        404: {"description": "Request not found"},
+        409: {"description": "Request is not pending"},
+        503: {"description": "Access-request workflow is disabled"},
+    },
+)
+async def reject_request(
+    request_id: str,
+    decision: AccessRequestRejectDecision,
+    admin_info: Dict[str, Any] = Depends(require_admin),
+) -> AccessRequest:
+    require_feature_enabled()
+    doc = reject_access_request(
+        request_id=request_id,
+        admin_info=admin_info,
+        notes=decision.notes,
+    )
+    return AccessRequest.from_document(doc)

--- a/api/services/access_request_services/__init__.py
+++ b/api/services/access_request_services/__init__.py
@@ -1,0 +1,10 @@
+# api/services/access_request_services/__init__.py
+
+from .access_request_service import (  # noqa: F401
+    approve_access_request,
+    create_access_request,
+    get_repository,
+    list_access_requests,
+    reject_access_request,
+    require_feature_enabled,
+)

--- a/api/services/access_request_services/access_request_service.py
+++ b/api/services/access_request_services/access_request_service.py
@@ -1,0 +1,226 @@
+# api/services/access_request_services/access_request_service.py
+"""
+Service layer for the access-request workflow.
+
+This module keeps the route handlers thin: it owns lifecycle rules (one
+pending request per user, idempotency, etc.) and drives the AAI API when
+an administrator approves a request.
+"""
+
+import logging
+from typing import Any, Dict, List, Literal, Optional
+
+from fastapi import HTTPException, status
+
+from api.config.affinities_settings import affinities_settings
+from api.config.catalog_settings import catalog_settings
+from api.config.swagger_settings import swagger_settings
+from api.repositories.access_request_repository import AccessRequestRepository
+from api.services.auth_services import aai_client
+from api.services.auth_services.authorization_service import endpoint_admin_role_name
+
+logger = logging.getLogger(__name__)
+
+# Module-level singleton so we reuse the MongoClient across requests.
+_repository: Optional[AccessRequestRepository] = None
+
+
+def require_feature_enabled() -> None:
+    """Return 503 when the feature flag is off, to keep surface area clear."""
+    if not swagger_settings.enable_access_requests:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Access-request workflow is disabled on this deployment.",
+        )
+
+
+def get_repository() -> AccessRequestRepository:
+    """
+    Return a cached :class:`AccessRequestRepository`, building it lazily.
+
+    The connection string and database name are reused from
+    :class:`CatalogSettings` so operators only configure MongoDB once.
+    """
+    global _repository
+    if _repository is None:
+        _repository = AccessRequestRepository(
+            connection_string=catalog_settings.mongodb_connection_string,
+            database_name=catalog_settings.mongodb_database,
+            collection_name=swagger_settings.access_requests_collection,
+        )
+    return _repository
+
+
+def reset_repository_for_tests() -> None:
+    """Drop the cached repository so tests can inject a fresh one."""
+    global _repository
+    if _repository is not None:
+        try:
+            _repository.close()
+        finally:
+            _repository = None
+
+
+def _require_endpoint_uuid() -> str:
+    ep_uuid = (affinities_settings.ep_uuid or "").strip()
+    if not ep_uuid:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Endpoint UUID is not configured; cannot grant access.",
+        )
+    return ep_uuid
+
+
+def create_access_request(
+    user_info: Dict[str, Any],
+    justification: Optional[str],
+) -> Dict[str, Any]:
+    """
+    Create a pending request for the given user.
+
+    Raises 409 if the user already has a pending request to prevent spam
+    and double-counting.
+    """
+    require_feature_enabled()
+
+    user_sub = user_info.get("sub")
+    username = user_info.get("username") or user_info.get("preferred_username")
+    email = user_info.get("email")
+
+    if not user_sub or not username:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot identify the requesting user from their token.",
+        )
+
+    repo = get_repository()
+    existing = repo.find_pending_by_user_sub(user_sub)
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="You already have a pending access request.",
+        )
+
+    return repo.create_pending(
+        user_sub=user_sub,
+        username=username,
+        email=email,
+        justification=justification,
+    )
+
+
+def list_access_requests(
+    status_filter: Optional[Literal["pending", "approved", "rejected", "all"]],
+) -> List[Dict[str, Any]]:
+    """Return the matching requests, newest first."""
+    require_feature_enabled()
+
+    if status_filter in (None, "pending"):
+        return get_repository().list(status="pending")
+    if status_filter == "all":
+        return get_repository().list(status=None)
+    return get_repository().list(status=status_filter)
+
+
+def _grant_via_aai(
+    admin_token: str,
+    grant_type: Literal["member", "admin"],
+    username: str,
+) -> None:
+    """Perform the actual IDP write for an approve decision."""
+    ep_uuid = _require_endpoint_uuid()
+
+    # "member" always grants group membership. "admin" grants the admin
+    # role on top — the two are complementary, not alternatives, so an
+    # admin user has both.
+    aai_client.add_user_to_group(admin_token, ep_uuid, username)
+
+    if grant_type == "admin":
+        admin_role = endpoint_admin_role_name()
+        if admin_role:
+            aai_client.assign_role(admin_token, admin_role, username)
+
+
+def approve_access_request(
+    request_id: str,
+    admin_info: Dict[str, Any],
+    admin_token: str,
+    grant_type: Literal["member", "admin"],
+    notes: Optional[str],
+) -> Dict[str, Any]:
+    """
+    Approve a pending request, perform the IDP grant, and persist the decision.
+    """
+    require_feature_enabled()
+
+    repo = get_repository()
+    doc = repo.find_by_id(request_id)
+    if not doc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Access request not found.",
+        )
+    if doc.get("status") != "pending":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Request is already {doc.get('status')}.",
+        )
+
+    # Execute the IDP side first. If the AAI rejects the write (admin does
+    # not actually have the required role, transient outage, etc.) the
+    # HTTPException propagates and the Mongo document stays pending — the
+    # admin can retry without producing a phantom "approved" record.
+    _grant_via_aai(admin_token, grant_type, doc["username"])
+
+    updated = repo.mark_decided(
+        request_id=request_id,
+        status="approved",
+        decided_by_sub=admin_info.get("sub", "unknown"),
+        decided_by_username=admin_info.get("username", "unknown"),
+        grant_type=grant_type,
+        decision_notes=notes,
+    )
+    if not updated:
+        # Someone else won the race between find_by_id and mark_decided.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Request state changed before the decision was recorded.",
+        )
+    return updated
+
+
+def reject_access_request(
+    request_id: str,
+    admin_info: Dict[str, Any],
+    notes: Optional[str],
+) -> Dict[str, Any]:
+    """Mark a pending request as rejected. Does not touch the IDP."""
+    require_feature_enabled()
+
+    repo = get_repository()
+    doc = repo.find_by_id(request_id)
+    if not doc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Access request not found.",
+        )
+    if doc.get("status") != "pending":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Request is already {doc.get('status')}.",
+        )
+
+    updated = repo.mark_decided(
+        request_id=request_id,
+        status="rejected",
+        decided_by_sub=admin_info.get("sub", "unknown"),
+        decided_by_username=admin_info.get("username", "unknown"),
+        grant_type=None,
+        decision_notes=notes,
+    )
+    if not updated:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Request state changed before the decision was recorded.",
+        )
+    return updated

--- a/api/services/auth_services/__init__.py
+++ b/api/services/auth_services/__init__.py
@@ -2,11 +2,19 @@
 from .authorization_service import (  # noqa: F401
     check_group_membership,
     check_organization_membership,  # backward compatibility
+    endpoint_admin_role_name,
     get_allowed_groups,
     get_user_for_endpoint_access,
     get_user_for_write_operation,
+    is_admin,
+    require_admin,
     require_group_member,
     require_organization_member,  # backward compatibility
+)
+from .aai_client import (  # noqa: F401
+    add_user_to_group,
+    assign_role,
+    list_group_members,
 )
 from .get_current_user import get_current_user  # noqa: F401
 from .user_login import authenticate_with_credentials  # noqa: F401

--- a/api/services/auth_services/aai_client.py
+++ b/api/services/auth_services/aai_client.py
@@ -1,0 +1,154 @@
+# api/services/auth_services/aai_client.py
+"""
+Thin client for the NDP AAI API (``auth_api_url`` base).
+
+The AAI API is authoritative for group and role writes in Keycloak. This
+module only exposes the few operations the access-request workflow needs:
+adding a user to a group, assigning a role and listing group members.
+
+Every call is made on behalf of an already-authenticated ep-api user — the
+caller provides the user's bearer token. The AAI API validates the token and
+checks the caller's roles (``ndp_admin`` or scoped ``group:<path>:admin``),
+so no service account lives on the ep-api side.
+"""
+
+import logging
+from typing import Any, Dict, List
+from urllib.parse import urlparse
+
+import requests
+from fastapi import HTTPException, status
+
+from api.config.swagger_settings import swagger_settings
+
+logger = logging.getLogger(__name__)
+
+
+def _aai_base_url() -> str:
+    """Return the base URL of the AAI API (scheme + host + optional port)."""
+    parsed = urlparse(swagger_settings.auth_api_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authentication service URL is not configured correctly.",
+        )
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def _forward_aai_error(response: requests.Response, fallback: str) -> None:
+    """Translate an AAI error response into an HTTPException for the caller."""
+    detail = fallback
+    try:
+        payload = response.json()
+        if isinstance(payload, dict):
+            detail = payload.get("detail") or payload.get("error") or fallback
+    except ValueError:
+        pass
+
+    if response.status_code in (400, 401):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=detail,
+        )
+    if response.status_code == 403:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=detail,
+        )
+    if response.status_code == 404:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=detail,
+        )
+    raise HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail=f"Authentication service returned HTTP {response.status_code}.",
+    )
+
+
+def _post(path: str, admin_token: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    url = f"{_aai_base_url()}{path}"
+    try:
+        response = requests.post(
+            url,
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json=payload,
+            timeout=15,
+        )
+    except requests.exceptions.RequestException as exc:
+        logger.error(f"AAI POST {url} failed: {exc}")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authentication service is unavailable.",
+        )
+
+    if 200 <= response.status_code < 300:
+        try:
+            return response.json() if response.content else {}
+        except ValueError:
+            return {}
+
+    _forward_aai_error(response, "Authentication service rejected the request.")
+    return {}  # unreachable — _forward_aai_error always raises
+
+
+def _get(path: str, admin_token: str, params: Dict[str, Any]) -> Any:
+    url = f"{_aai_base_url()}{path}"
+    try:
+        response = requests.get(
+            url,
+            headers={"Authorization": f"Bearer {admin_token}"},
+            params=params,
+            timeout=15,
+        )
+    except requests.exceptions.RequestException as exc:
+        logger.error(f"AAI GET {url} failed: {exc}")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authentication service is unavailable.",
+        )
+
+    if 200 <= response.status_code < 300:
+        try:
+            return response.json()
+        except ValueError:
+            return None
+
+    _forward_aai_error(response, "Authentication service rejected the request.")
+    return None  # unreachable
+
+
+def add_user_to_group(
+    admin_token: str, group_name: str, username: str
+) -> Dict[str, Any]:
+    """
+    Add ``username`` to the group identified by ``group_name``.
+
+    Uses the admin's own bearer token; the AAI API enforces that the caller
+    has ``ndp_admin`` or at least ``editor`` on the target group.
+    """
+    return _post(
+        "/group/add-user",
+        admin_token,
+        {"group_name": group_name, "username": username},
+    )
+
+
+def assign_role(admin_token: str, role_name: str, username: str) -> Dict[str, Any]:
+    """Assign the realm role ``role_name`` to ``username``."""
+    return _post(
+        "/role/assign",
+        admin_token,
+        {"role_name": role_name, "username": username},
+    )
+
+
+def list_group_members(admin_token: str, group_name: str) -> Dict[str, Any]:
+    """Return the members of ``group_name`` as reported by the AAI API."""
+    payload = _get(
+        "/group/members",
+        admin_token,
+        {"group_name": group_name},
+    )
+    # The AAI returns {} when the group is empty, and a mapping otherwise.
+    return payload or {}

--- a/api/services/auth_services/authorization_service.py
+++ b/api/services/auth_services/authorization_service.py
@@ -15,6 +15,18 @@ logger = logging.getLogger(__name__)
 ADMIN_ROLE_NAME = "ndp_admin"
 
 
+def endpoint_admin_role_name() -> str:
+    """
+    Return the endpoint-specific admin role name derived from the configured
+    ``AFFINITIES_EP_UUID``, e.g. ``96207a63-...-002330_admin``. Returns an
+    empty string when the UUID is not configured.
+    """
+    ep_uuid = (affinities_settings.ep_uuid or "").strip()
+    if not ep_uuid:
+        return ""
+    return f"{ep_uuid}_admin"
+
+
 def normalize_group_path(path: str) -> str:
     """
     Normalize a group path for comparison.
@@ -296,6 +308,55 @@ def get_user_for_endpoint_access(
         )
 
     return user_info
+
+
+def is_admin(user_info: Dict[str, Any]) -> bool:
+    """
+    Return True if the user has either the ``ndp_admin`` role or the
+    endpoint-specific admin role (``{AFFINITIES_EP_UUID}_admin``).
+    """
+    if _has_admin_role(user_info):
+        return True
+
+    ep_admin_role = endpoint_admin_role_name()
+    if not ep_admin_role:
+        return False
+
+    roles = user_info.get("roles", [])
+    if not isinstance(roles, list):
+        return False
+
+    target = ep_admin_role.strip().lower()
+    return any(
+        isinstance(role, str) and role.strip().lower() == target for role in roles
+    )
+
+
+def require_admin(
+    user_info: Dict[str, Any] = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """
+    Dependency that enforces an administrator role on the caller.
+
+    Grants access to users with the realm role ``ndp_admin`` or the
+    endpoint-specific admin role ``{AFFINITIES_EP_UUID}_admin``. Any
+    other authenticated user is rejected with 403.
+    """
+    if is_admin(user_info):
+        return user_info
+
+    logger.warning(
+        "Admin-only action denied for user '%s' (sub=%s). Required roles: "
+        "'%s' or '%s'.",
+        user_info.get("username"),
+        user_info.get("sub"),
+        ADMIN_ROLE_NAME,
+        endpoint_admin_role_name() or "<unset>",
+    )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Administrator role required.",
+    )
 
 
 # Backward compatibility aliases

--- a/tests/test_aai_client.py
+++ b/tests/test_aai_client.py
@@ -1,0 +1,176 @@
+# tests/test_aai_client.py
+"""
+Tests for the NDP AAI API client wrapper.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from fastapi import HTTPException
+
+from api.services.auth_services import aai_client
+
+
+class TestAaiBaseUrl:
+    @patch("api.services.auth_services.aai_client.swagger_settings")
+    def test_strips_path_and_keeps_port(self, mock_settings):
+        mock_settings.auth_api_url = "http://idp.example.com:5055/information"
+        assert aai_client._aai_base_url() == "http://idp.example.com:5055"
+
+    @patch("api.services.auth_services.aai_client.swagger_settings")
+    def test_raises_when_url_is_empty(self, mock_settings):
+        mock_settings.auth_api_url = ""
+        with pytest.raises(HTTPException) as exc:
+            aai_client._aai_base_url()
+        assert exc.value.status_code == 502
+
+
+class TestAddUserToGroup:
+    @patch("api.services.auth_services.aai_client.requests.post")
+    @patch("api.services.auth_services.aai_client.swagger_settings")
+    def test_happy_path_forwards_token(self, mock_settings, mock_post):
+        mock_settings.auth_api_url = "http://idp.example.com:5055/information"
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.content = b'{"message":"ok"}'
+        resp.json.return_value = {"message": "ok"}
+        mock_post.return_value = resp
+
+        result = aai_client.add_user_to_group("tok", "some-group", "yutian")
+
+        assert result == {"message": "ok"}
+        mock_post.assert_called_once_with(
+            "http://idp.example.com:5055/group/add-user",
+            headers={"Authorization": "Bearer tok"},
+            json={"group_name": "some-group", "username": "yutian"},
+            timeout=15,
+        )
+
+    @patch("api.services.auth_services.aai_client.requests.post")
+    @patch("api.services.auth_services.aai_client.swagger_settings")
+    def test_forbidden_response_surfaces_as_403(self, mock_settings, mock_post):
+        mock_settings.auth_api_url = "http://idp.example.com:5055/information"
+
+        resp = MagicMock()
+        resp.status_code = 403
+        resp.content = b'{"detail":"insufficient group privileges"}'
+        resp.json.return_value = {"detail": "insufficient group privileges"}
+        mock_post.return_value = resp
+
+        with pytest.raises(HTTPException) as exc:
+            aai_client.add_user_to_group("tok", "some-group", "yutian")
+        assert exc.value.status_code == 403
+        assert "insufficient" in exc.value.detail
+
+    @patch("api.services.auth_services.aai_client.requests.post")
+    @patch("api.services.auth_services.aai_client.swagger_settings")
+    def test_unauthorized_response_surfaces_as_401(self, mock_settings, mock_post):
+        mock_settings.auth_api_url = "http://idp.example.com:5055/information"
+
+        resp = MagicMock()
+        resp.status_code = 401
+        resp.content = b'{"detail":"Missing token"}'
+        resp.json.return_value = {"detail": "Missing token"}
+        mock_post.return_value = resp
+
+        with pytest.raises(HTTPException) as exc:
+            aai_client.add_user_to_group("tok", "some-group", "yutian")
+        assert exc.value.status_code == 401
+
+    @patch("api.services.auth_services.aai_client.requests.post")
+    @patch("api.services.auth_services.aai_client.swagger_settings")
+    def test_not_found_surfaces_as_404(self, mock_settings, mock_post):
+        mock_settings.auth_api_url = "http://idp.example.com:5055/information"
+
+        resp = MagicMock()
+        resp.status_code = 404
+        resp.content = b'{"detail":"user not found"}'
+        resp.json.return_value = {"detail": "user not found"}
+        mock_post.return_value = resp
+
+        with pytest.raises(HTTPException) as exc:
+            aai_client.add_user_to_group("tok", "g", "ghost")
+        assert exc.value.status_code == 404
+
+    @patch("api.services.auth_services.aai_client.requests.post")
+    @patch("api.services.auth_services.aai_client.swagger_settings")
+    def test_unexpected_status_surfaces_as_502(self, mock_settings, mock_post):
+        mock_settings.auth_api_url = "http://idp.example.com:5055/information"
+
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.content = b'{"detail":"boom"}'
+        resp.json.return_value = {"detail": "boom"}
+        mock_post.return_value = resp
+
+        with pytest.raises(HTTPException) as exc:
+            aai_client.add_user_to_group("tok", "g", "u")
+        assert exc.value.status_code == 502
+
+    @patch("api.services.auth_services.aai_client.requests.post")
+    @patch("api.services.auth_services.aai_client.swagger_settings")
+    def test_transport_error_becomes_502(self, mock_settings, mock_post):
+        mock_settings.auth_api_url = "http://idp.example.com:5055/information"
+        mock_post.side_effect = requests.exceptions.ConnectionError("boom")
+
+        with pytest.raises(HTTPException) as exc:
+            aai_client.add_user_to_group("tok", "g", "u")
+        assert exc.value.status_code == 502
+
+
+class TestAssignRole:
+    @patch("api.services.auth_services.aai_client.requests.post")
+    @patch("api.services.auth_services.aai_client.swagger_settings")
+    def test_happy_path(self, mock_settings, mock_post):
+        mock_settings.auth_api_url = "http://idp.example.com:5055/information"
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.content = b"{}"
+        resp.json.return_value = {}
+        mock_post.return_value = resp
+
+        aai_client.assign_role("tok", "my-role", "yutian")
+
+        mock_post.assert_called_once_with(
+            "http://idp.example.com:5055/role/assign",
+            headers={"Authorization": "Bearer tok"},
+            json={"role_name": "my-role", "username": "yutian"},
+            timeout=15,
+        )
+
+
+class TestListGroupMembers:
+    @patch("api.services.auth_services.aai_client.requests.get")
+    @patch("api.services.auth_services.aai_client.swagger_settings")
+    def test_happy_path(self, mock_settings, mock_get):
+        mock_settings.auth_api_url = "http://idp.example.com:5055/information"
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"yutian": ["viewer"]}
+        mock_get.return_value = resp
+
+        result = aai_client.list_group_members("tok", "g")
+
+        assert result == {"yutian": ["viewer"]}
+        mock_get.assert_called_once_with(
+            "http://idp.example.com:5055/group/members",
+            headers={"Authorization": "Bearer tok"},
+            params={"group_name": "g"},
+            timeout=15,
+        )
+
+    @patch("api.services.auth_services.aai_client.requests.get")
+    @patch("api.services.auth_services.aai_client.swagger_settings")
+    def test_empty_group_returns_empty_dict(self, mock_settings, mock_get):
+        mock_settings.auth_api_url = "http://idp.example.com:5055/information"
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {}
+        mock_get.return_value = resp
+
+        assert aai_client.list_group_members("tok", "g") == {}

--- a/tests/test_access_request_routes.py
+++ b/tests/test_access_request_routes.py
@@ -1,0 +1,206 @@
+# tests/test_access_request_routes.py
+"""
+Tests for the /user/access-requests REST endpoints.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.services.auth_services import get_current_user, require_admin
+
+client = TestClient(app)
+
+
+def _sample_doc(status_="pending", request_id="r1"):
+    return {
+        "_id": request_id,
+        "user_sub": "sub-yutian",
+        "username": "yutian",
+        "email": "y@example.com",
+        "status": status_,
+        "justification": "please",
+        "created_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "decided_at": None,
+        "decided_by_sub": None,
+        "decided_by_username": None,
+        "grant_type": None,
+        "decision_notes": None,
+    }
+
+
+class TestCreateAccessRequest:
+    def setup_method(self):
+        app.dependency_overrides[get_current_user] = lambda: {
+            "sub": "sub-yutian",
+            "username": "yutian",
+            "email": "y@example.com",
+            "roles": ["default-roles-ndp"],
+        }
+
+    def teardown_method(self):
+        app.dependency_overrides.clear()
+
+    @patch("api.routes.user_routes.access_requests.require_feature_enabled")
+    @patch("api.routes.user_routes.access_requests.create_access_request")
+    def test_201_returns_request(self, mock_create, mock_flag):
+        mock_create.return_value = _sample_doc()
+
+        response = client.post(
+            "/user/access-requests",
+            json={"justification": "please"},
+            headers={"Authorization": "Bearer tok"},
+        )
+        assert response.status_code == 201
+        assert response.json()["id"] == "r1"
+        assert response.json()["username"] == "yutian"
+
+    @patch("api.routes.user_routes.access_requests.require_feature_enabled")
+    @patch("api.routes.user_routes.access_requests.create_access_request")
+    def test_duplicate_surfaces_409(self, mock_create, mock_flag):
+        mock_create.side_effect = HTTPException(
+            status_code=409, detail="already pending"
+        )
+
+        response = client.post(
+            "/user/access-requests",
+            json={},
+            headers={"Authorization": "Bearer tok"},
+        )
+        assert response.status_code == 409
+
+    def test_rejects_oversized_justification(self):
+        response = client.post(
+            "/user/access-requests",
+            json={"justification": "x" * 2001},
+            headers={"Authorization": "Bearer tok"},
+        )
+        assert response.status_code == 422
+
+
+class TestListAccessRequests:
+    def setup_method(self):
+        app.dependency_overrides[require_admin] = lambda: {
+            "sub": "admin-sub",
+            "username": "raul",
+            "roles": ["ndp_admin"],
+        }
+
+    def teardown_method(self):
+        app.dependency_overrides.clear()
+
+    @patch("api.routes.user_routes.access_requests.require_feature_enabled")
+    @patch("api.routes.user_routes.access_requests.list_access_requests")
+    def test_list_happy_path(self, mock_list, mock_flag):
+        mock_list.return_value = [_sample_doc()]
+
+        response = client.get(
+            "/user/access-requests",
+            headers={"Authorization": "Bearer tok"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["username"] == "yutian"
+
+    def test_invalid_status_returns_422(self):
+        response = client.get(
+            "/user/access-requests?status=weird",
+            headers={"Authorization": "Bearer tok"},
+        )
+        assert response.status_code == 422
+
+    def test_non_admin_gets_403(self):
+        # Simulate require_admin raising a 403 like real life
+        def deny():
+            raise HTTPException(status_code=403, detail="Administrator role required.")
+
+        app.dependency_overrides[require_admin] = deny
+
+        response = client.get(
+            "/user/access-requests",
+            headers={"Authorization": "Bearer tok"},
+        )
+        assert response.status_code == 403
+
+
+class TestApproveAccessRequest:
+    def setup_method(self):
+        app.dependency_overrides[require_admin] = lambda: {
+            "sub": "admin-sub",
+            "username": "raul",
+            "roles": ["ndp_admin"],
+        }
+
+    def teardown_method(self):
+        app.dependency_overrides.clear()
+
+    @patch("api.routes.user_routes.access_requests.require_feature_enabled")
+    @patch("api.routes.user_routes.access_requests.approve_access_request")
+    def test_approve_member(self, mock_approve, mock_flag):
+        approved = _sample_doc(status_="approved")
+        approved["grant_type"] = "member"
+        approved["decided_by_username"] = "raul"
+        mock_approve.return_value = approved
+
+        response = client.post(
+            "/user/access-requests/r1/approve",
+            json={"grant_type": "member", "notes": "welcome"},
+            headers={"Authorization": "Bearer tok"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "approved"
+        assert body["grant_type"] == "member"
+
+        # Verify admin token forwarded to service
+        call_kwargs = mock_approve.call_args.kwargs
+        assert call_kwargs["admin_token"] == "tok"
+        assert call_kwargs["grant_type"] == "member"
+        assert call_kwargs["notes"] == "welcome"
+
+    def test_invalid_grant_type_returns_422(self):
+        response = client.post(
+            "/user/access-requests/r1/approve",
+            json={"grant_type": "root"},
+            headers={"Authorization": "Bearer tok"},
+        )
+        assert response.status_code == 422
+
+    def test_missing_authorization_returns_401(self):
+        # The project's exception handler translates missing bearer to 401
+        response = client.post(
+            "/user/access-requests/r1/approve",
+            json={"grant_type": "member"},
+        )
+        assert response.status_code == 401
+
+
+class TestRejectAccessRequest:
+    def setup_method(self):
+        app.dependency_overrides[require_admin] = lambda: {
+            "sub": "admin-sub",
+            "username": "raul",
+            "roles": ["ndp_admin"],
+        }
+
+    def teardown_method(self):
+        app.dependency_overrides.clear()
+
+    @patch("api.routes.user_routes.access_requests.require_feature_enabled")
+    @patch("api.routes.user_routes.access_requests.reject_access_request")
+    def test_reject(self, mock_reject, mock_flag):
+        rejected = _sample_doc(status_="rejected")
+        rejected["decision_notes"] = "no thanks"
+        mock_reject.return_value = rejected
+
+        response = client.post(
+            "/user/access-requests/r1/reject",
+            json={"notes": "no thanks"},
+            headers={"Authorization": "Bearer tok"},
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "rejected"

--- a/tests/test_access_request_service.py
+++ b/tests/test_access_request_service.py
@@ -1,0 +1,411 @@
+# tests/test_access_request_service.py
+"""
+Tests for the access-request service layer.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.services.access_request_services import access_request_service
+
+
+@pytest.fixture
+def mock_repo():
+    return MagicMock()
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    """Ensure each test starts with a fresh repository."""
+    access_request_service.reset_repository_for_tests()
+    yield
+    access_request_service.reset_repository_for_tests()
+
+
+class TestRequireFeatureEnabled:
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    def test_raises_503_when_disabled(self, mock_settings):
+        mock_settings.enable_access_requests = False
+        with pytest.raises(HTTPException) as exc:
+            access_request_service.require_feature_enabled()
+        assert exc.value.status_code == 503
+
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    def test_noop_when_enabled(self, mock_settings):
+        mock_settings.enable_access_requests = True
+        access_request_service.require_feature_enabled()
+
+
+class TestCreateAccessRequest:
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    @patch(
+        "api.services.access_request_services" ".access_request_service.get_repository"
+    )
+    def test_happy_path(self, mock_get_repo, mock_settings, mock_repo):
+        mock_settings.enable_access_requests = True
+        mock_repo.find_pending_by_user_sub.return_value = None
+        mock_repo.create_pending.return_value = {"_id": "req1", "status": "pending"}
+        mock_get_repo.return_value = mock_repo
+
+        user_info = {"sub": "s1", "username": "yutian", "email": "y@x"}
+        result = access_request_service.create_access_request(
+            user_info, "please let me in"
+        )
+
+        assert result["_id"] == "req1"
+        mock_repo.create_pending.assert_called_once_with(
+            user_sub="s1",
+            username="yutian",
+            email="y@x",
+            justification="please let me in",
+        )
+
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    @patch(
+        "api.services.access_request_services" ".access_request_service.get_repository"
+    )
+    def test_duplicate_pending_raises_409(
+        self, mock_get_repo, mock_settings, mock_repo
+    ):
+        mock_settings.enable_access_requests = True
+        mock_repo.find_pending_by_user_sub.return_value = {"_id": "old"}
+        mock_get_repo.return_value = mock_repo
+
+        with pytest.raises(HTTPException) as exc:
+            access_request_service.create_access_request(
+                {"sub": "s1", "username": "yutian"}, None
+            )
+        assert exc.value.status_code == 409
+
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    def test_missing_sub_raises_400(self, mock_settings):
+        mock_settings.enable_access_requests = True
+
+        with pytest.raises(HTTPException) as exc:
+            access_request_service.create_access_request({"username": "yutian"}, None)
+        assert exc.value.status_code == 400
+
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    def test_disabled_raises_503(self, mock_settings):
+        mock_settings.enable_access_requests = False
+
+        with pytest.raises(HTTPException) as exc:
+            access_request_service.create_access_request(
+                {"sub": "s", "username": "u"}, None
+            )
+        assert exc.value.status_code == 503
+
+
+class TestListAccessRequests:
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    @patch(
+        "api.services.access_request_services" ".access_request_service.get_repository"
+    )
+    def test_default_returns_pending_only(
+        self, mock_get_repo, mock_settings, mock_repo
+    ):
+        mock_settings.enable_access_requests = True
+        mock_repo.list.return_value = [{"_id": "r1"}]
+        mock_get_repo.return_value = mock_repo
+
+        access_request_service.list_access_requests(None)
+        mock_repo.list.assert_called_once_with(status="pending")
+
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    @patch(
+        "api.services.access_request_services" ".access_request_service.get_repository"
+    )
+    def test_all_passes_none_to_repo(self, mock_get_repo, mock_settings, mock_repo):
+        mock_settings.enable_access_requests = True
+        mock_repo.list.return_value = []
+        mock_get_repo.return_value = mock_repo
+
+        access_request_service.list_access_requests("all")
+        mock_repo.list.assert_called_once_with(status=None)
+
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    @patch(
+        "api.services.access_request_services" ".access_request_service.get_repository"
+    )
+    def test_specific_status_forwarded(self, mock_get_repo, mock_settings, mock_repo):
+        mock_settings.enable_access_requests = True
+        mock_repo.list.return_value = []
+        mock_get_repo.return_value = mock_repo
+
+        access_request_service.list_access_requests("approved")
+        mock_repo.list.assert_called_once_with(status="approved")
+
+
+class TestApproveAccessRequest:
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.affinities_settings"
+    )
+    @patch("api.services.access_request_services.access_request_service.aai_client")
+    @patch(
+        "api.services.access_request_services" ".access_request_service.get_repository"
+    )
+    def test_member_grant_calls_aai_and_marks_approved(
+        self,
+        mock_get_repo,
+        mock_aai,
+        mock_affinities,
+        mock_settings,
+        mock_repo,
+    ):
+        mock_settings.enable_access_requests = True
+        mock_affinities.ep_uuid = "ep-uuid"
+        mock_repo.find_by_id.return_value = {
+            "_id": "req1",
+            "status": "pending",
+            "username": "yutian",
+        }
+        mock_repo.mark_decided.return_value = {"_id": "req1", "status": "approved"}
+        mock_get_repo.return_value = mock_repo
+
+        result = access_request_service.approve_access_request(
+            request_id="req1",
+            admin_info={"sub": "admin-sub", "username": "raul"},
+            admin_token="tok",
+            grant_type="member",
+            notes="welcome",
+        )
+
+        mock_aai.add_user_to_group.assert_called_once_with("tok", "ep-uuid", "yutian")
+        mock_aai.assign_role.assert_not_called()
+        assert result == {"_id": "req1", "status": "approved"}
+
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.affinities_settings"
+    )
+    @patch("api.services.access_request_services.access_request_service.aai_client")
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.endpoint_admin_role_name"
+    )
+    @patch(
+        "api.services.access_request_services" ".access_request_service.get_repository"
+    )
+    def test_admin_grant_calls_add_user_and_assign_role(
+        self,
+        mock_get_repo,
+        mock_admin_role,
+        mock_aai,
+        mock_affinities,
+        mock_settings,
+        mock_repo,
+    ):
+        mock_settings.enable_access_requests = True
+        mock_affinities.ep_uuid = "ep-uuid"
+        mock_admin_role.return_value = "ep-uuid_admin"
+        mock_repo.find_by_id.return_value = {
+            "_id": "req1",
+            "status": "pending",
+            "username": "yutian",
+        }
+        mock_repo.mark_decided.return_value = {"_id": "req1"}
+        mock_get_repo.return_value = mock_repo
+
+        access_request_service.approve_access_request(
+            request_id="req1",
+            admin_info={"sub": "as", "username": "raul"},
+            admin_token="tok",
+            grant_type="admin",
+            notes=None,
+        )
+
+        mock_aai.add_user_to_group.assert_called_once_with("tok", "ep-uuid", "yutian")
+        mock_aai.assign_role.assert_called_once_with("tok", "ep-uuid_admin", "yutian")
+
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    @patch(
+        "api.services.access_request_services" ".access_request_service.get_repository"
+    )
+    def test_unknown_request_raises_404(self, mock_get_repo, mock_settings, mock_repo):
+        mock_settings.enable_access_requests = True
+        mock_repo.find_by_id.return_value = None
+        mock_get_repo.return_value = mock_repo
+
+        with pytest.raises(HTTPException) as exc:
+            access_request_service.approve_access_request(
+                "req1", {"sub": "as", "username": "r"}, "tok", "member", None
+            )
+        assert exc.value.status_code == 404
+
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    @patch(
+        "api.services.access_request_services" ".access_request_service.get_repository"
+    )
+    def test_already_decided_raises_409(self, mock_get_repo, mock_settings, mock_repo):
+        mock_settings.enable_access_requests = True
+        mock_repo.find_by_id.return_value = {"_id": "r1", "status": "approved"}
+        mock_get_repo.return_value = mock_repo
+
+        with pytest.raises(HTTPException) as exc:
+            access_request_service.approve_access_request(
+                "r1", {"sub": "as", "username": "r"}, "tok", "member", None
+            )
+        assert exc.value.status_code == 409
+
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.affinities_settings"
+    )
+    @patch("api.services.access_request_services.access_request_service.aai_client")
+    @patch(
+        "api.services.access_request_services" ".access_request_service.get_repository"
+    )
+    def test_aai_failure_does_not_mark_approved(
+        self,
+        mock_get_repo,
+        mock_aai,
+        mock_affinities,
+        mock_settings,
+        mock_repo,
+    ):
+        mock_settings.enable_access_requests = True
+        mock_affinities.ep_uuid = "ep-uuid"
+        mock_repo.find_by_id.return_value = {
+            "_id": "r1",
+            "status": "pending",
+            "username": "u",
+        }
+        mock_aai.add_user_to_group.side_effect = HTTPException(
+            status_code=403, detail="nope"
+        )
+        mock_get_repo.return_value = mock_repo
+
+        with pytest.raises(HTTPException) as exc:
+            access_request_service.approve_access_request(
+                "r1", {"sub": "as", "username": "r"}, "tok", "member", None
+            )
+        assert exc.value.status_code == 403
+        mock_repo.mark_decided.assert_not_called()
+
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.affinities_settings"
+    )
+    def test_missing_ep_uuid_raises_503(self, mock_affinities, mock_settings):
+        mock_settings.enable_access_requests = True
+        mock_affinities.ep_uuid = ""
+
+        with patch(
+            "api.services.access_request_services"
+            ".access_request_service.get_repository"
+        ) as mock_get_repo:
+            mock_repo = MagicMock()
+            mock_repo.find_by_id.return_value = {
+                "_id": "r1",
+                "status": "pending",
+                "username": "u",
+            }
+            mock_get_repo.return_value = mock_repo
+
+            with pytest.raises(HTTPException) as exc:
+                access_request_service.approve_access_request(
+                    "r1", {"sub": "as", "username": "r"}, "tok", "member", None
+                )
+            assert exc.value.status_code == 503
+
+
+class TestRejectAccessRequest:
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    @patch(
+        "api.services.access_request_services" ".access_request_service.get_repository"
+    )
+    def test_happy_path(self, mock_get_repo, mock_settings, mock_repo):
+        mock_settings.enable_access_requests = True
+        mock_repo.find_by_id.return_value = {
+            "_id": "r1",
+            "status": "pending",
+            "username": "u",
+        }
+        mock_repo.mark_decided.return_value = {"_id": "r1", "status": "rejected"}
+        mock_get_repo.return_value = mock_repo
+
+        result = access_request_service.reject_access_request(
+            "r1", {"sub": "as", "username": "r"}, "no thanks"
+        )
+        assert result["status"] == "rejected"
+        mock_repo.mark_decided.assert_called_once_with(
+            request_id="r1",
+            status="rejected",
+            decided_by_sub="as",
+            decided_by_username="r",
+            grant_type=None,
+            decision_notes="no thanks",
+        )
+
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    @patch(
+        "api.services.access_request_services" ".access_request_service.get_repository"
+    )
+    def test_unknown_request_raises_404(self, mock_get_repo, mock_settings, mock_repo):
+        mock_settings.enable_access_requests = True
+        mock_repo.find_by_id.return_value = None
+        mock_get_repo.return_value = mock_repo
+
+        with pytest.raises(HTTPException) as exc:
+            access_request_service.reject_access_request(
+                "r1", {"sub": "as", "username": "r"}, None
+            )
+        assert exc.value.status_code == 404

--- a/tests/test_require_admin.py
+++ b/tests/test_require_admin.py
@@ -1,0 +1,109 @@
+# tests/test_require_admin.py
+"""
+Tests for require_admin and is_admin authorization helpers.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.services.auth_services.authorization_service import (
+    ADMIN_ROLE_NAME,
+    endpoint_admin_role_name,
+    is_admin,
+    require_admin,
+)
+
+
+class TestEndpointAdminRoleName:
+    """Test cases for endpoint_admin_role_name helper."""
+
+    @patch("api.services.auth_services.authorization_service.affinities_settings")
+    def test_returns_suffixed_role_when_uuid_configured(self, mock_affinities):
+        mock_affinities.ep_uuid = "abc-123"
+        assert endpoint_admin_role_name() == "abc-123_admin"
+
+    @patch("api.services.auth_services.authorization_service.affinities_settings")
+    def test_returns_empty_when_uuid_missing(self, mock_affinities):
+        mock_affinities.ep_uuid = ""
+        assert endpoint_admin_role_name() == ""
+
+    @patch("api.services.auth_services.authorization_service.affinities_settings")
+    def test_strips_whitespace_in_uuid(self, mock_affinities):
+        mock_affinities.ep_uuid = "   abc-123  "
+        assert endpoint_admin_role_name() == "abc-123_admin"
+
+
+class TestIsAdmin:
+    """Test cases for is_admin helper."""
+
+    @patch("api.services.auth_services.authorization_service.affinities_settings")
+    def test_ndp_admin_role_is_admin(self, mock_affinities):
+        mock_affinities.ep_uuid = "some-uuid"
+        assert is_admin({"roles": [ADMIN_ROLE_NAME]}) is True
+
+    @patch("api.services.auth_services.authorization_service.affinities_settings")
+    def test_endpoint_admin_role_is_admin(self, mock_affinities):
+        mock_affinities.ep_uuid = "some-uuid"
+        assert is_admin({"roles": ["some-uuid_admin"]}) is True
+
+    @patch("api.services.auth_services.authorization_service.affinities_settings")
+    def test_case_insensitive_match(self, mock_affinities):
+        mock_affinities.ep_uuid = "Some-UUID"
+        assert is_admin({"roles": ["some-uuid_ADMIN"]}) is True
+
+    @patch("api.services.auth_services.authorization_service.affinities_settings")
+    def test_regular_role_is_not_admin(self, mock_affinities):
+        mock_affinities.ep_uuid = "some-uuid"
+        assert is_admin({"roles": ["default-roles-ndp"]}) is False
+
+    @patch("api.services.auth_services.authorization_service.affinities_settings")
+    def test_missing_roles_is_not_admin(self, mock_affinities):
+        mock_affinities.ep_uuid = "some-uuid"
+        assert is_admin({}) is False
+
+    @patch("api.services.auth_services.authorization_service.affinities_settings")
+    def test_non_list_roles_is_not_admin(self, mock_affinities):
+        mock_affinities.ep_uuid = "some-uuid"
+        assert is_admin({"roles": "ndp_admin"}) is False
+
+    @patch("api.services.auth_services.authorization_service.affinities_settings")
+    def test_empty_uuid_still_accepts_ndp_admin(self, mock_affinities):
+        mock_affinities.ep_uuid = ""
+        assert is_admin({"roles": [ADMIN_ROLE_NAME]}) is True
+
+    @patch("api.services.auth_services.authorization_service.affinities_settings")
+    def test_empty_uuid_rejects_endpoint_admin_pretender(self, mock_affinities):
+        # Without a UUID there is no "{uuid}_admin" role to validate against
+        mock_affinities.ep_uuid = ""
+        assert is_admin({"roles": ["_admin"]}) is False
+
+
+class TestRequireAdmin:
+    """Test cases for the require_admin FastAPI dependency."""
+
+    @patch("api.services.auth_services.authorization_service.affinities_settings")
+    def test_admin_user_returns_user_info(self, mock_affinities):
+        mock_affinities.ep_uuid = "some-uuid"
+        user_info = {"sub": "s", "username": "raul", "roles": [ADMIN_ROLE_NAME]}
+        assert require_admin(user_info) is user_info
+
+    @patch("api.services.auth_services.authorization_service.affinities_settings")
+    def test_endpoint_admin_user_returns_user_info(self, mock_affinities):
+        mock_affinities.ep_uuid = "some-uuid"
+        user_info = {
+            "sub": "s",
+            "username": "u",
+            "roles": ["some-uuid_admin"],
+        }
+        assert require_admin(user_info) is user_info
+
+    @patch("api.services.auth_services.authorization_service.affinities_settings")
+    def test_non_admin_user_raises_403(self, mock_affinities):
+        mock_affinities.ep_uuid = "some-uuid"
+        user_info = {"sub": "s", "username": "yutian", "roles": ["user"]}
+        with pytest.raises(HTTPException) as exc_info:
+            require_admin(user_info)
+        assert exc_info.value.status_code == 403
+        assert "Administrator role required" in exc_info.value.detail


### PR DESCRIPTION
## Summary
- Add a MongoDB-backed access-request workflow so denied users can ask for entry and administrators can approve or reject from ep-api.
- Four new REST endpoints under `/user/access-requests` for create / list / approve / reject.
- New `require_admin` dependency that admits users with either the global `ndp_admin` role or the endpoint-specific `{AFFINITIES_EP_UUID}_admin` role.
- New small client for the NDP AAI API (`add_user_to_group`, `assign_role`, `list_group_members`). The IDP write on approve uses the administrator's own bearer token, so no service account or new secret is introduced on the ep-api side.
- Persistence lives in the `access_requests` collection on the existing MongoDB instance. The connection string and database name are reused from `CatalogSettings` — no new env vars beyond the `ENABLE_ACCESS_REQUESTS` feature flag (off by default).
- Bump version to 0.13.0.

Closes #108

## Test plan
- [x] 52 new unit tests across `tests/test_require_admin.py`, `tests/test_aai_client.py`, `tests/test_access_request_service.py`, `tests/test_access_request_routes.py`
- [x] Full test suite passes (1101 tests)
- [x] `black --check --diff .` passes
- [x] `flake8 api/ tests/ --max-line-length=88 --extend-ignore=E203,W503,E501,F401` passes
- [x] Manual end-to-end run with Keycloak + MongoDB profiles: yutian submits request → 201; yutian submits again → 409; yutian tries to list → 403; raul lists → sees pending; raul approves with `grant_type=member` → user gets added to the endpoint group in Keycloak; yutian's subsequent `/user/info` returns 200; reject path also verified; `?status=all` returns both historical records.

## Followups
- UI is deliberately out of scope for this PR (tracked in issue 2). The existing 403 screen will keep its current wording until the UI PR lands.
- The endpoint group `{AFFINITIES_EP_UUID}` must exist in Keycloak before approving the first request. This is a one-time setup today; we can add lazy creation in a follow-up if needed.