### PR TITLE
Remove redundant 'Type' column from Dataset Management list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2] - 2026-04-29
+
+### Removed
+- Dataset Management page: the "Type" column on the datasets table has been removed. The page already filters out URL / S3 / Kafka / Service datasets, so by construction every row was labeled "General" and the column carried no useful signal
+
 ## [0.17.1] - 2026-04-29
 
 ### Removed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.17.1"
+    swagger_version: str = "0.17.2"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/pages/DatasetManagement.js
+++ b/ui/src/pages/DatasetManagement.js
@@ -1043,7 +1043,6 @@ const DatasetManagement = () => {
               <thead>
                 <tr>
                   <th>Dataset</th>
-                  <th>Type</th>
                   <th>Organization</th>
                   <th>Resources</th>
                   <th>Actions</th>
@@ -1098,11 +1097,6 @@ const DatasetManagement = () => {
                           </div>
                         </td>
                         <td>
-                          <span className="status-indicator status-info">
-                            General
-                          </span>
-                        </td>
-                        <td>
                           <span className="status-indicator status-success">
                             {dataset.owner_org || 'No organization'}
                           </span>
@@ -1155,7 +1149,7 @@ const DatasetManagement = () => {
                       {/* Expanded Resources Row */}
                       {isExpanded && hasResources && (
                         <tr>
-                          <td colSpan="5" style={{ backgroundColor: '#f8fafc', padding: '1rem' }}>
+                          <td colSpan="4" style={{ backgroundColor: '#f8fafc', padding: '1rem' }}>
                             <div style={{ marginLeft: '1.5rem' }}>
                               <h4 style={{ marginBottom: '0.75rem', color: '#374151', fontSize: '0.9rem' }}>
                                 Resources ({dataset.resources.length})


### PR DESCRIPTION
## Summary

Closes #124.

The Dataset Management page already filters out datasets that are URL / S3 / Kafka / Service resources, so every remaining row had its "Type" column hardcoded to "General". A column whose value is constant on every row carries no signal, so drop it.

## Changes

- `ui/src/pages/DatasetManagement.js`:
  - Drop the `<th>Type</th>` header.
  - Drop the `<td><span className="status-indicator status-info">General</span></td>` cell.
  - Update the expanded-resources row's `colSpan` from `5` to `4` to match the new column count.

## Test plan

- [x] `babel.parse` passes on the updated file.
- [x] Local Docker image rebuilt and verified visually: the table on the Dataset Management page no longer shows the "Type" column, and the expanded-resources row still spans the full table width.
- [x] Version bumped to `0.17.2` in `api/config/swagger_settings.py` and `CHANGELOG.md`.