### PR TITLE
Document CKAN_VERIFY_SSL and PRE_CKAN_VERIFY_SSL in example.env (v0.15.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-04-26
+
+### Fixed
+- `example.env` now documents `CKAN_VERIFY_SSL` and `PRE_CKAN_VERIFY_SSL`, the existing settings that toggle TLS certificate verification for the local CKAN and Pre-CKAN instances. Both default to `True` in code, so behavior is unchanged; this only makes the option discoverable for operators running against a self-signed CKAN.
+
 ## [0.15.0] - 2026-04-26
 
 ### Changed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.15.0"
+    swagger_version: str = "0.15.1"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/example.env
+++ b/example.env
@@ -80,6 +80,12 @@ CKAN_URL=
 # API Key for CKAN authentication (Required only for CKAN backend)
 CKAN_API_KEY=
 
+# Verify the local CKAN TLS certificate (True/False, default: True)
+# Set to False when CKAN_URL points to an instance with a self-signed
+# or otherwise untrusted certificate (e.g. local/dev clusters). Disabling
+# verification reduces security, so keep it True in production.
+CKAN_VERIFY_SSL=True
+
 # ==============================================
 # MongoDB Configuration (if LOCAL_CATALOG_BACKEND=mongodb)
 # ==============================================
@@ -104,6 +110,10 @@ PRE_CKAN_URL=
 
 # API key for Pre-CKAN authentication (Optional)
 PRE_CKAN_API_KEY=
+
+# Verify the Pre-CKAN TLS certificate (True/False, default: True)
+# Same semantics as CKAN_VERIFY_SSL but for the Pre-CKAN instance defined above.
+PRE_CKAN_VERIFY_SSL=True
 
 # Organization name for Pre-CKAN (Optional)
 # When set, this organization will be used for all datasets published to PRE-CKAN,


### PR DESCRIPTION
## Summary

Both `CKAN_VERIFY_SSL` and `PRE_CKAN_VERIFY_SSL` already exist in `api/config/ckan_settings.py` (default `True`) and are applied to every CKAN / Pre-CKAN session through the shared `_get_session` helper, but neither was listed in `example.env`. As a result, operators running this Endpoint against a CKAN instance with a self-signed or otherwise untrusted certificate had no easy way to discover the toggle and would just see SSL verification failures (e.g. in the metrics task and other internal CKAN reads).

This PR only adds documentation — no behavior change. Defaults stay at `True` so production deployments remain secure by default; deployments using self-signed certificates can now opt out by setting `CKAN_VERIFY_SSL=False` (and `PRE_CKAN_VERIFY_SSL=False`) in their `.env`.

## Changes

- `example.env`: add `CKAN_VERIFY_SSL=True` under the CKAN section and `PRE_CKAN_VERIFY_SSL=True` under the Pre-CKAN section, each with a comment explaining when to flip them off.
- `api/config/swagger_settings.py`: bump `swagger_version` to `0.15.1`.
- `CHANGELOG.md`: add `0.15.1` entry under **Fixed**.

Closes #49.

## Test plan

- [x] Full test suite passes inside the api container (`docker compose exec api python -m pytest tests/` → 1112 passed)
- [ ] Verify `/docs` reports version `0.15.1` after deploy
- [ ] Verify a deployment with `CKAN_VERIFY_SSL=False` no longer raises `SSLCertVerificationError` against a self-signed CKAN