### PR TITLE
fix(ui): keep header on a single row when admin nav is shown (closes #136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-04-30
+
+### Fixed
+- Top header: when an admin session showed the "Access Requests" link, the row no longer fit horizontally — "Access Requests" wrapped onto a second line and the Logout button on the right ended up looking misaligned. The header now stays on a single row regardless of which nav items are visible:
+  - Every nav link/button label uses `white-space: nowrap` so labels never wrap mid-word
+  - Nav and right-cluster gaps tightened from 1.5rem to 1rem; link padding from 0.75rem 1rem to 0.5rem 0.75rem; Logout button padding from 0.75rem 1.5rem to 0.5rem 1rem
+  - Inner container max width raised from 1200px to 1400px so the header has more horizontal room before falling back on the tighter sizes
+
 ## [0.19.0] - 2026-04-30
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.19.0"
+    swagger_version: str = "0.19.1"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/components/Navigation.js
+++ b/ui/src/components/Navigation.js
@@ -112,7 +112,7 @@ const Navigation = () => {
       borderBottom: '1px solid #e5e7eb'
     }}>
       <div style={{
-        maxWidth: '1200px',
+        maxWidth: '1400px',
         margin: '0 auto',
         padding: '0 1rem'
       }}>
@@ -120,7 +120,7 @@ const Navigation = () => {
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
-          gap: '2rem'
+          gap: '1rem'
         }}>
           
           {/* Left: NDP Logo */}
@@ -141,7 +141,7 @@ const Navigation = () => {
 
           {/* Center: Navigation Menu */}
           <nav style={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
-            <div style={{ display: 'flex', gap: '1.5rem', alignItems: 'center' }}>
+            <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
               
               {/* Dashboard */}
               <Link
@@ -150,12 +150,13 @@ const Navigation = () => {
                 style={{
                   color: '#6b7280', // Always same color
                   textDecoration: 'none',
-                  padding: '0.75rem 1rem',
+                  padding: '0.5rem 0.75rem',
                   borderRadius: '8px',
                   display: 'flex',
                   alignItems: 'center',
                   gap: '0.5rem',
                   fontSize: '0.95rem',
+                  whiteSpace: 'nowrap',
                   fontWeight: '500', // Always same weight
                   fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
                   backgroundColor: 'transparent',
@@ -181,12 +182,13 @@ const Navigation = () => {
                 style={{
                   color: '#6b7280', // Always same color
                   textDecoration: 'none',
-                  padding: '0.75rem 1rem',
+                  padding: '0.5rem 0.75rem',
                   borderRadius: '8px',
                   display: 'flex',
                   alignItems: 'center',
                   gap: '0.5rem',
                   fontSize: '0.95rem',
+                  whiteSpace: 'nowrap',
                   fontWeight: '500', // Always same weight
                   fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
                   backgroundColor: 'transparent',
@@ -418,12 +420,13 @@ const Navigation = () => {
                 style={{
                   color: '#6b7280', // Always same color
                   textDecoration: 'none',
-                  padding: '0.75rem 1rem',
+                  padding: '0.5rem 0.75rem',
                   borderRadius: '8px',
                   display: 'flex',
                   alignItems: 'center',
                   gap: '0.5rem',
                   fontSize: '0.95rem',
+                  whiteSpace: 'nowrap',
                   fontWeight: '500', // Always same weight
                   fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
                   backgroundColor: 'transparent',
@@ -449,12 +452,13 @@ const Navigation = () => {
                 style={{
                   color: '#6b7280', // Always same color
                   textDecoration: 'none',
-                  padding: '0.75rem 1rem',
+                  padding: '0.5rem 0.75rem',
                   borderRadius: '8px',
                   display: 'flex',
                   alignItems: 'center',
                   gap: '0.5rem',
                   fontSize: '0.95rem',
+                  whiteSpace: 'nowrap',
                   fontWeight: '500', // Always same weight
                   fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
                   backgroundColor: 'transparent',
@@ -509,10 +513,10 @@ const Navigation = () => {
           </nav>
 
           {/* Right: NSF Logo + Logout Button */}
-          <div style={{ 
-            display: 'flex', 
-            alignItems: 'center', 
-            gap: '1.5rem',
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '1rem',
             flex: '0 0 auto'
           }}>
             {/* NSF Logo */}
@@ -535,7 +539,7 @@ const Navigation = () => {
                 display: 'flex',
                 alignItems: 'center',
                 gap: '0.5rem',
-                padding: '0.75rem 1.5rem',
+                padding: '0.5rem 1rem',
                 backgroundColor: '#3b82f6', // Blue like in the image
                 color: 'white',
                 border: 'none',
@@ -543,6 +547,7 @@ const Navigation = () => {
                 fontSize: '0.9rem',
                 fontWeight: '600',
                 cursor: 'pointer',
+                whiteSpace: 'nowrap',
                 transition: 'all 0.2s ease',
                 fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
               }}


### PR DESCRIPTION
## Summary
- On admin sessions the Access Requests link bumped the header to six items and the previous spacing no longer fit, wrapping "Access Requests" onto a second line and visually misaligning the Logout button.
- Apply `white-space: nowrap` to every nav link/button so labels can't wrap mid-word.
- Tighten gaps and paddings (1.5rem → 1rem, 0.75rem 1rem → 0.5rem 0.75rem, Logout 0.75rem 1.5rem → 0.5rem 1rem) so all items fit on one row.
- Raise the inner container's max width from 1200px to 1400px to give the header more breathing room before falling back on the tighter sizes.
- Bump version to `0.19.1` (patch — pure UI layout fix).

## Test plan
- [x] UI build passes (`npm run build` inside `ui/`).
- [x] Manual visual check on local stack (`http://localhost:8002/ui`) with an admin session — header now renders Dashboard, Organizations, Resources, Services, Search, Access Requests, NSF logo and Logout on a single row.
- [ ] Visual check with a non-admin session (Access Requests hidden) to confirm the tighter spacing still looks good.

Closes #136