### PR TITLE
feat(ui): show dataset status as symbol column (closes #132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.2] - 2026-04-30
+
+### Added
+- Dataset Management page: a new "Status" column on the datasets table surfaces each dataset's submission state at a glance, using a small icon instead of the raw status string so the table stays compact:
+  - Amber Clock when the dataset has been published to PRE-CKAN (`extras.status === "submitted"`) and is awaiting review
+  - Gray Home when the dataset has no status entry (local-only, never published)
+  - Gray AlertCircle for any unrecognized status, with the raw value still exposed via the hover tooltip so the row never silently hides state
+- Each icon is wrapped in a `title`-bearing span so hovering reveals the underlying status text without cluttering the table
+
 ## [0.18.1] - 2026-04-30
 
 ### Removed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.18.1"
+    swagger_version: str = "0.18.2"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/pages/DatasetManagement.js
+++ b/ui/src/pages/DatasetManagement.js
@@ -11,7 +11,9 @@ import {
   ChevronDown,
   ChevronRight,
   ExternalLink,
-  Link
+  Link,
+  Clock,
+  Home
 } from 'lucide-react';
 import { organizationsAPI, searchAPI, generalDatasetAPI, datasetAPI, resourcesAPI } from '../services/api';
 
@@ -25,6 +27,34 @@ const formatApiError = (err) => {
     return detail.detail || detail.error || JSON.stringify(detail);
   }
   return err?.message || 'Unknown error';
+};
+
+// Map a dataset's extras.status to a small icon. The backend currently sets
+// extras.status="submitted" after a successful publish to PRE-CKAN; datasets
+// that have never been published have no status entry and are local-only.
+// Unknown values render a defensive AlertCircle so they are still visible.
+const renderDatasetStatusIcon = (status) => {
+  let Icon;
+  let color;
+  let label;
+  if (status === 'submitted') {
+    Icon = Clock;
+    color = '#f59e0b';
+    label = 'Submitted';
+  } else if (!status) {
+    Icon = Home;
+    color = '#94a3b8';
+    label = 'Local only';
+  } else {
+    Icon = AlertCircle;
+    color = '#64748b';
+    label = status;
+  }
+  return (
+    <span title={label} aria-label={`Status: ${label}`} style={{ display: 'inline-flex' }}>
+      <Icon size={16} color={color} />
+    </span>
+  );
 };
 
 /**
@@ -1044,6 +1074,7 @@ const DatasetManagement = () => {
                 <tr>
                   <th>Dataset</th>
                   <th>Organization</th>
+                  <th>Status</th>
                   <th>Resources</th>
                   <th>Actions</th>
                 </tr>
@@ -1102,6 +1133,9 @@ const DatasetManagement = () => {
                           </span>
                         </td>
                         <td>
+                          {renderDatasetStatusIcon(dataset.extras?.status)}
+                        </td>
+                        <td>
                           <button
                             onClick={() => hasResources && toggleDatasetExpansion(dataset.id)}
                             style={{
@@ -1149,7 +1183,7 @@ const DatasetManagement = () => {
                       {/* Expanded Resources Row */}
                       {isExpanded && hasResources && (
                         <tr>
-                          <td colSpan="4" style={{ backgroundColor: '#f8fafc', padding: '1rem' }}>
+                          <td colSpan="5" style={{ backgroundColor: '#f8fafc', padding: '1rem' }}>
                             <div style={{ marginLeft: '1.5rem' }}>
                               <h4 style={{ marginBottom: '0.75rem', color: '#374151', fontSize: '0.9rem' }}>
                                 Resources ({dataset.resources.length})


### PR DESCRIPTION
## Summary
- Add a **Status** column to the Dataset Management table that visualizes each dataset's submission state with a small icon (instead of a raw string), keeping the row compact:
  - **Clock (amber)** — `extras.status === "submitted"` (published to PRE-CKAN, awaiting review)
  - **Home (gray)** — no status entry (local-only)
  - **AlertCircle (gray)** — any unrecognized status; raw value surfaced via tooltip
- Each icon is wrapped in a `title`-bearing span so hovering reveals the underlying status text.
- Bump version to `0.18.2` (patch — UI-only addition that surfaces existing backend state, no API change).

## Test plan
- [x] UI build passes (`npm run build` inside the `ui/` workspace) with no warnings.
- [x] Backend test suite still passes (1119/1119) since the API was not touched.
- [ ] Manual visual check: a freshly created (unpublished) dataset shows the Home icon; after `POST /dataset/{id}/publish` succeeds, the same row shows the Clock icon and the row's expanded resources panel still spans the full table width.

Closes #132