### PR TITLE
Include organizations in the Search page (closes #149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-05-12
+
+### Added
+- Search page can now also find organizations alongside datasets and services:
+  - The mode selector gained a third scope, `Organizations`, in addition to `Datasets` and `Services`
+  - The default `All` mode runs the dataset search, the service search and the organization search in parallel, and renders the three result groups together so the user does not need to switch modes and re-run the same query to also see matching organizations
+  - Organization cards expose a `View datasets in this org →` action that re-runs the search scoped to that organization (using the existing POST `/search` `owner_org` filter) and switches the mode to `Datasets`, so the user can drill down without leaving the page
+  - When the org filter is active, a removable chip ("Filtered by org: X (×)") is shown right under the search bar so the user always sees which scope is applied and can clear it with one click
+  - Clicking the chip's clear button restores the unfiltered behavior and keeps the typed term (re-running the broader search if a term is present, or just clearing the page otherwise)
+- The search term is now optional when the mode is `Organizations` (the EP's `GET /organization` endpoint already lists every organization on the server when no `name` filter is provided), so the user can browse the full list of organizations without typing anything
+
+### Changed
+- Search hero title now reads "Find datasets, services and organizations"
+- Results summary now mentions the active organization scope when one is applied
+
 ## [0.20.0] - 2026-05-11
 
 ### Changed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.20.0"
+    swagger_version: str = "0.21.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/pages/Search.js
+++ b/ui/src/pages/Search.js
@@ -6,14 +6,16 @@ import {
   FileText,
   X,
   ExternalLink,
-  Database
+  Database,
+  Building2
 } from 'lucide-react';
-import { searchAPI } from '../services/api';
+import { searchAPI, organizationsAPI } from '../services/api';
 
 const MODES = [
   { id: 'both', label: 'All' },
   { id: 'datasets', label: 'Datasets' },
-  { id: 'services', label: 'Services' }
+  { id: 'services', label: 'Services' },
+  { id: 'organizations', label: 'Organizations' }
 ];
 
 const SERVERS = [
@@ -30,18 +32,34 @@ const Search = () => {
   const [hasSearched, setHasSearched] = useState(false);
   const [datasetResults, setDatasetResults] = useState([]);
   const [serviceResults, setServiceResults] = useState([]);
+  const [organizationResults, setOrganizationResults] = useState([]);
+  // When set, datasets/services queries are scoped to this org and the typed
+  // term is ignored, so clicking "View datasets" on an org card lists every
+  // dataset of that org without forcing the user to retype anything.
+  const [ownerOrgFilter, setOwnerOrgFilter] = useState(null);
   const inputRef = useRef(null);
 
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
 
-  const fetchDatasets = async (term, selectedServer) => {
+  const fetchDatasets = async (term, selectedServer, ownerOrg) => {
+    if (ownerOrg) {
+      const response = await searchAPI.searchAdvanced({
+        owner_org: ownerOrg,
+        search_term: term || undefined,
+        server: selectedServer
+      });
+      return (response.data || []).filter((item) => item.owner_org !== 'services');
+    }
     const response = await searchAPI.searchByTerms([term], null, selectedServer);
     return (response.data || []).filter((item) => item.owner_org !== 'services');
   };
 
-  const fetchServices = async (term, selectedServer) => {
+  const fetchServices = async (term, selectedServer, ownerOrg) => {
+    // Services always live in the "services" org; an external ownerOrg filter
+    // doesn't make sense for them, so we silently skip when one is active.
+    if (ownerOrg && ownerOrg !== 'services') return [];
     const response = await searchAPI.searchAdvanced({
       owner_org: 'services',
       search_term: term,
@@ -50,10 +68,19 @@ const Search = () => {
     return (response.data || []).filter((item) => item.owner_org === 'services');
   };
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    const term = searchTerm.trim();
-    if (!term) {
+  const fetchOrganizations = async (term, selectedServer) => {
+    const params = { server: selectedServer };
+    if (term) params.name = term;
+    const response = await organizationsAPI.list(params);
+    return Array.isArray(response.data) ? response.data : [];
+  };
+
+  const runSearch = async ({ term, currentMode, currentServer, currentOwnerOrg }) => {
+    const trimmed = (term || '').trim();
+    // Term is required unless the query already has another scope: a
+    // selected organization filter, or the "Organizations" mode (which can
+    // list every organization on the server).
+    if (!trimmed && !currentOwnerOrg && currentMode !== 'organizations') {
       setError('Please enter a search term');
       return;
     }
@@ -62,22 +89,41 @@ const Search = () => {
     setError(null);
 
     try {
-      const wantDatasets = mode === 'datasets' || mode === 'both';
-      const wantServices = mode === 'services' || mode === 'both';
+      const wantDatasets = currentMode === 'datasets' || currentMode === 'both';
+      const wantServices = currentMode === 'services' || currentMode === 'both';
+      // Organizations are listed whenever the user explicitly asked for the
+      // `organizations` mode (the org-level scope filter doesn't apply to a
+      // list of organizations). In `both` mode, an active org filter means
+      // the user is focused on a single org, so we hide the org list there.
+      const wantOrgs =
+        currentMode === 'organizations' ||
+        (currentMode === 'both' && !currentOwnerOrg);
 
-      const safe = (p) => p.then((data) => ({ ok: true, data })).catch((err) => ({ ok: false, err }));
-      const [datasetsRes, servicesRes] = await Promise.all([
-        wantDatasets ? safe(fetchDatasets(term, server)) : Promise.resolve({ ok: true, data: [] }),
-        wantServices ? safe(fetchServices(term, server)) : Promise.resolve({ ok: true, data: [] })
+      const safe = (p) =>
+        p.then((data) => ({ ok: true, data })).catch((err) => ({ ok: false, err }));
+      const [datasetsRes, servicesRes, orgsRes] = await Promise.all([
+        wantDatasets
+          ? safe(fetchDatasets(trimmed, currentServer, currentOwnerOrg))
+          : Promise.resolve({ ok: true, data: [] }),
+        wantServices
+          ? safe(fetchServices(trimmed, currentServer, currentOwnerOrg))
+          : Promise.resolve({ ok: true, data: [] }),
+        wantOrgs
+          ? safe(fetchOrganizations(trimmed, currentServer))
+          : Promise.resolve({ ok: true, data: [] })
       ]);
 
-      // Fail only when every requested search failed.
-      const requested = [wantDatasets && datasetsRes, wantServices && servicesRes].filter(Boolean);
-      const allFailed = requested.every((r) => !r.ok);
+      const requested = [
+        wantDatasets && datasetsRes,
+        wantServices && servicesRes,
+        wantOrgs && orgsRes
+      ].filter(Boolean);
+      const allFailed = requested.length > 0 && requested.every((r) => !r.ok);
       if (allFailed) throw requested[0].err;
 
       setDatasetResults(datasetsRes.ok ? datasetsRes.data : []);
       setServiceResults(servicesRes.ok ? servicesRes.data : []);
+      setOrganizationResults(orgsRes.ok ? orgsRes.data : []);
       setHasSearched(true);
     } catch (err) {
       const status = err.response?.status;
@@ -92,12 +138,51 @@ const Search = () => {
     }
   };
 
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    runSearch({
+      term: searchTerm,
+      currentMode: mode,
+      currentServer: server,
+      currentOwnerOrg: ownerOrgFilter
+    });
+  };
+
+  const handleViewDatasetsInOrg = (orgName) => {
+    setOwnerOrgFilter(orgName);
+    setMode('datasets');
+    runSearch({
+      term: '',
+      currentMode: 'datasets',
+      currentServer: server,
+      currentOwnerOrg: orgName
+    });
+  };
+
+  const handleClearOrgFilter = () => {
+    setOwnerOrgFilter(null);
+    if (searchTerm.trim()) {
+      runSearch({
+        term: searchTerm,
+        currentMode: mode,
+        currentServer: server,
+        currentOwnerOrg: null
+      });
+    } else {
+      setDatasetResults([]);
+      setServiceResults([]);
+      setOrganizationResults([]);
+      setHasSearched(false);
+    }
+  };
+
   const clearTerm = () => {
     setSearchTerm('');
     inputRef.current?.focus();
   };
 
-  const totalResults = datasetResults.length + serviceResults.length;
+  const totalResults =
+    datasetResults.length + serviceResults.length + organizationResults.length;
   const compact = hasSearched || loading;
 
   return (
@@ -128,7 +213,7 @@ const Search = () => {
               }}
             >
               <SearchIcon size={32} />
-              Find datasets and services
+              Find datasets, services and organizations
             </h1>
             <p style={{ color: '#64748b', margin: 0, marginBottom: '2rem' }}>
               Search across the National Data Platform
@@ -146,6 +231,10 @@ const Search = () => {
           />
 
           <FilterRow mode={mode} setMode={setMode} server={server} setServer={setServer} />
+
+          {ownerOrgFilter && mode !== 'organizations' && (
+            <OrgFilterChip orgName={ownerOrgFilter} onClear={handleClearOrgFilter} />
+          )}
         </form>
       </div>
 
@@ -157,7 +246,12 @@ const Search = () => {
       )}
 
       {hasSearched && !loading && !error && (
-        <ResultsSummary total={totalResults} mode={mode} term={searchTerm} />
+        <ResultsSummary
+          total={totalResults}
+          mode={mode}
+          term={searchTerm}
+          ownerOrg={mode === 'organizations' ? null : ownerOrgFilter}
+        />
       )}
 
       {hasSearched && !loading && !error && (mode === 'datasets' || mode === 'both') && (
@@ -179,6 +273,17 @@ const Search = () => {
           isService
         />
       )}
+
+      {hasSearched &&
+        !loading &&
+        !error &&
+        (mode === 'organizations' ||
+          (mode === 'both' && !ownerOrgFilter)) && (
+          <OrganizationsSection
+            items={organizationResults}
+            onViewDatasets={handleViewDatasetsInOrg}
+          />
+        )}
     </div>
   );
 };
@@ -318,28 +423,46 @@ const SegmentedControl = ({ options, value, onChange, subtle }) => (
   </div>
 );
 
-const ResultsSummary = ({ total, mode, term }) => (
-  <div
-    style={{
-      color: '#64748b',
-      fontSize: '0.9rem',
-      marginBottom: '1rem',
-      padding: '0 0.25rem'
-    }}
-  >
-    {total > 0 ? (
-      <>
-        Found <strong style={{ color: '#1e293b' }}>{total}</strong> result{total === 1 ? '' : 's'} for "
-        <strong style={{ color: '#1e293b' }}>{term}</strong>"
-        {mode !== 'both' && ` in ${mode}`}
-      </>
-    ) : (
-      <>
-        No results for "<strong style={{ color: '#1e293b' }}>{term}</strong>"
-      </>
-    )}
-  </div>
-);
+const ResultsSummary = ({ total, mode, term, ownerOrg }) => {
+  const trimmed = (term || '').trim();
+  const scope = mode !== 'both' ? ` in ${mode}` : '';
+  const termText = trimmed ? (
+    <>
+      {' '}for "<strong style={{ color: '#1e293b' }}>{trimmed}</strong>"
+    </>
+  ) : null;
+  const orgText = ownerOrg ? (
+    <>
+      {' '}in <strong style={{ color: '#1e293b' }}>{ownerOrg}</strong>
+    </>
+  ) : null;
+
+  return (
+    <div
+      style={{
+        color: '#64748b',
+        fontSize: '0.9rem',
+        marginBottom: '1rem',
+        padding: '0 0.25rem'
+      }}
+    >
+      {total > 0 ? (
+        <>
+          Found <strong style={{ color: '#1e293b' }}>{total}</strong> result
+          {total === 1 ? '' : 's'}
+          {termText}
+          {orgText || (!trimmed ? null : scope)}
+        </>
+      ) : (
+        <>
+          No results
+          {termText}
+          {orgText || (!trimmed ? null : scope)}
+        </>
+      )}
+    </div>
+  );
+};
 
 const ResultsSection = ({ title, icon, items, emptyMessage, isService }) => (
   <div style={{ marginBottom: '2rem' }}>
@@ -594,6 +717,154 @@ const Badge = ({ children, color, background }) => (
   >
     {children}
   </span>
+);
+
+const OrgFilterChip = ({ orgName, onClear }) => (
+  <div
+    style={{
+      marginTop: '0.75rem',
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '0.4rem',
+      background: '#eff6ff',
+      color: '#1d4ed8',
+      border: '1px solid #bfdbfe',
+      borderRadius: '999px',
+      padding: '0.25rem 0.5rem 0.25rem 0.75rem',
+      fontSize: '0.85rem',
+      fontWeight: 500
+    }}
+  >
+    <Building2 size={14} />
+    Filtered by org:&nbsp;<strong>{orgName}</strong>
+    <button
+      type="button"
+      onClick={onClear}
+      aria-label="Clear organization filter"
+      style={{
+        background: 'transparent',
+        border: 'none',
+        padding: '0.2rem',
+        marginLeft: '0.25rem',
+        cursor: 'pointer',
+        color: '#1d4ed8',
+        display: 'inline-flex',
+        alignItems: 'center'
+      }}
+    >
+      <X size={14} />
+    </button>
+  </div>
+);
+
+const OrganizationsSection = ({ items, onViewDatasets }) => (
+  <div style={{ marginBottom: '2rem' }}>
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        marginBottom: '0.75rem',
+        color: '#334155',
+        fontWeight: 600,
+        fontSize: '0.95rem',
+        textTransform: 'uppercase',
+        letterSpacing: '0.04em'
+      }}
+    >
+      <Building2 size={20} />
+      Organizations
+      <span
+        style={{
+          background: '#f1f5f9',
+          color: '#475569',
+          borderRadius: '999px',
+          padding: '0.1rem 0.55rem',
+          fontSize: '0.75rem',
+          fontWeight: 600
+        }}
+      >
+        {items.length}
+      </span>
+    </div>
+
+    {items.length === 0 ? (
+      <div
+        style={{
+          background: '#f8fafc',
+          border: '1px dashed #e2e8f0',
+          borderRadius: '8px',
+          padding: '1.25rem',
+          color: '#94a3b8',
+          fontSize: '0.9rem',
+          textAlign: 'center'
+        }}
+      >
+        No organizations matched your search.
+      </div>
+    ) : (
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))',
+          gap: '0.75rem'
+        }}
+      >
+        {items.map((orgName) => (
+          <OrganizationCard
+            key={orgName}
+            orgName={orgName}
+            onViewDatasets={onViewDatasets}
+          />
+        ))}
+      </div>
+    )}
+  </div>
+);
+
+const OrganizationCard = ({ orgName, onViewDatasets }) => (
+  <div
+    style={{
+      background: 'white',
+      border: '1px solid #e2e8f0',
+      borderRadius: '10px',
+      padding: '1rem 1.1rem',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '0.6rem'
+    }}
+  >
+    <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+      <Badge color="#0f766e" background="#ecfdf5">Organization</Badge>
+    </div>
+    <div
+      style={{
+        fontSize: '1.05rem',
+        fontWeight: 600,
+        color: '#0f172a',
+        wordBreak: 'break-word'
+      }}
+    >
+      {orgName}
+    </div>
+    <button
+      type="button"
+      onClick={() => onViewDatasets(orgName)}
+      style={{
+        marginTop: '0.1rem',
+        alignSelf: 'flex-start',
+        background: 'transparent',
+        border: 'none',
+        padding: 0,
+        color: '#2563eb',
+        fontSize: '0.85rem',
+        fontWeight: 500,
+        cursor: 'pointer'
+      }}
+    >
+      View datasets in this org →
+    </button>
+  </div>
 );
 
 export default Search;


### PR DESCRIPTION
## Summary
- Search page can now also surface organizations alongside datasets and services. The mode selector exposes "Organizations" as a third scope, and the default "All" mode runs the three queries in parallel and renders the three result groups together.
- Organization cards offer a one-click "View datasets in this org →" action that re-runs the search scoped to that organization (using the existing POST `/search` `owner_org` filter) without making the user retype the term.
- While an org scope is active, a removable chip ("Filtered by org: X (×)") is shown under the search bar so the user can always see — and clear — what is narrowing the results. The chip is hidden in "Organizations" mode because the scope does not apply to a list of organizations, but the state is preserved so switching back to "Datasets"/"Services" keeps the previous scope.
- The typed term is now optional in "Organizations" mode: the EP's existing `GET /organization` endpoint already lists every organization when no `name` filter is provided, so users can browse the full list of orgs without typing anything.
- Hero title updated to "Find datasets, services and organizations" and the results summary mentions the active org scope where it actually applies.

## Test plan
- [ ] In "All" mode, type a term and confirm three groups (Datasets, Services, Organizations) render with their per-group counts. The total in the summary equals the sum of the three groups.
- [ ] Switch to "Organizations" mode with an empty term and submit — confirm the full list of orgs for the selected server is returned and the chip/summary do not mention any org scope.
- [ ] From an organization card, click "View datasets in this org →". Confirm the page switches to "Datasets" mode, a chip "Filtered by org: <name>" appears under the search bar, and the dataset results are restricted to that org. The summary mentions the scope.
- [ ] Click the chip's × — confirm the filter is removed; if the search bar still has a term, the broader search is re-run, otherwise the results area is cleared.
- [ ] While the chip is active, switch to "Organizations" mode and submit — confirm the chip is hidden, the summary does not mention the scope, and the list of organizations is returned (the previous filter is restored when switching back to Datasets/Services).
- [ ] When every requested query fails (force an unreachable server) the error banner is shown; when at least one succeeds, no error is shown and the surviving groups render.
- [ ] `docker compose exec api python -m pytest tests/ -v` and `react-scripts build` both succeed.

Closes #149.