### PR TITLE
feat(ui): add publish action button to unpublished datasets (closes #134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-04-30
+
+### Added
+- Dataset Management page: each row whose `extras.status` is not "submitted" now exposes a primary "Publish" action button before the Edit/Delete buttons, so a user can push a local dataset to PRE-CKAN directly from the table without leaving the page (no more Swagger or curl round-trip):
+  - The button calls `POST /dataset/{dataset_id}/publish` through a new `generalDatasetAPI.publish` client method
+  - Per-row publishing state disables the button and switches its label to "Publishing…" while the request is in flight, so double-clicks cannot fire the publish twice
+  - On success the datasets list is refetched and the status icon flips from Home to Clock automatically
+  - When the backend had to auto-rename the dataset (because its `name` was already in use in PRE-CKAN), the response's `warning` field is surfaced via the yellow warning banner instead of the green success banner, so the user notices that the published name/title differ from theirs
+  - Once a dataset is already submitted the button is hidden, preventing a re-publish that would just create a renamed duplicate
+
 ## [0.18.2] - 2026-04-30
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.18.2"
+    swagger_version: str = "0.19.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/pages/DatasetManagement.js
+++ b/ui/src/pages/DatasetManagement.js
@@ -13,7 +13,8 @@ import {
   ExternalLink,
   Link,
   Clock,
-  Home
+  Home,
+  Send
 } from 'lucide-react';
 import { organizationsAPI, searchAPI, generalDatasetAPI, datasetAPI, resourcesAPI } from '../services/api';
 
@@ -72,6 +73,7 @@ const DatasetManagement = () => {
   const [editingDataset, setEditingDataset] = useState(null);
   const [selectedServer] = useState('local'); // Fixed to local for consistency
   const [expandedDatasets, setExpandedDatasets] = useState({});
+  const [publishingIds, setPublishingIds] = useState({});
   const [editingResource, setEditingResource] = useState(null);
   const [resourceFormData, setResourceFormData] = useState({
     name: '',
@@ -525,6 +527,43 @@ const DatasetManagement = () => {
   /**
    * Handle dataset deletion
    */
+  const handlePublishDataset = async (dataset) => {
+    const displayName = dataset.title || dataset.name || 'Unnamed Dataset';
+
+    if (!window.confirm(
+      `Publish dataset "${displayName}" to PRE-CKAN?`
+    )) {
+      return;
+    }
+
+    try {
+      setError(null);
+      setSuccess(null);
+      setWarning(null);
+      setPublishingIds((prev) => ({ ...prev, [dataset.id]: true }));
+
+      const response = await generalDatasetAPI.publish(dataset.id);
+      const apiWarning = response?.data?.warning;
+
+      if (apiWarning) {
+        setWarning(`WARNING: ${apiWarning}`);
+      } else {
+        setSuccess(`Dataset "${displayName}" published successfully!`);
+      }
+
+      fetchDatasets();
+    } catch (err) {
+      console.error('Error publishing dataset:', err);
+      setError(`Failed to publish dataset "${displayName}": ` + formatApiError(err));
+    } finally {
+      setPublishingIds((prev) => {
+        const next = { ...prev };
+        delete next[dataset.id];
+        return next;
+      });
+    }
+  };
+
   const handleDeleteDataset = async (dataset) => {
     const displayName = dataset.title || dataset.name || 'Unnamed Dataset';
     
@@ -1157,6 +1196,21 @@ const DatasetManagement = () => {
                         </td>
                         <td>
                           <div style={{ display: 'flex', gap: '0.5rem' }}>
+                            {dataset.extras?.status !== 'submitted' && (
+                              <button
+                                onClick={() => handlePublishDataset(dataset)}
+                                className="btn btn-primary"
+                                style={{ padding: '0.375rem 0.75rem' }}
+                                title="Publish dataset to PRE-CKAN"
+                                disabled={!!publishingIds[dataset.id]}
+                              >
+                                <Send size={14} />
+                                <span style={{ fontSize: '0.75rem' }}>
+                                  {publishingIds[dataset.id] ? 'Publishing…' : 'Publish'}
+                                </span>
+                              </button>
+                            )}
+
                             <button
                               onClick={() => startEditing(dataset)}
                               className="btn btn-secondary"

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -202,6 +202,9 @@ export const generalDatasetAPI = {
 
   partialUpdate: (datasetId, data, server = 'local') =>
     apiClient.patch(`/dataset/${datasetId}`, data, { params: { server } }),
+
+  publish: (datasetId) =>
+    apiClient.post(`/dataset/${datasetId}/publish`),
 };
 
 // Dataset API (for deletion)


### PR DESCRIPTION
## Summary
- Add a primary **Publish** button to every Dataset Management row whose `extras.status` is not `"submitted"`, so users can push a local dataset to PRE-CKAN directly from the page.
- New `generalDatasetAPI.publish(datasetId)` client method wired to `POST /dataset/{dataset_id}/publish`.
- Per-row publishing state disables the button and shows "Publishing…" while in flight.
- Surfaces the backend's `warning` field (auto-rename) via the yellow warning banner; otherwise shows the green success banner.
- On success the datasets list is refetched so the status icon flips from Home to Clock.
- Bump version to `0.19.0` (minor — new UI capability that uses an existing backend endpoint).

## Test plan
- [x] UI build passes (`npm run build` inside `ui/`) — +202 B gzip.
- [x] Backend test suite still passes (1119/1119) — API was not touched.
- [x] Manual verification on local stack: button visible on local-only datasets, hidden on already-submitted ones.
- [ ] Manual end-to-end check: publish a fresh dataset, confirm the status icon switches to Clock and the button disappears.
- [ ] Manual auto-rename check: publish a dataset whose name already exists in PRE-CKAN, confirm the yellow warning banner shows the renamed name/title.

Closes #134