### PR TITLE
Guide users through dataset resources without forcing them to write JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-04-26
+
+### Changed
+- Dataset Management page: the "Resources" input on the Create/Edit dataset form no longer requires the user to write JSON
+  - Default editor is a guided list of resource cards with URL, Name, Format and Description inputs and Add/Remove controls, mirroring the field set already exposed by the inline resource editor on the dataset detail row
+  - An "Advanced (JSON)" toggle still exposes the raw textarea for resources that need fields the simple editor does not show (mimetype, size, …)
+  - When editing an existing dataset, each resource is loaded into a card and any non-canonical fields it carries are preserved on save, so a fields-mode round-trip never silently drops data
+  - Switching back from JSON to fields is blocked with an inline message when the JSON is invalid, is not an array, or contains non-object items, so the user is never silently downgraded
+
 ## [0.15.1] - 2026-04-26
 
 ### Fixed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.15.1"
+    swagger_version: str = "0.16.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/pages/DatasetManagement.js
+++ b/ui/src/pages/DatasetManagement.js
@@ -850,17 +850,135 @@ const DatasetManagement = () => {
               </div>
 
               <div className="form-group">
-                <label className="form-label">Resources (JSON)</label>
-                <textarea
-                  value={resourcesJson}
-                  onChange={(e) => setResourcesJson(e.target.value)}
-                  className="form-input form-textarea"
-                  placeholder='[{"url": "http://example.com/data.csv", "name": "main_data", "format": "CSV"}]'
-                  style={{ fontFamily: 'monospace', fontSize: '0.875rem', minHeight: '120px' }}
-                />
-                <small style={{ color: '#64748b' }}>
-                  List of resources as JSON array
-                </small>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.25rem' }}>
+                  <label className="form-label" style={{ marginBottom: 0 }}>Resources</label>
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    style={{ fontSize: '0.75rem', padding: '0.25rem 0.5rem' }}
+                    onClick={resourcesMode === 'fields' ? switchResourcesToJsonMode : switchResourcesToFieldsMode}
+                  >
+                    {resourcesMode === 'fields' ? 'Advanced (JSON)' : 'Simple fields'}
+                  </button>
+                </div>
+
+                {resourcesMode === 'fields' ? (
+                  <>
+                    {resourcesItems.length === 0 ? (
+                      <small style={{ color: '#64748b', display: 'block', marginBottom: '0.5rem' }}>
+                        No resources. Click "Add resource" to attach one.
+                      </small>
+                    ) : (
+                      resourcesItems.map((item, idx) => (
+                        <div
+                          key={idx}
+                          style={{
+                            border: '1px solid #e2e8f0',
+                            borderRadius: '6px',
+                            padding: '0.75rem',
+                            marginBottom: '0.5rem',
+                            background: '#f8fafc'
+                          }}
+                        >
+                          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
+                            <small style={{ color: '#64748b', fontWeight: 500 }}>
+                              Resource {idx + 1}
+                            </small>
+                            <button
+                              type="button"
+                              onClick={() => removeResourceItem(idx)}
+                              className="btn btn-secondary"
+                              style={{ padding: '0.25rem 0.5rem', fontSize: '0.75rem' }}
+                              aria-label="Remove resource"
+                            >
+                              <Trash2 size={12} />
+                              Remove
+                            </button>
+                          </div>
+
+                          <div className="form-group" style={{ marginBottom: '0.5rem' }}>
+                            <label className="form-label" style={{ fontSize: '0.8rem' }}>URL *</label>
+                            <input
+                              type="text"
+                              value={item.url}
+                              onChange={(e) => updateResourceItem(idx, 'url', e.target.value)}
+                              className="form-input"
+                              placeholder="http://example.com/data.csv"
+                              style={{ padding: '0.5rem' }}
+                            />
+                          </div>
+
+                          <div className="grid grid-2" style={{ marginBottom: '0.5rem' }}>
+                            <div className="form-group" style={{ marginBottom: 0 }}>
+                              <label className="form-label" style={{ fontSize: '0.8rem' }}>Name *</label>
+                              <input
+                                type="text"
+                                value={item.name}
+                                onChange={(e) => updateResourceItem(idx, 'name', e.target.value)}
+                                className="form-input"
+                                placeholder="main_data"
+                                style={{ padding: '0.5rem' }}
+                              />
+                            </div>
+                            <div className="form-group" style={{ marginBottom: 0 }}>
+                              <label className="form-label" style={{ fontSize: '0.8rem' }}>Format</label>
+                              <input
+                                type="text"
+                                value={item.format}
+                                onChange={(e) => updateResourceItem(idx, 'format', e.target.value)}
+                                className="form-input"
+                                placeholder="CSV"
+                                style={{ padding: '0.5rem' }}
+                              />
+                            </div>
+                          </div>
+
+                          <div className="form-group" style={{ marginBottom: 0 }}>
+                            <label className="form-label" style={{ fontSize: '0.8rem' }}>Description</label>
+                            <textarea
+                              value={item.description}
+                              onChange={(e) => updateResourceItem(idx, 'description', e.target.value)}
+                              className="form-input"
+                              placeholder="What is in this resource"
+                              style={{ padding: '0.5rem', minHeight: '50px' }}
+                            />
+                          </div>
+                        </div>
+                      ))
+                    )}
+                    <button
+                      type="button"
+                      onClick={addResourceItem}
+                      className="btn btn-secondary"
+                      style={{ fontSize: '0.875rem' }}
+                    >
+                      <Plus size={14} />
+                      Add resource
+                    </button>
+                    <small style={{ color: '#64748b', display: 'block', marginTop: '0.5rem' }}>
+                      Each resource is a downloadable file or link attached to the dataset.
+                    </small>
+                  </>
+                ) : (
+                  <>
+                    <textarea
+                      value={resourcesJson}
+                      onChange={(e) => setResourcesJson(e.target.value)}
+                      className="form-input form-textarea"
+                      placeholder='[{"url": "http://example.com/data.csv", "name": "main_data", "format": "CSV"}]'
+                      style={{ fontFamily: 'monospace', fontSize: '0.875rem', minHeight: '120px' }}
+                    />
+                    <small style={{ color: '#64748b' }}>
+                      List of resources as JSON array. Use this to set fields the simple editor does not expose (mimetype, size, …).
+                    </small>
+                  </>
+                )}
+
+                {resourcesModeError && (
+                  <small style={{ color: '#dc2626', display: 'block', marginTop: '0.5rem' }}>
+                    {resourcesModeError}
+                  </small>
+                )}
               </div>
             </div>
 

--- a/ui/src/pages/DatasetManagement.js
+++ b/ui/src/pages/DatasetManagement.js
@@ -127,6 +127,102 @@ const DatasetManagement = () => {
     setExtrasModeError(null);
   };
 
+  // Resources editor: 'fields' for guided cards, 'json' for raw JSON array
+  const [resourcesMode, setResourcesMode] = useState('fields');
+  const [resourcesItems, setResourcesItems] = useState([]);
+  const [resourcesModeError, setResourcesModeError] = useState(null);
+
+  // The guided editor exposes the canonical resource fields. Anything else
+  // present on a loaded resource (mimetype, size, server-managed ids, …) is
+  // kept untouched in `_extra` so a fields-mode round-trip never drops data.
+  const SIMPLE_RESOURCE_FIELDS = ['name', 'url', 'format', 'description'];
+
+  const emptyResourceItem = () => ({
+    name: '',
+    url: '',
+    format: '',
+    description: '',
+    _extra: {}
+  });
+
+  const resourceToItem = (resource) => {
+    const item = emptyResourceItem();
+    if (!resource || typeof resource !== 'object') return item;
+    for (const [key, value] of Object.entries(resource)) {
+      if (SIMPLE_RESOURCE_FIELDS.includes(key)) {
+        item[key] = value === null || value === undefined ? '' : String(value);
+      } else {
+        item._extra[key] = value;
+      }
+    }
+    return item;
+  };
+
+  const itemToResource = (item) => {
+    const out = { ...(item._extra || {}) };
+    for (const f of SIMPLE_RESOURCE_FIELDS) {
+      if (item[f] !== undefined && item[f] !== null && item[f] !== '') {
+        out[f] = item[f];
+      }
+    }
+    return out;
+  };
+
+  const resourcesToItems = (resources) => {
+    if (!Array.isArray(resources)) return [];
+    return resources.map(resourceToItem);
+  };
+
+  const itemsToResources = (items) =>
+    items.map(itemToResource).filter((r) => Object.keys(r).length > 0);
+
+  const addResourceItem = () => {
+    setResourcesItems((prev) => [...prev, emptyResourceItem()]);
+    setResourcesModeError(null);
+  };
+
+  const removeResourceItem = (idx) => {
+    setResourcesItems((prev) => prev.filter((_, i) => i !== idx));
+  };
+
+  const updateResourceItem = (idx, field, value) => {
+    setResourcesItems((prev) =>
+      prev.map((r, i) => (i === idx ? { ...r, [field]: value } : r))
+    );
+  };
+
+  const switchResourcesToJsonMode = () => {
+    const arr = itemsToResources(resourcesItems);
+    setResourcesJson(JSON.stringify(arr, null, 2));
+    setResourcesMode('json');
+    setResourcesModeError(null);
+  };
+
+  const switchResourcesToFieldsMode = () => {
+    let parsed;
+    try {
+      parsed = resourcesJson.trim() === '' ? [] : JSON.parse(resourcesJson);
+    } catch {
+      setResourcesModeError('Cannot switch to simple fields: the JSON is invalid.');
+      return;
+    }
+    if (!Array.isArray(parsed)) {
+      setResourcesModeError(
+        'Cannot switch to simple fields: resources must be a JSON array.'
+      );
+      return;
+    }
+    if (!parsed.every((r) => r && typeof r === 'object' && !Array.isArray(r))) {
+      setResourcesModeError(
+        'Cannot switch to simple fields: every resource must be a JSON object.'
+      );
+      return;
+    }
+    setResourcesItems(resourcesToItems(parsed));
+    setResourcesMode('fields');
+    setResourcesModeError(null);
+  };
+
   /**
    * Fetch organizations for dropdown
    */

--- a/ui/src/pages/DatasetManagement.js
+++ b/ui/src/pages/DatasetManagement.js
@@ -343,6 +343,9 @@ const DatasetManagement = () => {
     setExtrasMode('fields');
     setExtrasPairs([]);
     setExtrasModeError(null);
+    setResourcesMode('fields');
+    setResourcesItems([]);
+    setResourcesModeError(null);
     setEditingDataset(null);
     setShowCreateForm(false);
   };
@@ -355,7 +358,9 @@ const DatasetManagement = () => {
     const extras = extrasMode === 'fields'
       ? pairsToObject(extrasPairs)
       : parseJsonSafely(extrasJson, {});
-    const resources = parseJsonSafely(resourcesJson, []);
+    const resources = resourcesMode === 'fields'
+      ? itemsToResources(resourcesItems)
+      : parseJsonSafely(resourcesJson, []);
 
     // Prepare final data
     const requestData = {
@@ -444,8 +449,9 @@ const DatasetManagement = () => {
     
     // Set JSON fields
     const extras = dataset.extras || {};
+    const resources = dataset.resources || [];
     setExtrasJson(JSON.stringify(extras, null, 2));
-    setResourcesJson(JSON.stringify(dataset.resources || [], null, 2));
+    setResourcesJson(JSON.stringify(resources, null, 2));
 
     // Default the extras editor to guided fields when the data is a flat
     // primitive map; fall back to raw JSON for nested/non-text values.
@@ -457,6 +463,12 @@ const DatasetManagement = () => {
       setExtrasMode('json');
     }
     setExtrasModeError(null);
+
+    // Resources always default to guided cards. Unknown fields are kept in
+    // each item's _extra bucket so they survive the round-trip.
+    setResourcesItems(resourcesToItems(resources));
+    setResourcesMode('fields');
+    setResourcesModeError(null);
 
     setShowCreateForm(true);
   };


### PR DESCRIPTION
Closes #117.

## Summary
- The "Resources" input on the Create/Edit dataset form is now a guided list of resource cards, each with URL, Name, Format and Description inputs plus Add/Remove controls. The field set mirrors the inline resource editor already used on the dataset detail row.
- An "Advanced (JSON)" toggle still exposes the original raw textarea, so users that need to set fields the simple editor does not expose (mimetype, size, …) can still do it.
- When editing an existing dataset, each resource loads into a card and any non-canonical fields ride along in a hidden bucket, so a fields-mode round-trip preserves data the editor does not visually expose.
- The toggle blocks switching back to fields when the JSON is invalid, is not an array, or contains non-object items, with an inline explanation, so users are never silently downgraded.

## Test plan
- [x] `docker compose exec api python -m pytest tests/ -v` (1112 passed)
- [x] UI production build with `CI=true` (no warnings)
- [x] Manual: create a dataset with two resource cards (URL/Name/Format/Description), verify persisted
- [x] Manual: edit a dataset → opens in fields mode, cards pre-populated
- [x] Manual: round-trip a resource carrying mimetype through the fields editor → mimetype preserved on save
- [x] Manual: toggle to JSON and edit, then toggle back; with `{}` instead of an array → blocked with inline message
- [x] Manual: card with empty url+name on submit → not sent to backend
- [x] Manual: existing inline resource editor on the dataset detail row still works as before