### PR TITLE
fix(ui): align Services controls layout and hide redundant Cancel toggle (closes #140, #141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3] - 2026-04-30
+
+### Fixed
+- Services Registry page: dropped the leftover "Controls" card wrapper, the static "Local Server Only" badge and the Refresh button so the layout now mirrors the other resource management pages — the page header is followed directly by the primary "Register Service" button (Dataset Management, Kafka Topics, URL Resources and S3 Resources had already been cleaned up in 0.17.1; Services was missed back then)
+- Resource management pages (Dataset Management, Kafka Topics, URL Resources, Services, S3 Resources): the outer primary button used to toggle its label between "Create …" / "Register …" and "Cancel" depending on whether the create form was open, which made two separate "Cancel" buttons visible at once (the outer toggle and the one inside the form's card header). The outer button is now only rendered while the form is closed, so the form's own Cancel button stays as the single way to dismiss the form
+
 ## [0.19.2] - 2026-04-30
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.19.2"
+    swagger_version: str = "0.19.3"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/pages/DatasetManagement.js
+++ b/ui/src/pages/DatasetManagement.js
@@ -749,15 +749,17 @@ const DatasetManagement = () => {
       )}
 
       {/* Create dataset button */}
-      <div style={{ marginBottom: '1rem' }}>
-        <button
-          onClick={() => setShowCreateForm(!showCreateForm)}
-          className="btn btn-primary"
-        >
-          <Plus size={16} />
-          {showCreateForm ? 'Cancel' : 'Create Dataset'}
-        </button>
-      </div>
+      {!showCreateForm && (
+        <div style={{ marginBottom: '1rem' }}>
+          <button
+            onClick={() => setShowCreateForm(true)}
+            className="btn btn-primary"
+          >
+            <Plus size={16} />
+            Create Dataset
+          </button>
+        </div>
+      )}
 
       {/* Create/Edit Dataset Form */}
       {showCreateForm && (

--- a/ui/src/pages/KafkaTopics.js
+++ b/ui/src/pages/KafkaTopics.js
@@ -393,13 +393,15 @@ const KafkaTopics = () => {
           <RefreshCw size={16} />
           Refresh
         </button>
-        <button
-          onClick={() => setShowCreateForm(!showCreateForm)}
-          className="btn btn-primary"
-        >
-          <Plus size={16} />
-          {showCreateForm ? 'Cancel' : 'Create Kafka Topic'}
-        </button>
+        {!showCreateForm && (
+          <button
+            onClick={() => setShowCreateForm(true)}
+            className="btn btn-primary"
+          >
+            <Plus size={16} />
+            Create Kafka Topic
+          </button>
+        )}
       </div>
 
       {/* Create/Edit Kafka Topic Form */}

--- a/ui/src/pages/S3Resources.js
+++ b/ui/src/pages/S3Resources.js
@@ -396,13 +396,15 @@ const S3Resources = () => {
           <RefreshCw size={16} />
           Refresh
         </button>
-        <button
-          onClick={() => setShowCreateForm(!showCreateForm)}
-          className="btn btn-primary"
-        >
-          <Plus size={16} />
-          {showCreateForm ? 'Cancel' : 'Create S3 Resource'}
-        </button>
+        {!showCreateForm && (
+          <button
+            onClick={() => setShowCreateForm(true)}
+            className="btn btn-primary"
+          >
+            <Plus size={16} />
+            Create S3 Resource
+          </button>
+        )}
       </div>
 
       {/* Create/Edit S3 Resource Form */}

--- a/ui/src/pages/Services.js
+++ b/ui/src/pages/Services.js
@@ -406,15 +406,17 @@ const Services = () => {
       )}
 
       {/* Register service button */}
-      <div style={{ marginBottom: '1rem' }}>
-        <button
-          onClick={() => setShowCreateForm(!showCreateForm)}
-          className="btn btn-primary"
-        >
-          <Plus size={16} />
-          {showCreateForm ? 'Cancel' : 'Register Service'}
-        </button>
-      </div>
+      {!showCreateForm && (
+        <div style={{ marginBottom: '1rem' }}>
+          <button
+            onClick={() => setShowCreateForm(true)}
+            className="btn btn-primary"
+          >
+            <Plus size={16} />
+            Register Service
+          </button>
+        </div>
+      )}
 
       {/* Create/Edit Service Form */}
       {showCreateForm && (

--- a/ui/src/pages/Services.js
+++ b/ui/src/pages/Services.js
@@ -6,7 +6,6 @@ import {
   Save,
   X,
   Trash2,
-  RefreshCw,
   ExternalLink,
   FileText,
   Server,
@@ -406,38 +405,15 @@ const Services = () => {
         </div>
       )}
 
-      {/* Controls */}
-      <div className="card">
-        <div className="card-header">
-          <h3 className="card-title">Controls</h3>
-          <div style={{ display: 'flex', gap: '0.5rem' }}>
-            <span style={{ 
-              fontSize: '0.875rem', 
-              color: '#64748b',
-              padding: '0.375rem 0.75rem',
-              backgroundColor: '#f1f5f9',
-              borderRadius: '6px',
-              border: '1px solid #e2e8f0'
-            }}>
-              📍 Local Server Only
-            </span>
-            <button
-              onClick={fetchServices}
-              className="btn btn-secondary"
-              disabled={loading}
-            >
-              <RefreshCw size={16} />
-              Refresh
-            </button>
-            <button
-              onClick={() => setShowCreateForm(!showCreateForm)}
-              className="btn btn-primary"
-            >
-              <Plus size={16} />
-              {showCreateForm ? 'Cancel' : 'Register Service'}
-            </button>
-          </div>
-        </div>
+      {/* Register service button */}
+      <div style={{ marginBottom: '1rem' }}>
+        <button
+          onClick={() => setShowCreateForm(!showCreateForm)}
+          className="btn btn-primary"
+        >
+          <Plus size={16} />
+          {showCreateForm ? 'Cancel' : 'Register Service'}
+        </button>
       </div>
 
       {/* Create/Edit Service Form */}

--- a/ui/src/pages/UrlResources.js
+++ b/ui/src/pages/UrlResources.js
@@ -548,13 +548,15 @@ const UrlResources = () => {
           <RefreshCw size={16} />
           Refresh
         </button>
-        <button
-          onClick={() => setShowCreateForm(!showCreateForm)}
-          className="btn btn-primary"
-        >
-          <Plus size={16} />
-          {showCreateForm ? 'Cancel' : 'Create URL Resource'}
-        </button>
+        {!showCreateForm && (
+          <button
+            onClick={() => setShowCreateForm(true)}
+            className="btn btn-primary"
+          >
+            <Plus size={16} />
+            Create URL Resource
+          </button>
+        )}
       </div>
 
       {/* Create/Edit URL Resource Form */}


### PR DESCRIPTION
## Summary
Two related UI consistency fixes across the resource management pages.

**Closes #140** — Services Registry: drop the leftover "Controls" card wrapper, the "Local Server Only" badge and the Refresh button so the layout matches the other resource management pages cleaned up in 0.17.1. Only the primary "Register Service" button remains under the page header. Drops the unused `RefreshCw` import.

**Closes #141** — Dataset Management, Kafka Topics, URL Resources, Services, S3 Resources: the outer primary button used to toggle its label between "Create …" / "Register …" and "Cancel" depending on whether the create form was open, which made two separate "Cancel" buttons visible at once (the outer toggle and the one inside the form's card header). The outer button is now only rendered while the form is closed, so the form's own Cancel button stays as the single way to dismiss the form.

Bump version to `0.19.3` (patch — UI consistency only, no behavioral change).

## Test plan
- [x] UI build passes (`npm run build` inside `ui/`).
- [x] Manual verification: opening the create/register form on each of the five pages no longer shows two Cancel buttons; closing the form via the form's Cancel restores the outer primary button.
- [x] Services Registry header layout now matches Dataset Management.

Closes #140
Closes #141