### PR TITLE
Drop footer copyright line and read live version from /openapi.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.3] - 2026-04-29
+
+### Changed
+- UI footer: the displayed version is now read at runtime from the backend's OpenAPI document (`info.version` exposed at `/openapi.json`), so it always matches the deployed API and no longer needs a manual bump on every release. While the version is being fetched, or if the request fails, the footer renders a neutral placeholder
+
+### Removed
+- UI footer: the "© <year> National Data Platform. All rights reserved." line has been removed; the version row now only shows the "NDP EndPoint" label and the live version badge
+
 ## [0.17.2] - 2026-04-29
 
 ### Removed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.17.2"
+    swagger_version: str = "0.17.3"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/components/Footer.js
+++ b/ui/src/components/Footer.js
@@ -1,15 +1,32 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Instagram, X, Linkedin } from 'lucide-react';
 
 /**
- * Enhanced Footer component - More similar to nationaldataplatform.org
- * Larger layout with better spacing and typography
- * Now includes application version display
- * UPDATED: Frontend version upgraded from 0.0.0 to 0.1.0
+ * Footer component for the NDP Endpoint UI.
+ *
+ * The displayed version is read at runtime from the backend's OpenAPI
+ * document (`/openapi.json`, `info.version`) so it always matches the
+ * deployed API and does not need a manual bump on every release.
  */
 const Footer = () => {
-  // Application version - update this when releasing new versions
-  const APP_VERSION = '1.3.0-alpha.2';
+  const [appVersion, setAppVersion] = useState(null);
+
+  useEffect(() => {
+    const rootPath = window.__EP_CONFIG__?.rootPath ?? '';
+    const url = `${rootPath}/openapi.json`;
+    let cancelled = false;
+    fetch(url)
+      .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+      .then((doc) => {
+        if (!cancelled) setAppVersion(doc?.info?.version ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setAppVersion(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return (
     <footer style={{
@@ -196,14 +213,11 @@ const Footer = () => {
           borderTop: '1px solid rgba(255, 255, 255, 0.1)',
           paddingTop: '0.75rem',
           display: 'flex',
-          justifyContent: 'space-between',
+          justifyContent: 'flex-end',
           alignItems: 'center',
           fontSize: '0.75rem',
           color: 'rgba(255, 255, 255, 0.7)'
         }}>
-          <div>
-            © {new Date().getFullYear()} National Data Platform. All rights reserved.
-          </div>
           <div style={{
             display: 'flex',
             alignItems: 'center',
@@ -218,7 +232,7 @@ const Footer = () => {
               fontFamily: 'monospace',
               color: 'rgba(255, 255, 255, 0.9)'
             }}>
-              v{APP_VERSION}
+              {appVersion ? `v${appVersion}` : '—'}
             </span>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Closes #126.

The UI footer used to show two pieces of stale / noisy information:

- A hardcoded `APP_VERSION = '1.3.0-alpha.2'` constant inside `Footer.js`, which nobody had been bumping on releases — it had drifted completely from the actual backend version.
- A `© <year> National Data Platform. All rights reserved.` line that adds visual noise without carrying any product signal.

This PR fetches the backend's OpenAPI document on mount and uses `info.version` as the displayed version, so the badge is always in sync with the deployed API. The copyright line is removed and the version row now only contains the right-aligned `NDP EndPoint <version>` badge.

## Behavior

- Successful fetch → footer renders `NDP EndPoint v0.17.3`.
- While the fetch is in flight, or if it fails, the badge shows `—` (no layout shift).
- The fetch uses `${window.__EP_CONFIG__?.rootPath ?? ''}/openapi.json`, the same root convention the rest of the UI already uses.

## Test plan

- [x] `babel.parse` passes on the updated `Footer.js`.
- [x] Local Docker image rebuilt; bundle no longer contains the strings `1.3.0-alpha.2` or `All rights reserved`, and does contain `openapi.json`.
- [x] Verified visually: the footer shows `NDP EndPoint v0.17.3`, no copyright line, and the badge falls back to `—` if `/openapi.json` is unreachable.
- [x] Version bumped to `0.17.3` in `api/config/swagger_settings.py` and `CHANGELOG.md`.