### PR TITLE
Access request workflow UI (still v0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.13.0] - 2026-04-23
 
 ### Added
-- Access-request workflow (backend only — the UI follow-up lands in a later release)
+- Access-request workflow, end-to-end (backend + UI)
   - New `ENABLE_ACCESS_REQUESTS` flag (off by default) so deployments without MongoDB boot unchanged
   - `POST /user/access-requests` lets an authenticated user submit a request with an optional justification; duplicates (existing pending request for the same user) are rejected with 409
   - `GET /user/access-requests` lists pending requests for administrators, with `?status=pending|approved|rejected|all` filter
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - A new `require_admin` dependency that admits users with either the `ndp_admin` role or the endpoint-specific `{AFFINITIES_EP_UUID}_admin` role
   - A thin client for the NDP AAI API (`add_user_to_group`, `assign_role`, `list_group_members`) so the grant step reuses the administrator's session and no service account is introduced
   - MongoDB-backed persistence in the `access_requests` collection, with the connection string and database name reused from `CatalogSettings` (no new env vars)
+  - UI: the AuthGuard 403 screen now offers a "Request access to this Endpoint" button with an optional justification, replaced by a success confirmation once the request is submitted. The user's bearer token is held in memory only for this single call and never persisted to `localStorage`.
+  - UI: a new "Access Requests" page, visible in the top nav only to users with the `ndp_admin` or endpoint-scoped `{UUID}_admin` role, lists pending/approved/rejected requests and lets administrators approve (choosing between `member` or `admin` grant, with optional notes) or reject (with optional notes).
 
 ## [0.12.0] - 2026-04-22
 

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -11,6 +11,7 @@ import S3Management from './pages/S3Management';
 import Services from './pages/Services';
 import Search from './pages/Search';
 import DatasetManagement from './pages/DatasetManagement';
+import AccessRequests from './pages/AccessRequests';
 import './styles/global.css';
 
 /**
@@ -44,6 +45,9 @@ function App() {
               
               {/* Search functionality route */}
               <Route path="/search" element={<Search />} />
+
+              {/* Access request management route (admin-gated on backend) */}
+              <Route path="/access-requests" element={<AccessRequests />} />
             </Routes>
           </Layout>
         </Router>

--- a/ui/src/components/AuthGuard.js
+++ b/ui/src/components/AuthGuard.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { Lock, AlertCircle, Eye, EyeOff, User } from 'lucide-react';
-import { authAPI } from '../services/api';
+import { Lock, AlertCircle, Eye, EyeOff, User, Send, CheckCircle } from 'lucide-react';
+import { accessRequestsAPI, authAPI } from '../services/api';
 
 /**
  * AuthGuard component that requires authentication before accessing the app
@@ -19,6 +19,23 @@ const AuthGuard = ({ children, onAuthenticated }) => {
   const [credentials, setCredentials] = useState({ username: '', password: '' });
   const [showPassword, setShowPassword] = useState(false);
   const [loggingIn, setLoggingIn] = useState(false);
+
+  // Access-request flow state. The token is held in component state only —
+  // it is never persisted because the user is not allowed into the app.
+  const [deniedToken, setDeniedToken] = useState(null);
+  const [requestFormOpen, setRequestFormOpen] = useState(false);
+  const [requestJustification, setRequestJustification] = useState('');
+  const [requestSubmitting, setRequestSubmitting] = useState(false);
+  const [requestSubmitted, setRequestSubmitted] = useState(false);
+  const [requestError, setRequestError] = useState(null);
+
+  const clearRequestState = () => {
+    setDeniedToken(null);
+    setRequestFormOpen(false);
+    setRequestJustification('');
+    setRequestSubmitted(false);
+    setRequestError(null);
+  };
 
   /**
    * Check if user is already authenticated using proper token validation
@@ -40,6 +57,9 @@ const AuthGuard = ({ children, onAuthenticated }) => {
           console.error('Token validation failed:', validationError);
           localStorage.removeItem('authToken');
           if (validationError.response?.status === 403) {
+            // Keep the token in memory so the user can submit an access
+            // request without having to paste it again.
+            setDeniedToken(existingToken);
             setError(
               validationError.response.data?.detail
               || 'You do not have permission to access this Endpoint.'
@@ -69,6 +89,7 @@ const AuthGuard = ({ children, onAuthenticated }) => {
 
     try {
       setError(null);
+      clearRequestState();
       setValidatingToken(true);
 
       const userInfo = await authAPI.setAndValidateToken(token.trim());
@@ -82,6 +103,12 @@ const AuthGuard = ({ children, onAuthenticated }) => {
       console.error('Token validation error:', err);
 
       let errorMessage = err.message || 'Token validation failed';
+      // If the IDP accepted the token but the Endpoint denied entry,
+      // hold the raw token so the user can request access without
+      // re-entering it.
+      if (err.deniedToken) {
+        setDeniedToken(err.deniedToken);
+      }
 
       if (errorMessage.includes('Invalid token')) {
         setError('Invalid token. Please check your token and try again.');
@@ -126,6 +153,7 @@ const AuthGuard = ({ children, onAuthenticated }) => {
 
     try {
       setError(null);
+      clearRequestState();
       setLoggingIn(true);
 
       await authAPI.login(credentials.username.trim(), credentials.password);
@@ -135,9 +163,59 @@ const AuthGuard = ({ children, onAuthenticated }) => {
       setCredentials({ username: '', password: '' });
     } catch (err) {
       console.error('Credentials login error:', err);
+      if (err.deniedToken) {
+        setDeniedToken(err.deniedToken);
+      }
       setError(err.message || 'Login failed');
     } finally {
       setLoggingIn(false);
+    }
+  };
+
+  /**
+   * Submit an access request on behalf of the denied user. The token held
+   * in state is attached to this single call and never persisted.
+   */
+  const handleAccessRequestSubmit = async (e) => {
+    e.preventDefault();
+    if (!deniedToken) return;
+
+    try {
+      setRequestError(null);
+      setRequestSubmitting(true);
+      await accessRequestsAPI.createWithToken(
+        deniedToken,
+        requestJustification.trim() || null
+      );
+      setRequestSubmitted(true);
+      setRequestFormOpen(false);
+      setRequestJustification('');
+    } catch (err) {
+      console.error('Access request submission failed:', err);
+      if (err.response?.status === 409) {
+        setRequestError(
+          'You already have a pending access request. An administrator ' +
+            'will review it.'
+        );
+      } else if (err.response?.status === 503) {
+        setRequestError(
+          'Access requests are disabled on this deployment. ' +
+            'Please contact the administrator directly.'
+        );
+      } else if (err.response?.status === 401 || err.response?.status === 403) {
+        setRequestError(
+          err.response.data?.detail ||
+            'Your session is no longer valid. Please sign in again.'
+        );
+      } else {
+        setRequestError(
+          err.response?.data?.detail ||
+            err.message ||
+            'Could not submit the access request. Please try again.'
+        );
+      }
+    } finally {
+      setRequestSubmitting(false);
     }
   };
 
@@ -252,8 +330,8 @@ const AuthGuard = ({ children, onAuthenticated }) => {
             </p>
           </div>
 
-          {/* Error Message */}
-          {error && (
+          {/* Error Message (hidden once the request-submitted view takes over) */}
+          {error && !requestSubmitted && (
             <div style={{
               backgroundColor: '#fef2f2',
               border: '1px solid #fecaca',
@@ -271,8 +349,173 @@ const AuthGuard = ({ children, onAuthenticated }) => {
             </div>
           )}
 
+          {/* Access-request CTA — shown when the user is authenticated to
+              the IDP but denied entry to this Endpoint */}
+          {deniedToken && !requestSubmitted && !requestFormOpen && (
+            <div style={{ marginBottom: '1rem' }}>
+              <button
+                type="button"
+                onClick={() => {
+                  setRequestFormOpen(true);
+                  setRequestError(null);
+                }}
+                style={{
+                  width: '100%',
+                  padding: '0.75rem 1rem',
+                  backgroundColor: '#ffffff',
+                  color: '#2563eb',
+                  border: '1px solid #2563eb',
+                  borderRadius: '6px',
+                  fontSize: '0.9rem',
+                  fontWeight: '600',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: '0.5rem'
+                }}
+              >
+                <Send size={16} />
+                Request access to this Endpoint
+              </button>
+            </div>
+          )}
+
+          {/* Access-request form */}
+          {deniedToken && requestFormOpen && !requestSubmitted && (
+            <form
+              onSubmit={handleAccessRequestSubmit}
+              style={{
+                marginBottom: '1rem',
+                padding: '1rem',
+                border: '1px solid #e2e8f0',
+                borderRadius: '6px',
+                backgroundColor: '#f8fafc'
+              }}
+            >
+              <label style={{
+                display: 'block',
+                fontWeight: '600',
+                color: '#374151',
+                marginBottom: '0.5rem',
+                fontSize: '0.9rem'
+              }}>
+                Justification (optional)
+              </label>
+              <textarea
+                value={requestJustification}
+                onChange={(e) => setRequestJustification(e.target.value)}
+                placeholder="Briefly explain why you need access."
+                maxLength={2000}
+                disabled={requestSubmitting}
+                style={{
+                  width: '100%',
+                  minHeight: '80px',
+                  padding: '0.65rem',
+                  border: '2px solid #e2e8f0',
+                  borderRadius: '6px',
+                  fontSize: '0.875rem',
+                  lineHeight: 1.4,
+                  resize: 'vertical',
+                  boxSizing: 'border-box',
+                  backgroundColor: requestSubmitting ? '#f3f4f6' : 'white'
+                }}
+              />
+
+              {requestError && (
+                <div style={{
+                  marginTop: '0.5rem',
+                  fontSize: '0.8rem',
+                  color: '#dc2626'
+                }}>
+                  {requestError}
+                </div>
+              )}
+
+              <div style={{
+                display: 'flex',
+                gap: '0.5rem',
+                marginTop: '0.75rem'
+              }}>
+                <button
+                  type="submit"
+                  disabled={requestSubmitting}
+                  style={{
+                    flex: 1,
+                    padding: '0.6rem 0.75rem',
+                    backgroundColor: requestSubmitting ? '#9ca3af' : '#2563eb',
+                    color: 'white',
+                    border: 'none',
+                    borderRadius: '6px',
+                    fontSize: '0.85rem',
+                    fontWeight: '600',
+                    cursor: requestSubmitting ? 'not-allowed' : 'pointer',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: '0.4rem'
+                  }}
+                >
+                  {requestSubmitting ? (
+                    <>
+                      <div className="loading-spinner" style={{ width: '14px', height: '14px' }} />
+                      Sending...
+                    </>
+                  ) : (
+                    <>
+                      <Send size={14} />
+                      Send request
+                    </>
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setRequestFormOpen(false);
+                    setRequestError(null);
+                  }}
+                  disabled={requestSubmitting}
+                  style={{
+                    flex: '0 0 auto',
+                    padding: '0.6rem 0.9rem',
+                    backgroundColor: 'white',
+                    color: '#64748b',
+                    border: '1px solid #cbd5e1',
+                    borderRadius: '6px',
+                    fontSize: '0.85rem',
+                    fontWeight: '500',
+                    cursor: requestSubmitting ? 'not-allowed' : 'pointer'
+                  }}
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          )}
+
+          {/* Confirmation after request submission */}
+          {requestSubmitted && (
+            <div style={{
+              marginBottom: '1rem',
+              padding: '1rem',
+              backgroundColor: '#ecfdf5',
+              border: '1px solid #a7f3d0',
+              borderRadius: '6px',
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: '0.6rem'
+            }}>
+              <CheckCircle size={20} style={{ color: '#059669', flexShrink: 0 }} />
+              <div style={{ fontSize: '0.875rem', color: '#065f46', lineHeight: 1.4 }}>
+                <strong>Request submitted.</strong> An administrator will review
+                your access request. You can close this page — you will be
+                notified through your organization once the decision is made.
+              </div>
+            </div>
+          )}
+
           {/* Token Form */}
-          {authMode === 'token' && (
+          {!requestSubmitted && authMode === 'token' && (
           <form onSubmit={handleTokenSubmit}>
             <div style={{ marginBottom: '1rem' }}>
               <label style={{
@@ -458,7 +701,7 @@ const AuthGuard = ({ children, onAuthenticated }) => {
           )}
 
           {/* Credentials Form */}
-          {authMode === 'credentials' && (
+          {!requestSubmitted && authMode === 'credentials' && (
           <form onSubmit={handleCredentialsSubmit}>
             <div style={{ marginBottom: '1rem' }}>
               <label style={{

--- a/ui/src/components/Navigation.js
+++ b/ui/src/components/Navigation.js
@@ -1,19 +1,21 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { 
-  Home, 
-  Building2, 
-  Radio, 
-  Link as LinkIcon, 
-  Database, 
-  Settings, 
+import {
+  Home,
+  Building2,
+  Radio,
+  Link as LinkIcon,
+  Database,
+  Settings,
   Search,
   FileText,
   LogOut,
   FolderOpen,
   ChevronDown,
-  HardDrive
+  HardDrive,
+  ShieldAlert
 } from 'lucide-react';
+import { isAccessRequestAdmin, userAPI } from '../services/api';
 
 /**
  * Enhanced navigation component similar to nationaldataplatform.org
@@ -25,6 +27,24 @@ const Navigation = () => {
   const dropdownRef = useRef(null);
   const buttonRef = useRef(null);
   const timeoutRef = useRef(null);
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  // Determine admin status from the current token's /user/info response so
+  // the "Access Requests" entry is only shown to users that can use it.
+  useEffect(() => {
+    let cancelled = false;
+    userAPI
+      .getUserInfo()
+      .then((response) => {
+        if (!cancelled) setIsAdmin(isAccessRequestAdmin(response.data));
+      })
+      .catch(() => {
+        if (!cancelled) setIsAdmin(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Clear timeout on unmount
   useEffect(() => {
@@ -453,6 +473,39 @@ const Navigation = () => {
                 <Search size={18} />
                 <span>Search</span>
               </Link>
+
+              {/* Access Requests (admin only) */}
+              {isAdmin && (
+                <Link
+                  to="/access-requests"
+                  onMouseEnter={handleOtherNavEnter}
+                  style={{
+                    color: '#6b7280',
+                    textDecoration: 'none',
+                    padding: '0.75rem 1rem',
+                    borderRadius: '8px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.5rem',
+                    fontSize: '0.95rem',
+                    fontWeight: '500',
+                    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+                    backgroundColor: 'transparent',
+                    transition: 'all 0.2s ease'
+                  }}
+                  onMouseOver={(e) => {
+                    e.target.style.color = '#374151';
+                    e.target.style.fontWeight = '600';
+                  }}
+                  onMouseOut={(e) => {
+                    e.target.style.color = '#6b7280';
+                    e.target.style.fontWeight = '500';
+                  }}
+                >
+                  <ShieldAlert size={18} />
+                  <span>Access Requests</span>
+                </Link>
+              )}
             </div>
           </nav>
 

--- a/ui/src/pages/AccessRequests.js
+++ b/ui/src/pages/AccessRequests.js
@@ -1,0 +1,641 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  AlertCircle,
+  CheckCircle,
+  Clock,
+  RefreshCw,
+  ShieldAlert,
+  XCircle,
+} from 'lucide-react';
+import { accessRequestsAPI } from '../services/api';
+
+const STATUS_TABS = [
+  { key: 'pending', label: 'Pending' },
+  { key: 'approved', label: 'Approved' },
+  { key: 'rejected', label: 'Rejected' },
+];
+
+const STATUS_STYLE = {
+  pending: { background: '#fef3c7', border: '#fcd34d', color: '#92400e' },
+  approved: { background: '#d1fae5', border: '#6ee7b7', color: '#065f46' },
+  rejected: { background: '#fee2e2', border: '#fecaca', color: '#991b1b' },
+};
+
+const formatDate = (value) => {
+  if (!value) return '—';
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return String(value);
+  }
+};
+
+/**
+ * Admin-only page to review and act on access requests.
+ */
+const AccessRequests = () => {
+  const [requests, setRequests] = useState([]);
+  const [statusFilter, setStatusFilter] = useState('pending');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [actionError, setActionError] = useState(null);
+  const [actionSuccess, setActionSuccess] = useState(null);
+
+  // Per-row action state keyed by request id.
+  const [approveDraft, setApproveDraft] = useState({}); // { [id]: { grant, notes } }
+  const [rejectDraft, setRejectDraft] = useState({}); // { [id]: notes }
+  const [busyId, setBusyId] = useState(null);
+
+  const fetchRequests = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await accessRequestsAPI.list(statusFilter);
+      setRequests(response.data || []);
+    } catch (err) {
+      console.error('Failed to load access requests:', err);
+      if (err.response?.status === 503) {
+        setError(
+          'The access-request workflow is disabled on this deployment.'
+        );
+      } else if (err.response?.status === 403) {
+        setError(
+          err.response.data?.detail ||
+            'Administrator role required to view this page.'
+        );
+      } else {
+        setError(
+          err.response?.data?.detail ||
+            err.message ||
+            'Could not load access requests.'
+        );
+      }
+      setRequests([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter]);
+
+  useEffect(() => {
+    fetchRequests();
+  }, [fetchRequests]);
+
+  const openApproveDraft = (id) => {
+    setApproveDraft((prev) => ({
+      ...prev,
+      [id]: prev[id] || { grant: 'member', notes: '' },
+    }));
+    setRejectDraft((prev) => {
+      if (!(id in prev)) return prev;
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+    setActionError(null);
+    setActionSuccess(null);
+  };
+
+  const openRejectDraft = (id) => {
+    setRejectDraft((prev) => ({ ...prev, [id]: prev[id] || '' }));
+    setApproveDraft((prev) => {
+      if (!(id in prev)) return prev;
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+    setActionError(null);
+    setActionSuccess(null);
+  };
+
+  const closeDrafts = (id) => {
+    setApproveDraft((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+    setRejectDraft((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  };
+
+  const handleApprove = async (id) => {
+    const draft = approveDraft[id] || { grant: 'member', notes: '' };
+    try {
+      setBusyId(id);
+      setActionError(null);
+      setActionSuccess(null);
+      await accessRequestsAPI.approve(id, draft.grant, draft.notes.trim() || null);
+      setActionSuccess(`Request approved as ${draft.grant}.`);
+      closeDrafts(id);
+      await fetchRequests();
+    } catch (err) {
+      console.error('Approve failed:', err);
+      setActionError(
+        err.response?.data?.detail ||
+          err.message ||
+          'Could not approve this request.'
+      );
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleReject = async (id) => {
+    const notes = (rejectDraft[id] || '').trim();
+    try {
+      setBusyId(id);
+      setActionError(null);
+      setActionSuccess(null);
+      await accessRequestsAPI.reject(id, notes || null);
+      setActionSuccess('Request rejected.');
+      closeDrafts(id);
+      await fetchRequests();
+    } catch (err) {
+      console.error('Reject failed:', err);
+      setActionError(
+        err.response?.data?.detail ||
+          err.message ||
+          'Could not reject this request.'
+      );
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div style={{ padding: '2rem', maxWidth: '1100px', margin: '0 auto' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: '1.5rem',
+          gap: '1rem',
+          flexWrap: 'wrap',
+        }}
+      >
+        <h1 style={{ margin: 0, color: '#1e293b', fontSize: '1.75rem', fontWeight: 700 }}>
+          <ShieldAlert size={24} style={{ verticalAlign: 'middle', marginRight: '0.5rem' }} />
+          Access Requests
+        </h1>
+        <button
+          type="button"
+          onClick={fetchRequests}
+          disabled={loading}
+          style={{
+            padding: '0.55rem 0.9rem',
+            backgroundColor: 'white',
+            border: '1px solid #cbd5e1',
+            borderRadius: '6px',
+            cursor: loading ? 'not-allowed' : 'pointer',
+            color: '#374151',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.4rem',
+            fontSize: '0.85rem',
+            fontWeight: 500,
+          }}
+        >
+          <RefreshCw size={14} />
+          Refresh
+        </button>
+      </div>
+
+      {/* Tabs */}
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+        {STATUS_TABS.map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => setStatusFilter(tab.key)}
+            style={{
+              padding: '0.5rem 1rem',
+              backgroundColor: statusFilter === tab.key ? '#2563eb' : 'white',
+              color: statusFilter === tab.key ? 'white' : '#374151',
+              border: '1px solid #cbd5e1',
+              borderRadius: '6px',
+              cursor: 'pointer',
+              fontSize: '0.85rem',
+              fontWeight: 500,
+            }}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {actionError && (
+        <div
+          style={{
+            backgroundColor: '#fef2f2',
+            border: '1px solid #fecaca',
+            borderRadius: '6px',
+            padding: '0.75rem',
+            marginBottom: '1rem',
+            display: 'flex',
+            gap: '0.5rem',
+            alignItems: 'center',
+          }}
+        >
+          <AlertCircle size={18} style={{ color: '#dc2626', flexShrink: 0 }} />
+          <span style={{ color: '#991b1b', fontSize: '0.875rem' }}>{actionError}</span>
+        </div>
+      )}
+
+      {actionSuccess && (
+        <div
+          style={{
+            backgroundColor: '#ecfdf5',
+            border: '1px solid #a7f3d0',
+            borderRadius: '6px',
+            padding: '0.75rem',
+            marginBottom: '1rem',
+            display: 'flex',
+            gap: '0.5rem',
+            alignItems: 'center',
+          }}
+        >
+          <CheckCircle size={18} style={{ color: '#059669', flexShrink: 0 }} />
+          <span style={{ color: '#065f46', fontSize: '0.875rem' }}>{actionSuccess}</span>
+        </div>
+      )}
+
+      {error && (
+        <div
+          style={{
+            backgroundColor: '#fef2f2',
+            border: '1px solid #fecaca',
+            borderRadius: '6px',
+            padding: '1rem',
+            color: '#991b1b',
+            fontSize: '0.9rem',
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {!error && loading && (
+        <div style={{ padding: '2rem', color: '#64748b', textAlign: 'center' }}>
+          Loading access requests...
+        </div>
+      )}
+
+      {!error && !loading && requests.length === 0 && (
+        <div
+          style={{
+            padding: '2rem',
+            border: '1px dashed #cbd5e1',
+            borderRadius: '8px',
+            color: '#64748b',
+            textAlign: 'center',
+            fontSize: '0.95rem',
+          }}
+        >
+          No {statusFilter} access requests.
+        </div>
+      )}
+
+      {!error && !loading && requests.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+          {requests.map((req) => {
+            const statusStyle = STATUS_STYLE[req.status] || STATUS_STYLE.pending;
+            const approveOpen = !!approveDraft[req.id];
+            const rejectOpen = Object.prototype.hasOwnProperty.call(rejectDraft, req.id);
+            const isBusy = busyId === req.id;
+
+            return (
+              <div
+                key={req.id}
+                style={{
+                  border: '1px solid #e2e8f0',
+                  borderRadius: '8px',
+                  padding: '1rem',
+                  backgroundColor: 'white',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '0.75rem',
+                }}
+              >
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'flex-start',
+                    gap: '1rem',
+                    flexWrap: 'wrap',
+                  }}
+                >
+                  <div>
+                    <div style={{ fontSize: '1rem', fontWeight: 600, color: '#1e293b' }}>
+                      {req.username}
+                      {req.email && (
+                        <span style={{ color: '#64748b', fontWeight: 400 }}>
+                          {' '}· {req.email}
+                        </span>
+                      )}
+                    </div>
+                    <div style={{ fontSize: '0.8rem', color: '#64748b' }}>
+                      <Clock size={12} style={{ verticalAlign: 'middle', marginRight: '0.25rem' }} />
+                      Requested {formatDate(req.created_at)}
+                    </div>
+                  </div>
+                  <span
+                    style={{
+                      padding: '0.25rem 0.6rem',
+                      fontSize: '0.75rem',
+                      fontWeight: 600,
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.04em',
+                      borderRadius: '999px',
+                      backgroundColor: statusStyle.background,
+                      border: `1px solid ${statusStyle.border}`,
+                      color: statusStyle.color,
+                    }}
+                  >
+                    {req.status}
+                  </span>
+                </div>
+
+                {req.justification && (
+                  <div
+                    style={{
+                      fontSize: '0.875rem',
+                      backgroundColor: '#f8fafc',
+                      border: '1px solid #e2e8f0',
+                      borderRadius: '6px',
+                      padding: '0.6rem 0.75rem',
+                      color: '#334155',
+                      whiteSpace: 'pre-wrap',
+                    }}
+                  >
+                    {req.justification}
+                  </div>
+                )}
+
+                {req.status !== 'pending' && (
+                  <div style={{ fontSize: '0.8rem', color: '#475569' }}>
+                    Decided {formatDate(req.decided_at)}
+                    {req.decided_by_username && (
+                      <> by <strong>{req.decided_by_username}</strong></>
+                    )}
+                    {req.grant_type && (
+                      <> · granted as <strong>{req.grant_type}</strong></>
+                    )}
+                    {req.decision_notes && (
+                      <div style={{ marginTop: '0.35rem', fontStyle: 'italic' }}>
+                        {req.decision_notes}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {req.status === 'pending' && (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                    {!approveOpen && !rejectOpen && (
+                      <div style={{ display: 'flex', gap: '0.5rem' }}>
+                        <button
+                          type="button"
+                          onClick={() => openApproveDraft(req.id)}
+                          disabled={isBusy}
+                          style={{
+                            padding: '0.55rem 0.9rem',
+                            backgroundColor: '#059669',
+                            color: 'white',
+                            border: 'none',
+                            borderRadius: '6px',
+                            cursor: isBusy ? 'not-allowed' : 'pointer',
+                            fontSize: '0.85rem',
+                            fontWeight: 600,
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '0.35rem',
+                          }}
+                        >
+                          <CheckCircle size={14} /> Approve
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => openRejectDraft(req.id)}
+                          disabled={isBusy}
+                          style={{
+                            padding: '0.55rem 0.9rem',
+                            backgroundColor: 'white',
+                            color: '#dc2626',
+                            border: '1px solid #fecaca',
+                            borderRadius: '6px',
+                            cursor: isBusy ? 'not-allowed' : 'pointer',
+                            fontSize: '0.85rem',
+                            fontWeight: 600,
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '0.35rem',
+                          }}
+                        >
+                          <XCircle size={14} /> Reject
+                        </button>
+                      </div>
+                    )}
+
+                    {approveOpen && (
+                      <div
+                        style={{
+                          padding: '0.75rem',
+                          backgroundColor: '#f8fafc',
+                          border: '1px solid #e2e8f0',
+                          borderRadius: '6px',
+                          display: 'flex',
+                          flexDirection: 'column',
+                          gap: '0.5rem',
+                        }}
+                      >
+                        <div style={{ fontSize: '0.85rem', color: '#374151', fontWeight: 600 }}>
+                          Approve request — choose grant
+                        </div>
+                        <div style={{ display: 'flex', gap: '1rem', fontSize: '0.85rem', color: '#374151' }}>
+                          <label style={{ display: 'flex', alignItems: 'center', gap: '0.3rem' }}>
+                            <input
+                              type="radio"
+                              name={`grant-${req.id}`}
+                              value="member"
+                              checked={approveDraft[req.id]?.grant === 'member'}
+                              onChange={() =>
+                                setApproveDraft((prev) => ({
+                                  ...prev,
+                                  [req.id]: {
+                                    ...(prev[req.id] || { notes: '' }),
+                                    grant: 'member',
+                                  },
+                                }))
+                              }
+                            />
+                            Member (access to the Endpoint)
+                          </label>
+                          <label style={{ display: 'flex', alignItems: 'center', gap: '0.3rem' }}>
+                            <input
+                              type="radio"
+                              name={`grant-${req.id}`}
+                              value="admin"
+                              checked={approveDraft[req.id]?.grant === 'admin'}
+                              onChange={() =>
+                                setApproveDraft((prev) => ({
+                                  ...prev,
+                                  [req.id]: {
+                                    ...(prev[req.id] || { notes: '' }),
+                                    grant: 'admin',
+                                  },
+                                }))
+                              }
+                            />
+                            Admin (access + manage future requests)
+                          </label>
+                        </div>
+                        <textarea
+                          value={approveDraft[req.id]?.notes || ''}
+                          onChange={(e) =>
+                            setApproveDraft((prev) => ({
+                              ...prev,
+                              [req.id]: {
+                                ...(prev[req.id] || { grant: 'member' }),
+                                notes: e.target.value,
+                              },
+                            }))
+                          }
+                          placeholder="Optional note (shown on the request record)"
+                          maxLength={2000}
+                          style={{
+                            width: '100%',
+                            minHeight: '60px',
+                            padding: '0.5rem',
+                            border: '1px solid #cbd5e1',
+                            borderRadius: '6px',
+                            fontSize: '0.85rem',
+                            boxSizing: 'border-box',
+                            resize: 'vertical',
+                          }}
+                        />
+                        <div style={{ display: 'flex', gap: '0.5rem' }}>
+                          <button
+                            type="button"
+                            onClick={() => handleApprove(req.id)}
+                            disabled={isBusy}
+                            style={{
+                              padding: '0.5rem 0.8rem',
+                              backgroundColor: '#059669',
+                              color: 'white',
+                              border: 'none',
+                              borderRadius: '6px',
+                              fontSize: '0.85rem',
+                              fontWeight: 600,
+                              cursor: isBusy ? 'not-allowed' : 'pointer',
+                            }}
+                          >
+                            {isBusy ? 'Working...' : 'Confirm approval'}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => closeDrafts(req.id)}
+                            disabled={isBusy}
+                            style={{
+                              padding: '0.5rem 0.8rem',
+                              backgroundColor: 'white',
+                              color: '#64748b',
+                              border: '1px solid #cbd5e1',
+                              borderRadius: '6px',
+                              fontSize: '0.85rem',
+                              cursor: isBusy ? 'not-allowed' : 'pointer',
+                            }}
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    )}
+
+                    {rejectOpen && (
+                      <div
+                        style={{
+                          padding: '0.75rem',
+                          backgroundColor: '#fff7ed',
+                          border: '1px solid #fed7aa',
+                          borderRadius: '6px',
+                          display: 'flex',
+                          flexDirection: 'column',
+                          gap: '0.5rem',
+                        }}
+                      >
+                        <div style={{ fontSize: '0.85rem', color: '#9a3412', fontWeight: 600 }}>
+                          Reject request
+                        </div>
+                        <textarea
+                          value={rejectDraft[req.id] || ''}
+                          onChange={(e) =>
+                            setRejectDraft((prev) => ({
+                              ...prev,
+                              [req.id]: e.target.value,
+                            }))
+                          }
+                          placeholder="Optional note for the record"
+                          maxLength={2000}
+                          style={{
+                            width: '100%',
+                            minHeight: '60px',
+                            padding: '0.5rem',
+                            border: '1px solid #fdba74',
+                            borderRadius: '6px',
+                            fontSize: '0.85rem',
+                            boxSizing: 'border-box',
+                            resize: 'vertical',
+                          }}
+                        />
+                        <div style={{ display: 'flex', gap: '0.5rem' }}>
+                          <button
+                            type="button"
+                            onClick={() => handleReject(req.id)}
+                            disabled={isBusy}
+                            style={{
+                              padding: '0.5rem 0.8rem',
+                              backgroundColor: '#dc2626',
+                              color: 'white',
+                              border: 'none',
+                              borderRadius: '6px',
+                              fontSize: '0.85rem',
+                              fontWeight: 600,
+                              cursor: isBusy ? 'not-allowed' : 'pointer',
+                            }}
+                          >
+                            {isBusy ? 'Working...' : 'Confirm rejection'}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => closeDrafts(req.id)}
+                            disabled={isBusy}
+                            style={{
+                              padding: '0.5rem 0.8rem',
+                              backgroundColor: 'white',
+                              color: '#64748b',
+                              border: '1px solid #cbd5e1',
+                              borderRadius: '6px',
+                              fontSize: '0.85rem',
+                              cursor: isBusy ? 'not-allowed' : 'pointer',
+                            }}
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AccessRequests;

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -359,6 +359,82 @@ export const userAPI = {
   getUserInfo: () => apiClient.get('/user/info'),
 };
 
+// Access-request workflow API
+export const accessRequestsAPI = {
+  /**
+   * Submit an access request for the currently-authenticated user.
+   * Used from pages that are already inside the app and therefore have a
+   * token in localStorage (goes through the standard apiClient interceptor).
+   */
+  create: (justification) =>
+    apiClient.post('/user/access-requests', { justification: justification || null }),
+
+  /**
+   * Submit an access request using an explicit token that is NOT stored in
+   * localStorage. Used from the AuthGuard screen for users that have a
+   * valid token but are denied entry to the Endpoint — we do not want to
+   * persist their token but we still need to attach it to this one call.
+   */
+  createWithToken: (token, justification) => {
+    const tempClient = axios.create({
+      baseURL: BASE_URL,
+      timeout: 60000,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    return tempClient.post('/user/access-requests', {
+      justification: justification || null,
+    });
+  },
+
+  /**
+   * List access requests. Admin only.
+   * @param {string|null} status - One of 'pending' | 'approved' | 'rejected' | 'all', or null to use the backend default (pending).
+   */
+  list: (status = null) =>
+    apiClient.get('/user/access-requests', {
+      params: status ? { status } : {},
+    }),
+
+  /**
+   * Approve a pending request. Admin only.
+   * @param {string} requestId
+   * @param {'member'|'admin'} grantType
+   * @param {string|null} notes
+   */
+  approve: (requestId, grantType, notes = null) =>
+    apiClient.post(`/user/access-requests/${requestId}/approve`, {
+      grant_type: grantType,
+      notes: notes || null,
+    }),
+
+  /**
+   * Reject a pending request. Admin only.
+   */
+  reject: (requestId, notes = null) =>
+    apiClient.post(`/user/access-requests/${requestId}/reject`, {
+      notes: notes || null,
+    }),
+};
+
+/**
+ * Return true if the given user_info payload grants admin access to the
+ * access-request management page. Admins are: holders of the `ndp_admin`
+ * realm role OR holders of any role ending in `_admin` (which covers the
+ * endpoint-scoped `{UUID}_admin` role).
+ */
+export const isAccessRequestAdmin = (userInfo) => {
+  const roles = userInfo?.roles;
+  if (!Array.isArray(roles)) return false;
+  return roles.some((role) => {
+    if (typeof role !== 'string') return false;
+    const lower = role.trim().toLowerCase();
+    return lower === 'ndp_admin' || lower.endsWith('_admin');
+  });
+};
+
 // Authentication API - Enhanced with proper user info validation
 export const authAPI = {
   /**
@@ -433,10 +509,14 @@ export const authAPI = {
       await authAPI.validateToken(data.access_token);
     } catch (error) {
       if (error.response?.status === 403) {
-        throw new Error(
+        // Propagate the raw token so the caller can offer a
+        // Request-access flow without re-entering credentials.
+        const err = new Error(
           error.response.data?.detail ||
             'You do not have permission to access this Endpoint.'
         );
+        err.deniedToken = data.access_token;
+        throw err;
       }
       if (error.response?.status === 401) {
         throw new Error('Invalid username or password');
@@ -476,10 +556,14 @@ export const authAPI = {
       if (error.response?.status === 401) {
         throw new Error('Invalid token: Authentication failed');
       } else if (error.response?.status === 403) {
-        throw new Error(
+        const err = new Error(
           error.response.data?.detail ||
             'You do not have permission to access this Endpoint.'
         );
+        // Propagate the raw token so the caller can offer a Request-access
+        // flow without forcing the user to re-enter it.
+        err.deniedToken = token.trim();
+        throw err;
       } else if (error.code === 'ECONNREFUSED' || error.message.includes('Network Error')) {
         throw new Error('Cannot connect to API server');
       } else {


### PR DESCRIPTION
## Summary
- Add the UI layer on top of the backend shipped in #109 so the access-request workflow is usable end-to-end from the browser.
- Denied users (AuthGuard 403) now see a "Request access to this Endpoint" button with an optional justification. The bearer token is held in the page only for this single call and never persisted to `localStorage`, so an unauthorized user is never considered signed in. On success the screen replaces the error with a confirmation panel.
- A new "Access Requests" admin page (route `/access-requests`) lists pending, approved and rejected requests in three tabs. Administrators can approve a pending request with a `member` or `admin` grant (plus optional notes) or reject it (plus optional notes). Errors coming back from the AAI grant on approve (403 insufficient privileges, 404, 502) are surfaced inline.
- A new nav entry "Access Requests" appears only for users whose `/user/info` payload contains either `ndp_admin` or an endpoint-scoped admin role. Everyone else never sees the link.
- Version stays at **0.13.0** — this PR is grouped into the same release as #109. No version bump, no Docker push yet.

Closes #110

## Test plan
- [x] Full backend test suite still passes (1101 tests)
- [x] `black --check --diff .` passes
- [x] `flake8 api/ tests/ --max-line-length=88 --extend-ignore=E203,W503,E501,F401` passes
- [x] UI build succeeds inside the multi-stage Dockerfile
- [ ] Manual end-to-end check in the browser (user submits a request after 403, administrator approves as `member`, user re-logs and enters the app) — to be done by the reviewer before releasing 0.13.0.

## Notes
- The endpoint group `{AFFINITIES_EP_UUID}` must already exist in Keycloak before the first approve (same caveat documented in #109). Lazy group creation is still a candidate follow-up.