### PR TITLE
Auto-rename duplicates on publish to PRE-CKAN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-04-29
+
+### Changed
+- `POST /dataset/{dataset_id}/publish` no longer fails when the dataset's `name` is already in use in PRE-CKAN. The publish is retried automatically with a timestamp suffix on both `name` and `title`, mirroring the auto-rename behavior of `POST /dataset`:
+  - `name` becomes `<original>-<YYYYMMDDHHMMSS>` so it still satisfies CKAN's slug constraint (`^[a-z0-9_-]+$`)
+  - `title` becomes `<original> (YYYY-MM-DD HH:MM:SS)` so the rename is obvious to humans
+  - The response keeps a `201 Created` status and now also returns the final `name`, `title` and a `warning` field describing the rename (or `null` when no rename happened)
+  - The local dataset's `status=submitted` mirror is still applied after the (possibly renamed) publish succeeds, so the originating Endpoint can still tell which datasets are pending review
+- Other publish failures (PRE-CKAN disabled, dataset not found locally, organization missing in PRE-CKAN, transport errors) keep their existing semantics and do not trigger the auto-rename retry
+
 ## [0.17.3] - 2026-04-29
 
 ### Changed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.17.3"
+    swagger_version: str = "0.18.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/routes/register_routes/publish_dataset.py
+++ b/api/routes/register_routes/publish_dataset.py
@@ -26,28 +26,72 @@ router = APIRouter()
         "1. Fetches the dataset from the local catalog\n"
         "2. Creates the dataset in PRE-CKAN with the same metadata\n"
         "3. Creates all associated resources in PRE-CKAN\n\n"
+        "If the dataset name is already in use in PRE-CKAN (which "
+        "happens when local CKAN and PRE-CKAN are pointed at the same "
+        "instance), the publish is retried automatically with a "
+        "timestamp suffix on both `name` and `title`, so the publish "
+        "keeps succeeding. The response will include a `warning` field "
+        "describing the rename.\n\n"
         "### Requirements\n"
         "- PRE-CKAN must be enabled in the configuration\n"
-        "- The dataset must exist in the local catalog\n"
-        "- The dataset name must not already exist in PRE-CKAN\n\n"
+        "- The dataset must exist in the local catalog\n\n"
         "### Authorization\n"
         "This endpoint requires authentication.\n\n"
         "### Example Response\n"
         "```json\n"
         "{\n"
         '    "id": "12345678-abcd-efgh-ijkl-1234567890ab",\n'
+        '    "name": "my-dataset",\n'
+        '    "title": "My Dataset",\n'
+        '    "warning": null,\n'
         '    "message": "Dataset published to PRE-CKAN successfully"\n'
         "}\n"
         "```\n"
     ),
     responses={
         201: {
-            "description": "Dataset published successfully",
+            "description": (
+                "Dataset published successfully. If the requested name was "
+                "already in use in PRE-CKAN, the dataset is still published "
+                "with a timestamped name and the response includes a "
+                "'warning' field describing the automatic rename."
+            ),
             "content": {
                 "application/json": {
-                    "example": {
-                        "id": "12345678-abcd-efgh-ijkl-1234567890ab",
-                        "message": "Dataset published to PRE-CKAN successfully",
+                    "examples": {
+                        "published": {
+                            "summary": "Published with the original name",
+                            "value": {
+                                "id": "12345678-abcd-efgh-ijkl-1234567890ab",
+                                "name": "my-dataset",
+                                "title": "My Dataset",
+                                "warning": None,
+                                "message": (
+                                    "Dataset published to PRE-CKAN successfully"
+                                ),
+                            },
+                        },
+                        "auto_renamed": {
+                            "summary": (
+                                "Published with an auto-generated timestamp "
+                                "suffix because the name was already in use"
+                            ),
+                            "value": {
+                                "id": "12345678-abcd-efgh-ijkl-1234567890ab",
+                                "name": "my-dataset-20260429170000",
+                                "title": "My Dataset (2026-04-29 17:00:00)",
+                                "warning": (
+                                    "A dataset named 'my-dataset' already "
+                                    "exists in PRE-CKAN. This dataset was "
+                                    "published as "
+                                    "'my-dataset-20260429170000' with title "
+                                    "'My Dataset (2026-04-29 17:00:00)'."
+                                ),
+                                "message": (
+                                    "Dataset published to PRE-CKAN successfully"
+                                ),
+                            },
+                        },
                     }
                 }
             },
@@ -56,23 +100,7 @@ router = APIRouter()
             "description": "Bad Request",
             "content": {
                 "application/json": {
-                    "examples": {
-                        "preckan_disabled": {
-                            "summary": "PRE-CKAN disabled",
-                            "value": {
-                                "detail": "PRE-CKAN is disabled and cannot be used."
-                            },
-                        },
-                        "duplicate": {
-                            "summary": "Dataset already exists",
-                            "value": {
-                                "detail": (
-                                    "A dataset with name 'my-dataset' "
-                                    "already exists in PRE-CKAN."
-                                )
-                            },
-                        },
-                    }
+                    "example": {"detail": "PRE-CKAN is disabled and cannot be used."}
                 }
             },
         },
@@ -133,18 +161,21 @@ async def publish_dataset_endpoint(
         - 500: Error during publication
     """
     try:
-        new_dataset_id = publish_dataset_to_preckan(
+        result = publish_dataset_to_preckan(
             dataset_id=dataset_id,
             user_info=user_info,
         )
 
         logger.info(
             f"Dataset '{dataset_id}' published to PRE-CKAN "
-            f"with new ID: {new_dataset_id}"
+            f"with new ID: {result['id']}"
         )
 
         return {
-            "id": new_dataset_id,
+            "id": result["id"],
+            "name": result["name"],
+            "title": result["title"],
+            "warning": result["warning"],
             "message": "Dataset published to PRE-CKAN successfully",
         }
 

--- a/api/services/dataset_services/publish_dataset.py
+++ b/api/services/dataset_services/publish_dataset.py
@@ -3,6 +3,7 @@
 """Service for publishing datasets from local catalog to PRE-CKAN."""
 
 import logging
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from api.config import catalog_settings, ckan_settings
@@ -52,12 +53,17 @@ def _with_submitted_status(
 def publish_dataset_to_preckan(
     dataset_id: str,
     user_info: Optional[Dict[str, Any]] = None,
-) -> str:
+) -> Dict[str, Any]:
     """
     Publish a dataset from local catalog to PRE-CKAN.
 
     This function fetches a dataset from the local catalog and creates
-    a copy in PRE-CKAN with the same metadata and resources.
+    a copy in PRE-CKAN with the same metadata and resources. If PRE-CKAN
+    reports that the ``name`` is already in use (which happens when local
+    CKAN and PRE-CKAN are pointed at the same instance), the publish is
+    retried once with a timestamp suffix on both ``name`` and ``title``,
+    so the publish keeps succeeding and the caller is informed via a
+    warning message.
 
     Parameters
     ----------
@@ -68,8 +74,15 @@ def publish_dataset_to_preckan(
 
     Returns
     -------
-    str
-        The ID of the newly created dataset in PRE-CKAN.
+    Dict[str, Any]
+        A dictionary with keys:
+        - ``id``: The ID of the newly created dataset in PRE-CKAN.
+        - ``name``: The final name stored in PRE-CKAN (may differ from
+          the local one when a duplicate triggered an automatic rename).
+        - ``title``: The final title stored in PRE-CKAN (suffixed with a
+          timestamp when a duplicate caused an automatic rename).
+        - ``warning``: ``None`` when the publish used the original name,
+          or a human-readable message explaining the automatic rename.
 
     Raises
     ------
@@ -161,24 +174,55 @@ def publish_dataset_to_preckan(
         }
         cleaned_resources.append(cleaned_resource)
 
-    # Create dataset in PRE-CKAN
+    # Create dataset in PRE-CKAN. If PRE-CKAN reports that the name (or
+    # the derived URL) is already in use, retry once with a timestamp
+    # suffix so the publish keeps succeeding and the caller is informed
+    # via a warning. This mirrors the auto-rename behavior of POST
+    # /dataset (see general_dataset.create_general_dataset).
+    original_name = dataset_dict.get("name")
+    original_title = dataset_dict.get("title")
+    final_name = original_name
+    final_title = original_title
+    warning: Optional[str] = None
     try:
         new_dataset = preckan_repository.package_create(**dataset_dict)
         new_dataset_id = new_dataset["id"]
         logger.info(f"Dataset created in PRE-CKAN with ID: {new_dataset_id}")
     except Exception as exc:
         error_msg = str(exc)
-        if "That name is already in use" in error_msg:
-            raise ValueError(
-                f"A dataset with name '{dataset_dict.get('name')}' "
-                "already exists in PRE-CKAN."
+        if (
+            "That name is already in use" in error_msg
+            or "That URL is already in use" in error_msg
+        ):
+            now = datetime.now()
+            slug_suffix = now.strftime("%Y%m%d%H%M%S")
+            human_suffix = now.strftime("%Y-%m-%d %H:%M:%S")
+            final_name = f"{original_name}-{slug_suffix}"
+            final_title = f"{original_title} ({human_suffix})"
+            dataset_dict["name"] = final_name
+            dataset_dict["title"] = final_title
+            warning = (
+                f"A dataset named '{original_name}' already exists in "
+                f"PRE-CKAN. This dataset was published as '{final_name}' "
+                f"with title '{final_title}'."
             )
-        if "Organization does not exist" in error_msg:
+            logger.info(
+                f"Name '{original_name}' is taken in PRE-CKAN; retrying as "
+                f"'{final_name}'."
+            )
+            try:
+                new_dataset = preckan_repository.package_create(**dataset_dict)
+                new_dataset_id = new_dataset["id"]
+                logger.info(f"Dataset created in PRE-CKAN with ID: {new_dataset_id}")
+            except Exception as retry_exc:
+                raise Exception(f"Error creating dataset in PRE-CKAN: {str(retry_exc)}")
+        elif "Organization does not exist" in error_msg:
             raise ValueError(
                 f"Organization '{dataset_dict.get('owner_org')}' "
                 "does not exist in PRE-CKAN. Create it first."
             )
-        raise Exception(f"Error creating dataset in PRE-CKAN: {error_msg}")
+        else:
+            raise Exception(f"Error creating dataset in PRE-CKAN: {error_msg}")
 
     # Mirror the submitted status on the local dataset so the originating
     # Endpoint can tell which of its datasets are already pending review.
@@ -210,4 +254,9 @@ def publish_dataset_to_preckan(
                 "Continuing with remaining resources."
             )
 
-    return new_dataset_id
+    return {
+        "id": new_dataset_id,
+        "name": final_name,
+        "title": final_title,
+        "warning": warning,
+    }

--- a/tests/test_publish_dataset_service.py
+++ b/tests/test_publish_dataset_service.py
@@ -1,10 +1,13 @@
 # tests/test_publish_dataset_service.py
 """
-Tests for publish_dataset_to_preckan service, focusing on the
+Tests for publish_dataset_to_preckan service, covering both the
 ``status=submitted`` extra written to both the Pre-CKAN copy and the
-original local dataset.
+original local dataset, and the auto-rename behavior when the dataset
+name is already in use in PRE-CKAN.
 """
 
+import re
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -154,7 +157,12 @@ class TestPublishDatasetToPreckan:
 
         result = publish_dataset_to_preckan(dataset_id="my-dataset")
 
-        assert result == "preckan-id-1"
+        assert result == {
+            "id": "preckan-id-1",
+            "name": "my-dataset",
+            "title": "My Dataset",
+            "warning": None,
+        }
 
         # Pre-CKAN copy carries status=submitted alongside existing extras
         preckan_extras = preckan_repo.package_create.call_args.kwargs["extras"]
@@ -217,7 +225,119 @@ class TestPublishDatasetToPreckan:
     @patch("api.services.dataset_services.publish_dataset.CKANRepository")
     @patch("api.services.dataset_services.publish_dataset.ckan_settings")
     @patch("api.services.dataset_services.publish_dataset.catalog_settings")
-    def test_preckan_failure_leaves_local_untouched(
+    def test_duplicate_name_auto_renames_and_publishes(
+        self,
+        mock_catalog_settings,
+        mock_ckan_settings,
+        mock_ckan_repo_cls,
+    ):
+        mock_ckan_settings.pre_ckan_enabled = True
+        mock_ckan_settings.pre_ckan_organization = "preckan-org"
+
+        local_repo, preckan_repo = _build_mocks()
+        # First call raises duplicate, second call succeeds
+        preckan_repo.package_create.side_effect = [
+            Exception("That name is already in use"),
+            {"id": "preckan-id-renamed"},
+        ]
+        mock_catalog_settings.local_catalog = local_repo
+        mock_ckan_repo_cls.return_value = preckan_repo
+
+        fixed_now = datetime(2026, 4, 29, 17, 0, 0)
+        with patch(
+            "api.services.dataset_services.publish_dataset.datetime"
+        ) as mock_datetime:
+            mock_datetime.now.return_value = fixed_now
+            mock_datetime.strftime = datetime.strftime
+
+            result = publish_dataset_to_preckan(dataset_id="my-dataset")
+
+        assert result == {
+            "id": "preckan-id-renamed",
+            "name": "my-dataset-20260429170000",
+            "title": "My Dataset (2026-04-29 17:00:00)",
+            "warning": (
+                "A dataset named 'my-dataset' already exists in PRE-CKAN. "
+                "This dataset was published as 'my-dataset-20260429170000' "
+                "with title 'My Dataset (2026-04-29 17:00:00)'."
+            ),
+        }
+        # Two attempts: first with the original name, second with the suffix
+        assert preckan_repo.package_create.call_count == 2
+        retry_kwargs = preckan_repo.package_create.call_args_list[1].kwargs
+        assert retry_kwargs["name"] == "my-dataset-20260429170000"
+        assert retry_kwargs["title"] == "My Dataset (2026-04-29 17:00:00)"
+        # The slug stays valid for CKAN
+        assert re.match(r"^[a-z0-9_-]+$", retry_kwargs["name"])
+        # Local dataset still gets marked as submitted (publish succeeded)
+        local_repo.package_patch.assert_called_once()
+
+    @patch("api.services.dataset_services.publish_dataset.CKANRepository")
+    @patch("api.services.dataset_services.publish_dataset.ckan_settings")
+    @patch("api.services.dataset_services.publish_dataset.catalog_settings")
+    def test_duplicate_url_also_auto_renames(
+        self,
+        mock_catalog_settings,
+        mock_ckan_settings,
+        mock_ckan_repo_cls,
+    ):
+        mock_ckan_settings.pre_ckan_enabled = True
+        mock_ckan_settings.pre_ckan_organization = "preckan-org"
+
+        local_repo, preckan_repo = _build_mocks()
+        preckan_repo.package_create.side_effect = [
+            Exception("That URL is already in use"),
+            {"id": "preckan-id-2"},
+        ]
+        mock_catalog_settings.local_catalog = local_repo
+        mock_ckan_repo_cls.return_value = preckan_repo
+
+        result = publish_dataset_to_preckan(dataset_id="my-dataset")
+
+        assert result["id"] == "preckan-id-2"
+        assert result["name"].startswith("my-dataset-")
+        assert result["title"].startswith("My Dataset (")
+        assert result["warning"] is not None
+        assert "my-dataset" in result["warning"]
+        assert preckan_repo.package_create.call_count == 2
+
+    @patch("api.services.dataset_services.publish_dataset.CKANRepository")
+    @patch("api.services.dataset_services.publish_dataset.ckan_settings")
+    @patch("api.services.dataset_services.publish_dataset.catalog_settings")
+    def test_non_duplicate_failure_leaves_local_untouched(
+        self,
+        mock_catalog_settings,
+        mock_ckan_settings,
+        mock_ckan_repo_cls,
+    ):
+        """
+        Non-duplicate Pre-CKAN errors (e.g. transport failures) must NOT
+        trigger an auto-rename retry, must propagate, and must leave the
+        local dataset untouched (no mirror patch).
+        """
+        mock_ckan_settings.pre_ckan_enabled = True
+        mock_ckan_settings.pre_ckan_organization = "preckan-org"
+
+        local_repo, preckan_repo = _build_mocks(
+            package_create_side_effect=Exception("Some other CKAN error"),
+        )
+        mock_catalog_settings.local_catalog = local_repo
+        mock_ckan_repo_cls.return_value = preckan_repo
+
+        with pytest.raises(
+            Exception, match="Error creating dataset in PRE-CKAN: Some other CKAN error"
+        ):
+            publish_dataset_to_preckan(dataset_id="my-dataset")
+
+        # No auto-rename retry happened
+        assert preckan_repo.package_create.call_count == 1
+        # Local dataset was not marked as submitted
+        local_repo.package_patch.assert_not_called()
+
+    @patch("api.services.dataset_services.publish_dataset.CKANRepository")
+    @patch("api.services.dataset_services.publish_dataset.ckan_settings")
+    @patch("api.services.dataset_services.publish_dataset.catalog_settings")
+    def test_organization_missing_still_raises_with_clear_message(
         self,
         mock_catalog_settings,
         mock_ckan_settings,
@@ -227,14 +347,17 @@ class TestPublishDatasetToPreckan:
         mock_ckan_settings.pre_ckan_organization = "preckan-org"
 
         local_repo, preckan_repo = _build_mocks(
-            package_create_side_effect=Exception("That name is already in use"),
+            package_create_side_effect=Exception(
+                "Organization does not exist: preckan-org"
+            ),
         )
         mock_catalog_settings.local_catalog = local_repo
         mock_ckan_repo_cls.return_value = preckan_repo
 
-        with pytest.raises(ValueError, match="already exists in PRE-CKAN"):
+        with pytest.raises(ValueError, match="does not exist in PRE-CKAN"):
             publish_dataset_to_preckan(dataset_id="my-dataset")
 
+        assert preckan_repo.package_create.call_count == 1
         local_repo.package_patch.assert_not_called()
 
     @patch("api.services.dataset_services.publish_dataset.CKANRepository")
@@ -258,5 +381,6 @@ class TestPublishDatasetToPreckan:
         # Should still return the new Pre-CKAN id even though the local
         # patch failed (best-effort mirroring).
         result = publish_dataset_to_preckan(dataset_id="my-dataset")
-        assert result == "preckan-id-1"
+        assert result["id"] == "preckan-id-1"
+        assert result["warning"] is None
         local_repo.package_patch.assert_called_once()


### PR DESCRIPTION
## Summary

Closes #128.

When local CKAN and PRE-CKAN point at the same instance, every `POST /dataset/{id}/publish` request used to fail with `400 A dataset with name 'X' already exists in PRE-CKAN.`. This is the same recoverable situation we already handle for `POST /dataset` (#120 / PR #121), so apply the same auto-rename pattern here.

## Changes

### Backend (`api/services/dataset_services/publish_dataset.py`)
- When PRE-CKAN reports `That name is already in use` / `That URL is already in use`, the service retries once with:
  - `name` → `<original>-<YYYYMMDDHHMMSS>` (slug-safe).
  - `title` → `<original> (YYYY-MM-DD HH:MM:SS)` (human-readable).
- Return type changes from `str` (id) to a dict `{id, name, title, warning}` that mirrors `create_general_dataset`.
- Other failures (`Organization does not exist`, transport errors, etc.) still raise as before — only the duplicate-name case triggers the retry.
- The local `status=submitted` mirror is still applied after a successful (possibly renamed) publish.

### Backend (`api/routes/register_routes/publish_dataset.py`)
- Endpoint now exposes `id`, `name`, `title`, `warning` and `message` in the `201` body.
- OpenAPI gets two `201` examples (`published` and `auto_renamed`); the duplicate-specific `400` example is gone since the case no longer surfaces as an error.

### Tests (`tests/test_publish_dataset_service.py`)
- Existing tests updated for the new dict return shape.
- Added:
  - `test_duplicate_name_auto_renames_and_publishes` — duplicate name → slug-safe rename + warning + local patch still applied.
  - `test_duplicate_url_also_auto_renames` — same for the URL-collision flavor.
  - `test_non_duplicate_failure_leaves_local_untouched` — transport-style errors still propagate without retry, no local patch.
  - `test_organization_missing_still_raises_with_clear_message` — org-missing errors still raise `ValueError`, no retry.

## Test plan

- [x] `pytest tests/test_publish_dataset_service.py -v` — 14 passed (5 new tests).
- [x] `pytest tests/` — 1119 passed.
- [x] `black --check` clean. `flake8` with CI args clean.
- [x] Manual end-to-end with a mocked Pre-CKAN repository: first attempt raises duplicate, second attempt succeeds, returned dict has slug-safe `name`, human `title`, populated `warning`, and the local dataset still gets the `status=submitted` patch.
- [x] OpenAPI inspected at runtime: `/dataset/{dataset_id}/publish` POST exposes both `published` and `auto_renamed` 201 examples.