### PR TITLE
Drop the empty 'Controls' card from resource pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-04-29
+
+### Removed
+- Dataset Management, Kafka Topics, URL Resources and S3 Resources pages: the "Controls" card that wrapped the create / refresh buttons (and showed a static "📍 Local Server Only" badge) has been removed. The page header now flows directly into the action buttons, which removes visual weight that was not carrying any function
+
 ## [0.17.0] - 2026-04-29
 
 ### Changed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.17.0"
+    swagger_version: str = "0.17.1"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/pages/DatasetManagement.js
+++ b/ui/src/pages/DatasetManagement.js
@@ -678,30 +678,15 @@ const DatasetManagement = () => {
         </div>
       )}
 
-      {/* Controls */}
-      <div className="card">
-        <div className="card-header">
-          <h3 className="card-title">Controls</h3>
-          <div style={{ display: 'flex', gap: '0.5rem' }}>
-            <span style={{ 
-              fontSize: '0.875rem', 
-              color: '#64748b',
-              padding: '0.375rem 0.75rem',
-              backgroundColor: '#f1f5f9',
-              borderRadius: '6px',
-              border: '1px solid #e2e8f0'
-            }}>
-              📍 Local Server Only
-            </span>
-            <button
-              onClick={() => setShowCreateForm(!showCreateForm)}
-              className="btn btn-primary"
-            >
-              <Plus size={16} />
-              {showCreateForm ? 'Cancel' : 'Create Dataset'}
-            </button>
-          </div>
-        </div>
+      {/* Create dataset button */}
+      <div style={{ marginBottom: '1rem' }}>
+        <button
+          onClick={() => setShowCreateForm(!showCreateForm)}
+          className="btn btn-primary"
+        >
+          <Plus size={16} />
+          {showCreateForm ? 'Cancel' : 'Create Dataset'}
+        </button>
       </div>
 
       {/* Create/Edit Dataset Form */}

--- a/ui/src/pages/KafkaTopics.js
+++ b/ui/src/pages/KafkaTopics.js
@@ -383,38 +383,23 @@ const KafkaTopics = () => {
         </div>
       )}
 
-      {/* Controls */}
-      <div className="card">
-        <div className="card-header">
-          <h3 className="card-title">Controls</h3>
-          <div style={{ display: 'flex', gap: '0.5rem' }}>
-            <span style={{ 
-              fontSize: '0.875rem', 
-              color: '#64748b',
-              padding: '0.375rem 0.75rem',
-              backgroundColor: '#f1f5f9',
-              borderRadius: '6px',
-              border: '1px solid #e2e8f0'
-            }}>
-              📍 Local Server Only
-            </span>
-            <button
-              onClick={fetchKafkaTopics}
-              className="btn btn-secondary"
-              disabled={loading}
-            >
-              <RefreshCw size={16} />
-              Refresh
-            </button>
-            <button
-              onClick={() => setShowCreateForm(!showCreateForm)}
-              className="btn btn-primary"
-            >
-              <Plus size={16} />
-              {showCreateForm ? 'Cancel' : 'Create Kafka Topic'}
-            </button>
-          </div>
-        </div>
+      {/* Page actions */}
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+        <button
+          onClick={fetchKafkaTopics}
+          className="btn btn-secondary"
+          disabled={loading}
+        >
+          <RefreshCw size={16} />
+          Refresh
+        </button>
+        <button
+          onClick={() => setShowCreateForm(!showCreateForm)}
+          className="btn btn-primary"
+        >
+          <Plus size={16} />
+          {showCreateForm ? 'Cancel' : 'Create Kafka Topic'}
+        </button>
       </div>
 
       {/* Create/Edit Kafka Topic Form */}

--- a/ui/src/pages/S3Resources.js
+++ b/ui/src/pages/S3Resources.js
@@ -386,38 +386,23 @@ const S3Resources = () => {
         </div>
       )}
 
-      {/* Controls */}
-      <div className="card">
-        <div className="card-header">
-          <h3 className="card-title">Controls</h3>
-          <div style={{ display: 'flex', gap: '0.5rem' }}>
-            <span style={{ 
-              fontSize: '0.875rem', 
-              color: '#64748b',
-              padding: '0.375rem 0.75rem',
-              backgroundColor: '#f1f5f9',
-              borderRadius: '6px',
-              border: '1px solid #e2e8f0'
-            }}>
-              📍 Local Server Only
-            </span>
-            <button
-              onClick={fetchS3Resources}
-              className="btn btn-secondary"
-              disabled={loading}
-            >
-              <RefreshCw size={16} />
-              Refresh
-            </button>
-            <button
-              onClick={() => setShowCreateForm(!showCreateForm)}
-              className="btn btn-primary"
-            >
-              <Plus size={16} />
-              {showCreateForm ? 'Cancel' : 'Create S3 Resource'}
-            </button>
-          </div>
-        </div>
+      {/* Page actions */}
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+        <button
+          onClick={fetchS3Resources}
+          className="btn btn-secondary"
+          disabled={loading}
+        >
+          <RefreshCw size={16} />
+          Refresh
+        </button>
+        <button
+          onClick={() => setShowCreateForm(!showCreateForm)}
+          className="btn btn-primary"
+        >
+          <Plus size={16} />
+          {showCreateForm ? 'Cancel' : 'Create S3 Resource'}
+        </button>
       </div>
 
       {/* Create/Edit S3 Resource Form */}

--- a/ui/src/pages/UrlResources.js
+++ b/ui/src/pages/UrlResources.js
@@ -538,38 +538,23 @@ const UrlResources = () => {
         </div>
       )}
 
-      {/* Controls */}
-      <div className="card">
-        <div className="card-header">
-          <h3 className="card-title">Controls</h3>
-          <div style={{ display: 'flex', gap: '0.5rem' }}>
-            <span style={{ 
-              fontSize: '0.875rem', 
-              color: '#64748b',
-              padding: '0.375rem 0.75rem',
-              backgroundColor: '#f1f5f9',
-              borderRadius: '6px',
-              border: '1px solid #e2e8f0'
-            }}>
-              📍 Local Server Only
-            </span>
-            <button
-              onClick={fetchUrlResources}
-              className="btn btn-secondary"
-              disabled={loading}
-            >
-              <RefreshCw size={16} />
-              Refresh
-            </button>
-            <button
-              onClick={() => setShowCreateForm(!showCreateForm)}
-              className="btn btn-primary"
-            >
-              <Plus size={16} />
-              {showCreateForm ? 'Cancel' : 'Create URL Resource'}
-            </button>
-          </div>
-        </div>
+      {/* Page actions */}
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+        <button
+          onClick={fetchUrlResources}
+          className="btn btn-secondary"
+          disabled={loading}
+        >
+          <RefreshCw size={16} />
+          Refresh
+        </button>
+        <button
+          onClick={() => setShowCreateForm(!showCreateForm)}
+          className="btn btn-primary"
+        >
+          <Plus size={16} />
+          {showCreateForm ? 'Cancel' : 'Create URL Resource'}
+        </button>
       </div>
 
       {/* Create/Edit URL Resource Form */}


### PR DESCRIPTION
## Summary

Closes #122.

The "Controls" card on Dataset Management, Kafka Topics, URL Resources and S3 Resources only wrapped the Refresh / Create buttons and a static "📍 Local Server Only" badge. There were no real controls inside (the server is fixed to local), so the card added visual weight without carrying any function.

The action buttons now sit directly under the page header.

## Pages updated

- `ui/src/pages/DatasetManagement.js`
- `ui/src/pages/KafkaTopics.js`
- `ui/src/pages/UrlResources.js`
- `ui/src/pages/S3Resources.js`

`Services.js` and `Organizations.js` still have the same wrapper. They are intentionally out of scope for this PR — open a follow-up if you want them aligned too.

## Test plan

- [x] All four updated files parse cleanly with Babel (JSX).
- [x] Local Docker image rebuilt and verified visually on each of the four pages: the create / refresh buttons sit directly under the page header, the "📍 Local Server Only" chip and "Controls" header are gone.
- [x] Version bumped to `0.17.1` in `api/config/swagger_settings.py` and `CHANGELOG.md`.