### PR TITLE
feat(ui): filter datasets by organization on Dataset Management page (closes #138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2] - 2026-04-30
+
+### Added
+- Dataset Management page: a new "Organization" select on the right side of the datasets card header now filters the visible rows by the organization that owns them. The filter runs client-side on the data the page already fetches, so no extra API call is needed:
+  - Default value is "All organizations", which keeps the current behavior of showing every dataset
+  - When a filter is active, the dataset count next to the title becomes "Datasets (X of Y)" so the user knows how many were hidden
+  - When the filter matches no rows, the empty-state copy suggests trying a different organization or going back to the full list, instead of nudging the user to create a new dataset
+  - The select reuses the organization name strings the page already fetches for the create/edit form, so the dropdown values match the strings rendered in the table's "Organization" column
+
 ## [0.19.1] - 2026-04-30
 
 ### Fixed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.19.1"
+    swagger_version: str = "0.19.2"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/pages/DatasetManagement.js
+++ b/ui/src/pages/DatasetManagement.js
@@ -72,6 +72,7 @@ const DatasetManagement = () => {
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [editingDataset, setEditingDataset] = useState(null);
   const [selectedServer] = useState('local'); // Fixed to local for consistency
+  const [orgFilter, setOrgFilter] = useState('');
   const [expandedDatasets, setExpandedDatasets] = useState({});
   const [publishingIds, setPublishingIds] = useState({});
   const [editingResource, setEditingResource] = useState(null);
@@ -1088,11 +1089,33 @@ const DatasetManagement = () => {
       )}
 
       {/* Datasets List */}
+      {(() => {
+        const filteredDatasets = orgFilter
+          ? datasets.filter((d) => d.owner_org === orgFilter)
+          : datasets;
+        return (
       <div className="card">
-        <div className="card-header">
-          <h3 className="card-title">
-            Datasets ({datasets.length})
+        <div className="card-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+          <h3 className="card-title" style={{ margin: 0 }}>
+            Datasets ({filteredDatasets.length}{orgFilter ? ` of ${datasets.length}` : ''})
           </h3>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <label htmlFor="org-filter" style={{ fontSize: '0.875rem', color: '#64748b' }}>
+              Organization:
+            </label>
+            <select
+              id="org-filter"
+              value={orgFilter}
+              onChange={(e) => setOrgFilter(e.target.value)}
+              className="form-input"
+              style={{ minWidth: '200px', padding: '0.375rem 0.5rem' }}
+            >
+              <option value="">All organizations</option>
+              {organizations.map((org) => (
+                <option key={org} value={org}>{org}</option>
+              ))}
+            </select>
+          </div>
         </div>
 
         {loading && !showCreateForm ? (
@@ -1100,11 +1123,20 @@ const DatasetManagement = () => {
             <div className="loading-spinner" style={{ margin: '0 auto' }}></div>
             <p style={{ marginTop: '1rem' }}>Loading datasets...</p>
           </div>
-        ) : datasets.length === 0 ? (
+        ) : filteredDatasets.length === 0 ? (
           <div style={{ textAlign: 'center', padding: '2rem', color: '#64748b' }}>
             <Database size={48} style={{ marginBottom: '1rem', opacity: 0.5 }} />
-            <p>No general datasets found</p>
-            <p>Create your first general dataset using the form above, or check other pages for specific resource types (URL, S3, Kafka, Services)</p>
+            {orgFilter ? (
+              <>
+                <p>No datasets found for organization "{orgFilter}"</p>
+                <p>Try selecting a different organization or "All organizations" to see the full list.</p>
+              </>
+            ) : (
+              <>
+                <p>No general datasets found</p>
+                <p>Create your first general dataset using the form above, or check other pages for specific resource types (URL, S3, Kafka, Services)</p>
+              </>
+            )}
           </div>
         ) : (
           <div className="table-container">
@@ -1119,7 +1151,7 @@ const DatasetManagement = () => {
                 </tr>
               </thead>
               <tbody>
-                {datasets.map((dataset, index) => {
+                {filteredDatasets.map((dataset, index) => {
                   const isExpanded = expandedDatasets[dataset.id];
                   const hasResources = dataset.resources && dataset.resources.length > 0;
 
@@ -1399,6 +1431,8 @@ const DatasetManagement = () => {
           </div>
         )}
       </div>
+        );
+      })()}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Add an "Organization" select on the right side of the Dataset Management card header that filters the visible rows client-side, using the org list the page already fetches for the create/edit form (no extra API call).
- Default value "All organizations" preserves the current behavior; when a filter is active the count next to the title becomes "Datasets (X of Y)".
- The empty-state copy is specialised for the filtered case so it never nudges the user to create a dataset when the filter simply has no matches.
- Bump version to `0.19.2` (patch — pure UI filter on existing data, no backend changes).

## Test plan
- [x] UI build passes (`npm run build` inside `ui/`) — +228 B gzip.
- [x] Manual verification on local stack: dropdown values match the strings rendered in the "Organization" column; selecting an org narrows the table; "All organizations" restores the full list.
- [ ] Manual check that the empty-state copy switches when the filter matches no rows.

Closes #138