### PR TITLE
feat(publish): mark datasets as submitted when sent to Pre-CKAN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-04-26
+
+### Changed
+- `POST /dataset/{dataset_id}/publish` now marks both the local dataset and the Pre-CKAN copy with a `status=submitted` entry in their `extras`, so an Endpoint can tell which of its datasets are pending review and Pre-CKAN reviewers can identify newly submitted datasets in their queue
+  - The status is stored as a CKAN-style extra (`{"key": "status", "value": "submitted"}`) alongside any existing extras (`ndp_user_id`, `ndp_group_id`, `ndp_creator_md5`, user-provided extras)
+  - Re-publishing a dataset that already had a `status` entry (for example `approved` or `rejected`) replaces it with `submitted`, since this represents a fresh submission to the review queue
+  - If creating the dataset in Pre-CKAN fails, the local dataset is left untouched
+  - If the local update fails after a successful Pre-CKAN creation, the failure is logged as a warning and the publish still returns success — the Pre-CKAN copy is the source of truth for the review workflow
+
 ## [0.13.0] - 2026-04-23
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.13.0"
+    swagger_version: str = "0.14.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/services/dataset_services/publish_dataset.py
+++ b/api/services/dataset_services/publish_dataset.py
@@ -27,6 +27,27 @@ EXCLUDED_FIELDS = {
     "organization",
 }
 
+SUBMITTED_STATUS_EXTRA = {"key": "status", "value": "submitted"}
+
+
+def _with_submitted_status(
+    extras: Optional[List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    """
+    Return a new extras list carrying ``status=submitted``.
+
+    Any pre-existing ``status`` entry is dropped so that re-publishing a
+    previously approved or rejected dataset always resets it to a fresh
+    submission.
+    """
+    cleaned = [
+        extra
+        for extra in (extras or [])
+        if not (isinstance(extra, dict) and extra.get("key") == "status")
+    ]
+    cleaned.append(dict(SUBMITTED_STATUS_EXTRA))
+    return cleaned
+
 
 def publish_dataset_to_preckan(
     dataset_id: str,
@@ -105,6 +126,11 @@ def publish_dataset_to_preckan(
                     f"Could not resolve owner_org '{owner_org}', using as-is"
                 )
 
+    # Mark the Pre-CKAN copy as freshly submitted for review. Any previous
+    # status entry is dropped so re-published datasets always go back to
+    # the start of the review queue.
+    dataset_dict["extras"] = _with_submitted_status(dataset_dict.get("extras"))
+
     # Extract resources to create separately
     resources = dataset_dict.pop("resources", [])
 
@@ -153,6 +179,21 @@ def publish_dataset_to_preckan(
                 "does not exist in PRE-CKAN. Create it first."
             )
         raise Exception(f"Error creating dataset in PRE-CKAN: {error_msg}")
+
+    # Mirror the submitted status on the local dataset so the originating
+    # Endpoint can tell which of its datasets are already pending review.
+    # A failure here must not undo the Pre-CKAN creation, so it is logged
+    # and swallowed.
+    try:
+        local_repository.package_patch(
+            id=dataset_id,
+            extras=_with_submitted_status(dataset.get("extras")),
+        )
+        logger.info(f"Local dataset '{dataset_id}' marked as submitted in extras")
+    except Exception as exc:
+        logger.warning(
+            f"Failed to mark local dataset '{dataset_id}' as submitted: " f"{str(exc)}"
+        )
 
     # Create resources in PRE-CKAN
     for resource in cleaned_resources:

--- a/tests/test_publish_dataset_service.py
+++ b/tests/test_publish_dataset_service.py
@@ -1,0 +1,262 @@
+# tests/test_publish_dataset_service.py
+"""
+Tests for publish_dataset_to_preckan service, focusing on the
+``status=submitted`` extra written to both the Pre-CKAN copy and the
+original local dataset.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.services.dataset_services.publish_dataset import (
+    SUBMITTED_STATUS_EXTRA,
+    _with_submitted_status,
+    publish_dataset_to_preckan,
+)
+
+
+class TestWithSubmittedStatus:
+    """Helper that produces an extras list carrying status=submitted."""
+
+    def test_none_input_returns_only_status(self):
+        result = _with_submitted_status(None)
+        assert result == [SUBMITTED_STATUS_EXTRA]
+
+    def test_empty_list_returns_only_status(self):
+        result = _with_submitted_status([])
+        assert result == [SUBMITTED_STATUS_EXTRA]
+
+    def test_preserves_other_extras(self):
+        existing = [
+            {"key": "ndp_user_id", "value": "abc123"},
+            {"key": "ndp_group_id", "value": "my-org"},
+        ]
+        result = _with_submitted_status(existing)
+        assert {"key": "ndp_user_id", "value": "abc123"} in result
+        assert {"key": "ndp_group_id", "value": "my-org"} in result
+        assert SUBMITTED_STATUS_EXTRA in result
+        assert len(result) == 3
+
+    def test_replaces_existing_status_entry(self):
+        existing = [
+            {"key": "status", "value": "approved"},
+            {"key": "ndp_user_id", "value": "abc123"},
+        ]
+        result = _with_submitted_status(existing)
+        status_entries = [e for e in result if e.get("key") == "status"]
+        assert status_entries == [SUBMITTED_STATUS_EXTRA]
+        assert {"key": "ndp_user_id", "value": "abc123"} in result
+
+    def test_does_not_mutate_input(self):
+        existing = [{"key": "status", "value": "approved"}]
+        original_snapshot = [dict(item) for item in existing]
+        _with_submitted_status(existing)
+        assert existing == original_snapshot
+
+
+def _build_mocks(
+    monkeypatch_settings_path="api.services.dataset_services.publish_dataset",
+    pre_ckan_enabled=True,
+    pre_ckan_organization=None,
+    local_dataset=None,
+    package_create_side_effect=None,
+    package_patch_side_effect=None,
+):
+    """Build the standard mock setup used by the publish tests."""
+    local_repo = MagicMock(name="local_repo")
+    local_repo.package_show.return_value = local_dataset or {
+        "id": "local-id-1",
+        "name": "my-dataset",
+        "title": "My Dataset",
+        "owner_org": "my-org",
+        "extras": [],
+        "resources": [],
+    }
+    if package_patch_side_effect is not None:
+        local_repo.package_patch.side_effect = package_patch_side_effect
+
+    preckan_repo = MagicMock(name="preckan_repo")
+    if package_create_side_effect is not None:
+        preckan_repo.package_create.side_effect = package_create_side_effect
+    else:
+        preckan_repo.package_create.return_value = {"id": "preckan-id-1"}
+
+    return local_repo, preckan_repo
+
+
+class TestPublishDatasetToPreckan:
+    """End-to-end behaviour of the publish service."""
+
+    @patch("api.services.dataset_services.publish_dataset.CKANRepository")
+    @patch("api.services.dataset_services.publish_dataset.ckan_settings")
+    @patch("api.services.dataset_services.publish_dataset.catalog_settings")
+    def test_pre_ckan_disabled_raises(
+        self,
+        mock_catalog_settings,
+        mock_ckan_settings,
+        mock_ckan_repo_cls,
+    ):
+        mock_ckan_settings.pre_ckan_enabled = False
+
+        with pytest.raises(ValueError, match="PRE-CKAN is disabled"):
+            publish_dataset_to_preckan(dataset_id="any")
+
+        mock_ckan_repo_cls.assert_not_called()
+
+    @patch("api.services.dataset_services.publish_dataset.CKANRepository")
+    @patch("api.services.dataset_services.publish_dataset.ckan_settings")
+    @patch("api.services.dataset_services.publish_dataset.catalog_settings")
+    def test_dataset_not_found_raises(
+        self,
+        mock_catalog_settings,
+        mock_ckan_settings,
+        mock_ckan_repo_cls,
+    ):
+        mock_ckan_settings.pre_ckan_enabled = True
+        mock_ckan_settings.pre_ckan_organization = None
+
+        local_repo = MagicMock()
+        local_repo.package_show.side_effect = Exception("Not found")
+        mock_catalog_settings.local_catalog = local_repo
+        mock_ckan_repo_cls.return_value = MagicMock()
+
+        with pytest.raises(ValueError, match="Dataset not found"):
+            publish_dataset_to_preckan(dataset_id="missing")
+
+    @patch("api.services.dataset_services.publish_dataset.CKANRepository")
+    @patch("api.services.dataset_services.publish_dataset.ckan_settings")
+    @patch("api.services.dataset_services.publish_dataset.catalog_settings")
+    def test_successful_publish_sets_status_in_both_catalogs(
+        self,
+        mock_catalog_settings,
+        mock_ckan_settings,
+        mock_ckan_repo_cls,
+    ):
+        mock_ckan_settings.pre_ckan_enabled = True
+        mock_ckan_settings.pre_ckan_organization = "preckan-org"
+
+        local_repo, preckan_repo = _build_mocks(
+            local_dataset={
+                "id": "local-id-1",
+                "name": "my-dataset",
+                "title": "My Dataset",
+                "owner_org": "my-org",
+                "extras": [
+                    {"key": "ndp_user_id", "value": "user-hash"},
+                    {"key": "ndp_group_id", "value": "my-org"},
+                ],
+                "resources": [],
+            },
+        )
+        mock_catalog_settings.local_catalog = local_repo
+        mock_ckan_repo_cls.return_value = preckan_repo
+
+        result = publish_dataset_to_preckan(dataset_id="my-dataset")
+
+        assert result == "preckan-id-1"
+
+        # Pre-CKAN copy carries status=submitted alongside existing extras
+        preckan_extras = preckan_repo.package_create.call_args.kwargs["extras"]
+        assert SUBMITTED_STATUS_EXTRA in preckan_extras
+        assert {"key": "ndp_user_id", "value": "user-hash"} in preckan_extras
+        assert {"key": "ndp_group_id", "value": "my-org"} in preckan_extras
+
+        # Local dataset is patched with the same submitted status
+        local_repo.package_patch.assert_called_once()
+        patch_kwargs = local_repo.package_patch.call_args.kwargs
+        assert patch_kwargs["id"] == "my-dataset"
+        assert SUBMITTED_STATUS_EXTRA in patch_kwargs["extras"]
+        assert {"key": "ndp_user_id", "value": "user-hash"} in patch_kwargs["extras"]
+
+    @patch("api.services.dataset_services.publish_dataset.CKANRepository")
+    @patch("api.services.dataset_services.publish_dataset.ckan_settings")
+    @patch("api.services.dataset_services.publish_dataset.catalog_settings")
+    def test_republish_replaces_previous_status(
+        self,
+        mock_catalog_settings,
+        mock_ckan_settings,
+        mock_ckan_repo_cls,
+    ):
+        mock_ckan_settings.pre_ckan_enabled = True
+        mock_ckan_settings.pre_ckan_organization = None
+
+        local_repo, preckan_repo = _build_mocks(
+            local_dataset={
+                "id": "local-id-1",
+                "name": "my-dataset",
+                "title": "My Dataset",
+                "owner_org": "my-org",
+                "extras": [
+                    {"key": "status", "value": "approved"},
+                    {"key": "ndp_user_id", "value": "user-hash"},
+                ],
+                "resources": [],
+            },
+        )
+        # organization_show is consulted when pre_ckan_organization is None
+        local_repo.organization_show.return_value = {"name": "my-org"}
+        mock_catalog_settings.local_catalog = local_repo
+        mock_ckan_repo_cls.return_value = preckan_repo
+
+        publish_dataset_to_preckan(dataset_id="my-dataset")
+
+        # The Pre-CKAN copy must carry exactly one status entry, equal to
+        # submitted — the previous "approved" must be gone.
+        preckan_extras = preckan_repo.package_create.call_args.kwargs["extras"]
+        status_entries = [e for e in preckan_extras if e.get("key") == "status"]
+        assert status_entries == [SUBMITTED_STATUS_EXTRA]
+
+        # Same invariant on the local patch
+        patch_kwargs = local_repo.package_patch.call_args.kwargs
+        local_status_entries = [
+            e for e in patch_kwargs["extras"] if e.get("key") == "status"
+        ]
+        assert local_status_entries == [SUBMITTED_STATUS_EXTRA]
+
+    @patch("api.services.dataset_services.publish_dataset.CKANRepository")
+    @patch("api.services.dataset_services.publish_dataset.ckan_settings")
+    @patch("api.services.dataset_services.publish_dataset.catalog_settings")
+    def test_preckan_failure_leaves_local_untouched(
+        self,
+        mock_catalog_settings,
+        mock_ckan_settings,
+        mock_ckan_repo_cls,
+    ):
+        mock_ckan_settings.pre_ckan_enabled = True
+        mock_ckan_settings.pre_ckan_organization = "preckan-org"
+
+        local_repo, preckan_repo = _build_mocks(
+            package_create_side_effect=Exception("That name is already in use"),
+        )
+        mock_catalog_settings.local_catalog = local_repo
+        mock_ckan_repo_cls.return_value = preckan_repo
+
+        with pytest.raises(ValueError, match="already exists in PRE-CKAN"):
+            publish_dataset_to_preckan(dataset_id="my-dataset")
+
+        local_repo.package_patch.assert_not_called()
+
+    @patch("api.services.dataset_services.publish_dataset.CKANRepository")
+    @patch("api.services.dataset_services.publish_dataset.ckan_settings")
+    @patch("api.services.dataset_services.publish_dataset.catalog_settings")
+    def test_local_patch_failure_does_not_undo_preckan(
+        self,
+        mock_catalog_settings,
+        mock_ckan_settings,
+        mock_ckan_repo_cls,
+    ):
+        mock_ckan_settings.pre_ckan_enabled = True
+        mock_ckan_settings.pre_ckan_organization = "preckan-org"
+
+        local_repo, preckan_repo = _build_mocks(
+            package_patch_side_effect=Exception("read-only"),
+        )
+        mock_catalog_settings.local_catalog = local_repo
+        mock_ckan_repo_cls.return_value = preckan_repo
+
+        # Should still return the new Pre-CKAN id even though the local
+        # patch failed (best-effort mirroring).
+        result = publish_dataset_to_preckan(dataset_id="my-dataset")
+        assert result == "preckan-id-1"
+        local_repo.package_patch.assert_called_once()


### PR DESCRIPTION
Closes #112.

## Summary

When a dataset is published from the local catalog to Pre-CKAN via `POST /dataset/{dataset_id}/publish`, both copies are now tagged with a `status=submitted` entry in their `extras` so the review workflow has a consistent marker on each side.

## Behaviour

- The Pre-CKAN copy created by `package_create` carries `{"key": "status", "value": "submitted"}` in its `extras`, alongside any existing entries (`ndp_user_id`, `ndp_group_id`, `ndp_creator_md5`, user-provided extras).
- The original local dataset is patched with the same status entry via `package_patch`, so the originating Endpoint can tell which of its datasets are pending review.
- Re-publishing a dataset that already had a `status` entry (for example `approved` or `rejected`) replaces it with `submitted`, since this represents a fresh submission.
- If the Pre-CKAN creation fails, the local dataset is left untouched.
- If the local patch fails after a successful Pre-CKAN creation, the failure is logged as a warning and the publish still returns success — the Pre-CKAN copy is the source of truth for the review workflow.

## Test plan

- [x] `docker compose exec api python -m pytest tests/ -v` — 1112 passed
- [x] `flake8 api/services/dataset_services/publish_dataset.py tests/test_publish_dataset_service.py --max-line-length=88` — clean
- [x] `black --check` on the modified files — clean
- [x] New unit tests in `tests/test_publish_dataset_service.py` cover:
  - `_with_submitted_status` helper (None, empty, preserve other extras, replace existing status, no input mutation)
  - Successful publish writes `status=submitted` to both the Pre-CKAN copy and the local dataset, preserving existing extras
  - Re-publish replaces a previous `status=approved` with `submitted` on both sides
  - Pre-CKAN creation failure leaves the local dataset untouched (no `package_patch` call)
  - Local `package_patch` failure does not undo the Pre-CKAN creation (publish still returns the new id)