### PR TITLE
feat(ui): route Services Access link through the redirect proxy (closes #145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.5] - 2026-04-30
+
+### Changed
+- Services Registry table: the "Access Service" link no longer points straight at the registered `service_url`. It now goes through the EP API's existing redirect proxy at `/services/redirect/{service_name}`, so every consumption of the registered service stays inside the EP boundary (consistent logging, headers, future auth handling) and the UI no longer hardcodes external URLs in `<a href>` attributes:
+  - `BASE_URL` is now exported from the shared API client and consumed in the Services page so the proxy URL is built from the same `rootPath` the axios client uses
+  - The link is rendered only when the service has both a usable `service_url` and a `name` (the CKAN-style name is the identifier the backend's `get_service_url` matches against)
+  - The hover tooltip now reads "Proxied through <redirect-url> → <service-url>" so the user can see at a glance that the click goes through the EP API and where it ends up
+- The Documentation link is intentionally left untouched: documentation typically lives on a different host than the service URL, and the redirect proxy is not designed to forward to arbitrary external URLs
+
 ## [0.19.4] - 2026-04-30
 
 ### Changed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.19.4"
+    swagger_version: str = "0.19.5"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/pages/Services.js
+++ b/ui/src/pages/Services.js
@@ -11,7 +11,7 @@ import {
   Server,
   Edit3
 } from 'lucide-react';
-import { servicesAPI, searchAPI, resourcesAPI } from '../services/api';
+import { servicesAPI, searchAPI, resourcesAPI, BASE_URL } from '../services/api';
 
 /**
  * Services page component for managing registered services
@@ -827,9 +827,9 @@ const Services = () => {
                         </span>
                       </td>
                       <td>
-                        {serviceUrl !== 'No URL' ? (
+                        {serviceUrl !== 'No URL' && service.name ? (
                           <a
-                            href={serviceUrl}
+                            href={`${BASE_URL}/services/redirect/${service.name}`}
                             target="_blank"
                             rel="noopener noreferrer"
                             style={{
@@ -844,7 +844,7 @@ const Services = () => {
                               textOverflow: 'ellipsis',
                               whiteSpace: 'nowrap'
                             }}
-                            title={serviceUrl}
+                            title={`Proxied through ${BASE_URL}/services/redirect/${service.name} → ${serviceUrl}`}
                           >
                             <ExternalLink size={12} />
                             Access Service

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 // Base URL of your API - configurable via environment variable
-const BASE_URL = window.__EP_CONFIG__?.rootPath ?? '';
+export const BASE_URL = window.__EP_CONFIG__?.rootPath ?? '';
 
 // Create axios instance with default configuration
 const apiClient = axios.create({


### PR DESCRIPTION
## Summary
- The Services Registry table's "Access Service" link no longer points at the registered `service_url` directly; it now uses the existing `/services/redirect/{service_name}` proxy so every consumption of the registered service stays inside the EP boundary.
- Export `BASE_URL` from the shared API client and consume it on the Services page so the proxy URL uses the same `rootPath` as the axios client.
- The link only renders when the service has both a usable URL and a name; the hover tooltip surfaces both the redirect URL and the underlying `service_url`.
- The Documentation link is intentionally untouched (docs typically live on a different host than the service URL, where the redirect proxy is not designed to point).
- Bump version to `0.19.5` (patch — UI plumbing change with no API surface change).

## Test plan
- [x] UI build passes (`npm run build` inside `ui/`).
- [x] Manual verification on local stack: clicking "Access Service" on the Open-Meteo entry hits `${BASE_URL}/services/redirect/open-meteo` and is proxied to `https://api.open-meteo.com/v1/`; the tooltip now shows both URLs.
- [ ] Manual edge case: a service registered without a name still falls back to the "No URL" placeholder and does not render a broken link.

Closes #145