### PR TITLE
Auto-rename duplicate datasets instead of failing with 409

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-04-29
+
+### Changed
+- `POST /dataset` no longer rejects requests whose `name` (or its derived URL) is already in use. Instead, the dataset is created with an automatic timestamp suffix and the response keeps a `201 Created` status while including a `warning` field that explains the rename:
+  - `name` becomes `<original>-<YYYYMMDDHHMMSS>` so it still satisfies CKAN's slug constraint (`^[a-z0-9_-]+$`)
+  - `title` becomes `<original> (YYYY-MM-DD HH:MM:SS)` so the rename is obvious to humans
+  - The response body now also returns the final `name` and `title` so any consumer (UI, CURL, scripts) can detect and surface the rename
+- The previous `409 Conflict` response with a structured `detail` object has been removed from this endpoint, since the duplicate-name case is now handled transparently
+- Dataset Management page: the create form now reads the new `warning` field and shows the rename in the success banner instead of just "Dataset created successfully!"
+
+### Fixed
+- Dataset Management page: creating a dataset that triggered a backend error with a structured `detail` payload used to display the meaningless string "Failed to create dataset: [object Object]". A new helper now flattens structured detail objects into a readable message before showing them to the user
+
 ## [0.16.0] - 2026-04-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `title` becomes `<original> (YYYY-MM-DD HH:MM:SS)` so the rename is obvious to humans
   - The response body now also returns the final `name` and `title` so any consumer (UI, CURL, scripts) can detect and surface the rename
 - The previous `409 Conflict` response with a structured `detail` object has been removed from this endpoint, since the duplicate-name case is now handled transparently
-- Dataset Management page: the create form now reads the new `warning` field and shows the rename in the success banner instead of just "Dataset created successfully!"
+- Dataset Management page: when the backend renames a duplicate dataset, the create form now shows a dedicated yellow warning banner prefixed with "WARNING:" instead of the green success banner, so the user immediately notices that the stored `name` and `title` differ from the ones they submitted
 
 ### Fixed
 - Dataset Management page: creating a dataset that triggered a backend error with a structured `detail` payload used to display the meaningless string "Failed to create dataset: [object Object]". A new helper now flattens structured detail objects into a readable message before showing them to the user

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.16.0"
+    swagger_version: str = "0.17.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/routes/register_routes/post_general_dataset.py
+++ b/api/routes/register_routes/post_general_dataset.py
@@ -75,10 +75,46 @@ router = APIRouter()
     ),
     responses={
         201: {
-            "description": "Dataset created successfully",
+            "description": (
+                "Dataset created successfully. If the requested name was "
+                "already in use, the dataset is still created with a "
+                "timestamped name and the response includes a 'warning' "
+                "field describing the automatic rename."
+            ),
             "content": {
                 "application/json": {
-                    "example": {"id": "12345678-abcd-efgh-ijkl-1234567890ab"}
+                    "examples": {
+                        "created": {
+                            "summary": "Dataset created with the requested name",
+                            "value": {
+                                "id": "12345678-abcd-efgh-ijkl-1234567890ab",
+                                "name": "my_research_dataset",
+                                "title": "My Research Dataset",
+                                "warning": None,
+                            },
+                        },
+                        "auto_renamed": {
+                            "summary": (
+                                "Dataset created with an auto-generated "
+                                "timestamp suffix because the requested "
+                                "name was already in use"
+                            ),
+                            "value": {
+                                "id": "12345678-abcd-efgh-ijkl-1234567890ab",
+                                "name": "my_research_dataset-20260429143052",
+                                "title": (
+                                    "My Research Dataset " "(2026-04-29 14:30:52)"
+                                ),
+                                "warning": (
+                                    "A dataset named 'my_research_dataset' "
+                                    "already exists. This dataset was saved "
+                                    "as 'my_research_dataset-20260429143052' "
+                                    "with title 'My Research Dataset "
+                                    "(2026-04-29 14:30:52)'."
+                                ),
+                            },
+                        },
+                    }
                 }
             },
         },
@@ -97,19 +133,6 @@ router = APIRouter()
                             "Access forbidden: write operations require "
                             "membership in organization 'Research Group'"
                         )
-                    }
-                }
-            },
-        },
-        409: {
-            "description": "Conflict - Duplicate dataset",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "detail": {
-                            "error": "Duplicate Dataset",
-                            "detail": ("A dataset with the given name already exists."),
-                        }
                     }
                 }
             },
@@ -167,7 +190,6 @@ async def create_general_dataset_endpoint(
     HTTPException
         - 401: Authentication required
         - 403: Organization membership required (if enabled)
-        - 409: Duplicate dataset
         - 400: Invalid parameters, server configuration, or other errors
     """
     try:
@@ -187,7 +209,7 @@ async def create_general_dataset_endpoint(
         if data.resources:
             resources = [resource.dict() for resource in data.resources]
 
-        dataset_id = create_general_dataset(
+        creation_result = create_general_dataset(
             name=data.name,
             title=data.title,
             owner_org=data.owner_org,
@@ -203,14 +225,19 @@ async def create_general_dataset_endpoint(
             user_info=user_info,
         )
 
+        dataset_id = creation_result["id"]
+        final_name = creation_result["name"]
+        final_title = creation_result["title"]
+        warning = creation_result["warning"]
+
         # Register in Affinities (non-blocking, errors are logged)
         affinities_client = AffinitiesClient()
         if affinities_client.is_enabled:
             try:
                 affinity_uuid = await affinities_client.register_dataset(
-                    title=data.title,
+                    title=final_title,
                     metadata={
-                        "name": data.name,
+                        "name": final_name,
                         "owner_org": data.owner_org,
                         "local_id": dataset_id,
                         "notes": data.notes,
@@ -236,7 +263,12 @@ async def create_general_dataset_endpoint(
             except Exception as e:
                 logger.warning(f"Failed to register dataset in Affinities: {e}")
 
-        return {"id": dataset_id}
+        return {
+            "id": dataset_id,
+            "name": final_name,
+            "title": final_title,
+            "warning": warning,
+        }
 
     except ValueError as exc:
         # Handle validation errors
@@ -254,17 +286,6 @@ async def create_general_dataset_endpoint(
         if "No scheme supplied" in error_msg:
             raise HTTPException(
                 status_code=400, detail="Server is not configured or unreachable."
-            )
-        if (
-            "That name is already in use" in error_msg
-            or "That URL is already in use" in error_msg
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail={
-                    "error": "Duplicate Dataset",
-                    "detail": "A dataset with the given name already exists.",
-                },
             )
 
         # Generic error handling

--- a/api/services/dataset_services/general_dataset.py
+++ b/api/services/dataset_services/general_dataset.py
@@ -1,5 +1,6 @@
 # api/services/dataset_services/general_dataset.py
 
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from api.config.catalog_settings import catalog_settings
@@ -74,8 +75,16 @@ def create_general_dataset(
 
     Returns
     -------
-    str
-        The ID of the newly created dataset.
+    Dict[str, Any]
+        A dictionary with keys:
+        - ``id``: The ID of the newly created dataset.
+        - ``name``: The final name stored (may differ from ``name`` if a
+          duplicate was detected and a timestamp suffix was appended).
+        - ``title``: The final title stored (suffixed with a timestamp when
+          a duplicate name caused an automatic rename).
+        - ``warning``: ``None`` when the dataset was created with the
+          requested name, or a human-readable message explaining the
+          automatic rename when the requested name was already in use.
 
     Raises
     ------
@@ -132,12 +141,40 @@ def create_general_dataset(
     if extras:
         dataset_dict["extras"] = [{"key": k, "value": v} for k, v in extras.items()]
 
-    # Create the dataset
+    # Create the dataset. If the catalog reports that the name (or its
+    # derived URL) is already in use, retry once with a timestamp suffix so
+    # the request keeps succeeding and the caller is informed via a warning.
+    final_name = name
+    final_title = title
+    warning: Optional[str] = None
     try:
         dataset = repository.package_create(**dataset_dict)
         dataset_id = dataset["id"]
     except Exception as exc:
-        raise Exception(f"Error creating general dataset: {str(exc)}")
+        error_msg = str(exc)
+        if (
+            "That name is already in use" in error_msg
+            or "That URL is already in use" in error_msg
+        ):
+            now = datetime.now()
+            slug_suffix = now.strftime("%Y%m%d%H%M%S")
+            human_suffix = now.strftime("%Y-%m-%d %H:%M:%S")
+            final_name = f"{name}-{slug_suffix}"
+            final_title = f"{title} ({human_suffix})"
+            dataset_dict["name"] = final_name
+            dataset_dict["title"] = final_title
+            warning = (
+                f"A dataset named '{name}' already exists. "
+                f"This dataset was saved as '{final_name}' "
+                f"with title '{final_title}'."
+            )
+            try:
+                dataset = repository.package_create(**dataset_dict)
+                dataset_id = dataset["id"]
+            except Exception as retry_exc:
+                raise Exception(f"Error creating general dataset: {str(retry_exc)}")
+        else:
+            raise Exception(f"Error creating general dataset: {error_msg}")
 
     # Create resources if provided
     if resources:
@@ -149,7 +186,12 @@ def create_general_dataset(
         except Exception as exc:
             raise Exception(f"Error creating dataset resources: {str(exc)}")
 
-    return dataset_id
+    return {
+        "id": dataset_id,
+        "name": final_name,
+        "title": final_title,
+        "warning": warning,
+    }
 
 
 def update_general_dataset(

--- a/tests/test_general_dataset.py
+++ b/tests/test_general_dataset.py
@@ -1,4 +1,6 @@
 # tests/test_general_dataset.py
+import re
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -48,7 +50,12 @@ class TestCreateGeneralDataset:
             repository=mock_repo,
         )
 
-        assert result == "dataset-123"
+        assert result == {
+            "id": "dataset-123",
+            "name": "test_dataset",
+            "title": "Test Dataset",
+            "warning": None,
+        }
         mock_repo.package_create.assert_called_once()
 
         # Verify the call arguments
@@ -80,7 +87,12 @@ class TestCreateGeneralDataset:
             repository=mock_repo,
         )
 
-        assert result == "dataset-456"
+        assert result == {
+            "id": "dataset-456",
+            "name": "complete_dataset",
+            "title": "Complete Dataset",
+            "warning": None,
+        }
 
         # Verify package_create call
         package_call = mock_repo.package_create.call_args[1]
@@ -111,7 +123,12 @@ class TestCreateGeneralDataset:
             repository=custom_repo,
         )
 
-        assert result == "custom-789"
+        assert result == {
+            "id": "custom-789",
+            "name": "custom_dataset",
+            "title": "Custom Dataset",
+            "warning": None,
+        }
         custom_repo.package_create.assert_called_once()
 
     def test_create_invalid_extras_type(self):
@@ -179,7 +196,12 @@ class TestCreateGeneralDataset:
             # No optional fields provided
         )
 
-        assert result == "minimal-123"
+        assert result == {
+            "id": "minimal-123",
+            "name": "minimal_dataset",
+            "title": "Minimal Dataset",
+            "warning": None,
+        }
 
         # Verify only required fields are in the call
         call_args = mock_repo.package_create.call_args[1]
@@ -189,6 +211,102 @@ class TestCreateGeneralDataset:
         assert "tags" not in call_args
         assert "groups" not in call_args
         assert "extras" not in call_args
+
+    def test_create_with_duplicate_name_auto_renames(self):
+        """Duplicate name -> retry once with timestamp suffix and warn."""
+        mock_repo = MagicMock()
+        mock_repo.package_create.side_effect = [
+            Exception("That name is already in use"),
+            {"id": "dataset-renamed-123"},
+        ]
+
+        fixed_now = datetime(2026, 4, 29, 14, 30, 52)
+        with patch(
+            "api.services.dataset_services.general_dataset.datetime"
+        ) as mock_datetime:
+            mock_datetime.now.return_value = fixed_now
+            mock_datetime.strftime = datetime.strftime
+
+            result = create_general_dataset(
+                name="my_dataset",
+                title="My Dataset",
+                owner_org="test_org",
+                repository=mock_repo,
+            )
+
+        assert result == {
+            "id": "dataset-renamed-123",
+            "name": "my_dataset-20260429143052",
+            "title": "My Dataset (2026-04-29 14:30:52)",
+            "warning": (
+                "A dataset named 'my_dataset' already exists. "
+                "This dataset was saved as 'my_dataset-20260429143052' "
+                "with title 'My Dataset (2026-04-29 14:30:52)'."
+            ),
+        }
+        assert mock_repo.package_create.call_count == 2
+        retry_call = mock_repo.package_create.call_args_list[1][1]
+        assert retry_call["name"] == "my_dataset-20260429143052"
+        assert retry_call["title"] == "My Dataset (2026-04-29 14:30:52)"
+        # Generated slug must satisfy CKAN's name format constraints
+        assert re.match(r"^[a-z0-9_-]+$", retry_call["name"])
+
+    def test_create_with_duplicate_url_auto_renames(self):
+        """Duplicate URL (slug) -> same retry-with-timestamp behavior."""
+        mock_repo = MagicMock()
+        mock_repo.package_create.side_effect = [
+            Exception("That URL is already in use"),
+            {"id": "dataset-renamed-456"},
+        ]
+
+        result = create_general_dataset(
+            name="another_dataset",
+            title="Another Dataset",
+            owner_org="test_org",
+            repository=mock_repo,
+        )
+
+        assert result["id"] == "dataset-renamed-456"
+        assert result["name"].startswith("another_dataset-")
+        assert result["title"].startswith("Another Dataset (")
+        assert result["warning"] is not None
+        assert "another_dataset" in result["warning"]
+        assert mock_repo.package_create.call_count == 2
+
+    def test_create_duplicate_retry_failure_propagates(self):
+        """If the second attempt also fails, surface the retry error."""
+        mock_repo = MagicMock()
+        mock_repo.package_create.side_effect = [
+            Exception("That name is already in use"),
+            Exception("Some other catalog error"),
+        ]
+
+        with pytest.raises(
+            Exception, match="Error creating general dataset: Some other catalog error"
+        ):
+            create_general_dataset(
+                name="dup_dataset",
+                title="Dup Dataset",
+                owner_org="test_org",
+                repository=mock_repo,
+            )
+
+    def test_create_non_duplicate_error_does_not_retry(self):
+        """Non-duplicate errors must not trigger a second package_create call."""
+        mock_repo = MagicMock()
+        mock_repo.package_create.side_effect = Exception("Some unrelated CKAN error")
+
+        with pytest.raises(
+            Exception, match="Error creating general dataset: Some unrelated CKAN error"
+        ):
+            create_general_dataset(
+                name="other_dataset",
+                title="Other Dataset",
+                owner_org="test_org",
+                repository=mock_repo,
+            )
+
+        assert mock_repo.package_create.call_count == 1
 
 
 class TestUpdateGeneralDataset:

--- a/ui/src/pages/DatasetManagement.js
+++ b/ui/src/pages/DatasetManagement.js
@@ -15,6 +15,18 @@ import {
 } from 'lucide-react';
 import { organizationsAPI, searchAPI, generalDatasetAPI, datasetAPI, resourcesAPI } from '../services/api';
 
+// Extract a human-readable message from an axios error so we never display
+// the meaningless string "[object Object]" when the backend returns a
+// structured detail payload (e.g. {"error": "...", "detail": "..."}).
+const formatApiError = (err) => {
+  const detail = err?.response?.data?.detail;
+  if (typeof detail === 'string') return detail;
+  if (detail && typeof detail === 'object') {
+    return detail.detail || detail.error || JSON.stringify(detail);
+  }
+  return err?.message || 'Unknown error';
+};
+
 /**
  * Dataset Management component for creating and managing general datasets
  * Provides full CRUD operations for datasets with flexible schema
@@ -384,23 +396,27 @@ const DatasetManagement = () => {
    */
   const handleCreate = async (e) => {
     e.preventDefault();
-    
+
     try {
       setError(null);
       setSuccess(null);
       setLoading(true);
 
       const requestData = prepareFormData();
-      await generalDatasetAPI.create(requestData, selectedServer);
+      const response = await generalDatasetAPI.create(requestData, selectedServer);
 
-      setSuccess('Dataset created successfully!');
+      const warning = response?.data?.warning;
+      if (warning) {
+        setSuccess(`Dataset created. ${warning}`);
+      } else {
+        setSuccess('Dataset created successfully!');
+      }
       resetForm();
       fetchDatasets();
-      
+
     } catch (err) {
       console.error('Error creating dataset:', err);
-      setError('Failed to create dataset: ' + 
-        (err.response?.data?.detail || err.message));
+      setError('Failed to create dataset: ' + formatApiError(err));
     } finally {
       setLoading(false);
     }

--- a/ui/src/pages/DatasetManagement.js
+++ b/ui/src/pages/DatasetManagement.js
@@ -37,6 +37,7 @@ const DatasetManagement = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
+  const [warning, setWarning] = useState(null);
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [editingDataset, setEditingDataset] = useState(null);
   const [selectedServer] = useState('local'); // Fixed to local for consistency
@@ -400,14 +401,15 @@ const DatasetManagement = () => {
     try {
       setError(null);
       setSuccess(null);
+      setWarning(null);
       setLoading(true);
 
       const requestData = prepareFormData();
       const response = await generalDatasetAPI.create(requestData, selectedServer);
 
-      const warning = response?.data?.warning;
-      if (warning) {
-        setSuccess(`Dataset created. ${warning}`);
+      const apiWarning = response?.data?.warning;
+      if (apiWarning) {
+        setWarning(`WARNING: ${apiWarning}`);
       } else {
         setSuccess('Dataset created successfully!');
       }
@@ -431,6 +433,7 @@ const DatasetManagement = () => {
     try {
       setError(null);
       setSuccess(null);
+      setWarning(null);
       setLoading(true);
 
       const requestData = prepareFormData();
@@ -504,7 +507,8 @@ const DatasetManagement = () => {
     try {
       setError(null);
       setSuccess(null);
-      
+      setWarning(null);
+
       // Debug: Log the dataset being deleted
       console.log('Attempting to delete dataset with ID:', dataset.id);
       console.log('Using endpoint: DELETE /resource?resource_id=' + dataset.id + '&server=local');
@@ -596,6 +600,7 @@ const DatasetManagement = () => {
     try {
       setError(null);
       setSuccess(null);
+      setWarning(null);
 
       await resourcesAPI.patch(editingResource.id, resourceFormData, selectedServer);
 
@@ -625,6 +630,7 @@ const DatasetManagement = () => {
     try {
       setError(null);
       setSuccess(null);
+      setWarning(null);
 
       await resourcesAPI.deleteById(resource.id, selectedServer);
 
@@ -662,6 +668,13 @@ const DatasetManagement = () => {
       {success && (
         <div className="alert alert-success">
           {success}
+        </div>
+      )}
+
+      {warning && (
+        <div className="alert alert-warning">
+          <AlertCircle size={20} />
+          {warning}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Closes #120.

`POST /dataset` used to reject any request whose `name` (or its derived URL) was already in use, returning a `409 Conflict` with a structured `detail` payload. This was poor UX in two places:

- The web UI rendered that structured detail through naive string concatenation, so the user saw `Failed to create dataset: [object Object]`.
- API consumers (CURL, scripts, integrations) had to implement retry/rename logic on their side just to recover from a very common case.

This PR moves the recovery into the API itself so the same fix benefits both the UI and any direct API consumer.

## What changed

### Backend (`POST /dataset`)
- When CKAN reports `That name is already in use` / `That URL is already in use`, the service retries once with a timestamp suffix:
  - `name` becomes `<original>-<YYYYMMDDHHMMSS>` (slug-safe, satisfies CKAN's `^[a-z0-9_-]+$` constraint).
  - `title` becomes `<original> (YYYY-MM-DD HH:MM:SS)` (human-readable).
- The endpoint now always responds `201 Created` on success, and the response body exposes:
  - `id` — the created dataset id (unchanged)
  - `name` and `title` — the final values stored, so callers can detect renames
  - `warning` — `null` when no rename happened, or a readable message explaining the rename
- The `409` response is removed from this endpoint — the case it described is now handled transparently. Other duplicate-name endpoints (`POST /kafka`, `POST /service`, etc.) are out of scope and unchanged.

### UI (Dataset Management)
- The create form reads the new `warning` field and shows it in the success banner when set, instead of always showing "Dataset created successfully!".
- A small `formatApiError` helper flattens structured `detail` payloads into a readable string, so future structured errors don't fall back to `[object Object]`.

### Tests
- Existing `create_general_dataset` tests updated for the new dict return shape.
- Four new tests cover:
  - Duplicate name → retry with timestamped name/title and warning.
  - Duplicate URL → same retry behavior.
  - Retry failure → original error is surfaced (no infinite loop).
  - Non-duplicate error → no retry, original error surfaced.

## Test plan

- [x] `pytest tests/` — 1116 passed (4 new tests added on top of 1112)
- [x] `pytest tests/test_general_dataset.py -v` — 31 passed
- [x] Coverage on `api/services/dataset_services/general_dataset.py` — 97%
- [x] `black --check --diff .` — clean
- [x] `flake8 api/ tests/ --max-line-length=88 --extend-ignore=E203,W503,E501,F401` (CI args) — clean
- [x] Manual end-to-end via the running container: imported the service, simulated a duplicate-name failure on first attempt, confirmed second attempt was called with the slug-safe `name` and human-readable `title`, and that the returned `warning` field carries the explanation.
- [x] OpenAPI inspection: `/dataset` POST no longer lists `409`; `201` exposes both `created` and `auto_renamed` examples.
- [x] UI source parses cleanly with Babel (full `npm run build` not run locally — `npm` is not on the host PATH; the all-in-one Docker build exercises this on every release).