### PR TITLE
Persist creator hash on POST /organization (closes #151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-05-12
+
+### Added
+- Organizations created through `POST /organization` now persist the same one-way creator hashes (`ndp_user_id` and `ndp_creator_md5`) that datasets, services, URL, S3 and Kafka registrations already store via `inject_ndp_metadata`:
+  - The route used to capture the authenticated `user_info` only to satisfy the auth dependency and then discarded it; it now forwards it to the `create_organization` service, which derives the hashes with the existing helpers (`hash_user_id`/`calculate_md5`).
+  - The MongoDB backend persists `ndp_user_id` and `ndp_creator_md5` as top-level fields on the organization document when the request was authenticated.
+  - The CKAN backend turns those same hashes into standard CKAN organization extras (so CKAN never receives unknown top-level fields). Any caller-provided extras are preserved and the creator extras are appended.
+  - No PII is stored. Only the same hash family already used for datasets — the raw user identity is never persisted.
+  - Organizations created before this version stay valid and simply keep no attribution; no migration is performed.
+
+### Changed
+- `hash_user_id` and `calculate_md5` are now re-exported from `api.services.metadata_services`, so services other than `inject_ndp_metadata` can reuse them without reaching into the submodule.
+
 ## [0.21.0] - 2026-05-12
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.21.0"
+    swagger_version: str = "0.22.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/repositories/ckan_repository.py
+++ b/api/repositories/ckan_repository.py
@@ -268,7 +268,10 @@ class CKANRepository(DataCatalogRepository):
         Parameters
         ----------
         **kwargs
-            Organization creation parameters (name, title, etc.)
+            Organization creation parameters (name, title, etc.).
+            ``ndp_user_id`` and ``ndp_creator_md5``, when provided, are
+            forwarded to CKAN as organization extras instead of
+            top-level fields (CKAN would otherwise reject unknown keys).
 
         Returns
         -------
@@ -280,6 +283,19 @@ class CKANRepository(DataCatalogRepository):
         Exception
             If CKAN organization creation fails
         """
+        # Pull the creator hashes out of the kwargs and forward them as
+        # standard CKAN extras, so the data lives on the org but the
+        # public surface of the route stays unchanged.
+        ndp_user_id = kwargs.pop("ndp_user_id", None)
+        ndp_creator_md5 = kwargs.pop("ndp_creator_md5", None)
+        creator_extras = []
+        if ndp_user_id:
+            creator_extras.append({"key": "ndp_user_id", "value": ndp_user_id})
+        if ndp_creator_md5:
+            creator_extras.append({"key": "ndp_creator_md5", "value": ndp_creator_md5})
+        if creator_extras:
+            existing_extras = kwargs.get("extras") or []
+            kwargs["extras"] = list(existing_extras) + creator_extras
         return self.ckan.action.organization_create(**kwargs)
 
     def organization_show(self, id: str) -> Dict[str, Any]:

--- a/api/repositories/mongodb_repository.py
+++ b/api/repositories/mongodb_repository.py
@@ -789,6 +789,13 @@ class MongoDBRepository(DataCatalogRepository):
             "state": "active",
             "type": "organization",
         }
+        # Persist the creator hashes when provided. Same one-way scheme
+        # already used by datasets/services via inject_ndp_metadata —
+        # no PII is stored.
+        if kwargs.get("ndp_user_id"):
+            org_doc["ndp_user_id"] = kwargs["ndp_user_id"]
+        if kwargs.get("ndp_creator_md5"):
+            org_doc["ndp_creator_md5"] = kwargs["ndp_creator_md5"]
 
         try:
             self.organizations.insert_one(org_doc.copy())

--- a/api/routes/register_routes/post_organization.py
+++ b/api/routes/register_routes/post_organization.py
@@ -69,7 +69,7 @@ async def create_organization_endpoint(
     server: Literal["local", "pre_ckan"] = Query(
         "local", description="Specify 'local' or 'pre_ckan'. Defaults to 'local'."
     ),
-    _: Dict[str, Any] = Depends(get_user_for_write_operation),
+    user_info: Dict[str, Any] = Depends(get_user_for_write_operation),
 ):
     """
     Endpoint to create a new organization in CKAN.
@@ -81,8 +81,10 @@ async def create_organization_endpoint(
         the organization.
     server : Literal['local', 'pre_ckan']
         The CKAN server instance to use.
-    _ : Dict[str, Any]
-        User authentication and authorization (unused).
+    user_info : Dict[str, Any]
+        Authenticated user information. Only used to compute the
+        one-way creator hashes that are persisted with the
+        organization; no PII is stored.
 
     Returns
     -------
@@ -99,7 +101,11 @@ async def create_organization_endpoint(
     """
     try:
         organization_id = organization_services.create_organization(
-            name=org.name, title=org.title, description=org.description, server=server
+            name=org.name,
+            title=org.title,
+            description=org.description,
+            server=server,
+            user_info=user_info,
         )
         return {
             "id": organization_id,

--- a/api/services/metadata_services/__init__.py
+++ b/api/services/metadata_services/__init__.py
@@ -1,3 +1,7 @@
 # api/services/metadata_services/__init__.py
 
-from .metadata_injection import inject_ndp_metadata  # noqa: F401
+from .metadata_injection import (  # noqa: F401
+    calculate_md5,
+    hash_user_id,
+    inject_ndp_metadata,
+)

--- a/api/services/organization_services/create_organization.py
+++ b/api/services/organization_services/create_organization.py
@@ -1,10 +1,11 @@
 # api/services/organization_services/create_organization.py
-from typing import Literal, Optional
+from typing import Any, Dict, Literal, Optional
 
 from ckanapi import NotFound, ValidationError
 
 from api.config import catalog_settings
 from api.config.ckan_settings import ckan_settings
+from api.services.metadata_services import calculate_md5, hash_user_id
 
 
 def create_organization(
@@ -12,6 +13,7 @@ def create_organization(
     title: str,
     description: Optional[str] = None,
     server: Literal["local", "pre_ckan"] = "local",
+    user_info: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     Create a new organization in CKAN.
@@ -27,6 +29,11 @@ def create_organization(
     server : Literal["local", "pre_ckan"]
         The server instance where the organization will be created.
         Defaults to "local".
+    user_info : Optional[Dict[str, Any]]
+        Authenticated user information. Only used to derive the same
+        one-way creator hashes (``ndp_user_id`` and ``ndp_creator_md5``)
+        that are already persisted alongside datasets via
+        ``inject_ndp_metadata``. The raw user identity is never stored.
 
     Returns
     -------
@@ -47,11 +54,19 @@ def create_organization(
         # Use local catalog (can be CKAN or MongoDB)
         repository = catalog_settings.local_catalog
 
-    try:
-        # Create the organization
-        organization = repository.organization_create(
-            name=name, title=title, description=description
+    create_kwargs: Dict[str, Any] = {
+        "name": name,
+        "title": title,
+        "description": description,
+    }
+    if user_info:
+        create_kwargs["ndp_user_id"] = hash_user_id(user_info)
+        create_kwargs["ndp_creator_md5"] = calculate_md5(
+            user_info.get("sub", "unknown")
         )
+
+    try:
+        organization = repository.organization_create(**create_kwargs)
         # Return the organization ID
         return organization["id"]
     except ValidationError as e:

--- a/tests/repositories/test_ckan_repository.py
+++ b/tests/repositories/test_ckan_repository.py
@@ -156,6 +156,47 @@ class TestCKANRepositoryOrganizationOperations:
             name="test-org", title="Test Org"
         )
 
+    def test_organization_create_forwards_creator_hashes_as_extras(self):
+        """Creator hashes are turned into CKAN organization extras."""
+        mock_ckan = MagicMock()
+        mock_ckan.action.organization_create.return_value = {"id": "org-with-hash"}
+
+        repo = CKANRepository(mock_ckan)
+        repo.organization_create(
+            name="hashed-org",
+            title="Hashed Org",
+            ndp_user_id="abcd1234efgh5678",
+            ndp_creator_md5="d41d8cd98f00b204e9800998ecf8427e",
+        )
+
+        call_kwargs = mock_ckan.action.organization_create.call_args.kwargs
+        # The hashes must not leak through as top-level CKAN kwargs.
+        assert "ndp_user_id" not in call_kwargs
+        assert "ndp_creator_md5" not in call_kwargs
+        assert call_kwargs["extras"] == [
+            {"key": "ndp_user_id", "value": "abcd1234efgh5678"},
+            {"key": "ndp_creator_md5", "value": "d41d8cd98f00b204e9800998ecf8427e"},
+        ]
+
+    def test_organization_create_preserves_caller_extras(self):
+        """Hashes are appended to caller-provided extras, not replacing them."""
+        mock_ckan = MagicMock()
+        mock_ckan.action.organization_create.return_value = {"id": "org-mixed"}
+
+        repo = CKANRepository(mock_ckan)
+        repo.organization_create(
+            name="mixed-org",
+            title="Mixed Org",
+            extras=[{"key": "existing", "value": "kept"}],
+            ndp_user_id="abcd1234efgh5678",
+        )
+
+        call_kwargs = mock_ckan.action.organization_create.call_args.kwargs
+        assert call_kwargs["extras"] == [
+            {"key": "existing", "value": "kept"},
+            {"key": "ndp_user_id", "value": "abcd1234efgh5678"},
+        ]
+
     def test_organization_show(self):
         """Test retrieving an organization."""
         mock_ckan = MagicMock()

--- a/tests/repositories/test_mongodb_repository.py
+++ b/tests/repositories/test_mongodb_repository.py
@@ -254,6 +254,26 @@ def test_organization_create(mongodb_repo):
     assert org["name"] == "new-test-org"
     assert org["title"] == "New Test Organization"
     assert org["description"] == "A test organization"
+    # Without creator hashes, the fields stay absent from the doc.
+    assert "ndp_user_id" not in org
+    assert "ndp_creator_md5" not in org
+
+
+def test_organization_create_with_creator_hashes(mongodb_repo):
+    """When ndp_user_id is provided it is persisted on the org doc."""
+    org = mongodb_repo.organization_create(
+        name="hashed-test-org",
+        title="Hashed Test Org",
+        ndp_user_id="abc123def4567890",
+        ndp_creator_md5="d41d8cd98f00b204e9800998ecf8427e",
+    )
+
+    assert org["ndp_user_id"] == "abc123def4567890"
+    assert org["ndp_creator_md5"] == "d41d8cd98f00b204e9800998ecf8427e"
+    # Round-trip: the stored doc keeps the fields.
+    fetched = mongodb_repo.organization_show(org["id"])
+    assert fetched["ndp_user_id"] == "abc123def4567890"
+    assert fetched["ndp_creator_md5"] == "d41d8cd98f00b204e9800998ecf8427e"
 
 
 def test_organization_show(mongodb_repo):

--- a/tests/test_create_organization_service.py
+++ b/tests/test_create_organization_service.py
@@ -158,6 +158,72 @@ class TestCreateOrganization:
         mock_repository.organization_create.assert_called_once()
 
     @patch("api.services.organization_services.create_organization.catalog_settings")
+    def test_create_organization_with_user_info_injects_hashes(
+        self, mock_catalog_settings
+    ):
+        """When user_info is provided, the creator hashes are forwarded."""
+        from api.services.metadata_services import calculate_md5, hash_user_id
+
+        mock_repository = MagicMock()
+        mock_repository.organization_create.return_value = {"id": "org-with-user"}
+        mock_catalog_settings.local_catalog = mock_repository
+
+        user_info = {"sub": "user-sub-abc123"}
+        result = create_organization(
+            name="hashed-org",
+            title="Hashed Org",
+            server="local",
+            user_info=user_info,
+        )
+
+        assert result == "org-with-user"
+        call_args = mock_repository.organization_create.call_args[1]
+        # Same hashing helpers that datasets use; never the raw sub.
+        assert call_args["ndp_user_id"] == hash_user_id(user_info)
+        assert call_args["ndp_creator_md5"] == calculate_md5("user-sub-abc123")
+        # The original org fields are still passed unchanged.
+        assert call_args["name"] == "hashed-org"
+        assert call_args["title"] == "Hashed Org"
+
+    @patch("api.services.organization_services.create_organization.catalog_settings")
+    def test_create_organization_without_user_info_does_not_inject_hashes(
+        self, mock_catalog_settings
+    ):
+        """Without user_info, no hash fields are added to the call."""
+        mock_repository = MagicMock()
+        mock_repository.organization_create.return_value = {"id": "org-no-user"}
+        mock_catalog_settings.local_catalog = mock_repository
+
+        create_organization(name="plain-org", title="Plain Org", server="local")
+
+        call_args = mock_repository.organization_create.call_args[1]
+        assert "ndp_user_id" not in call_args
+        assert "ndp_creator_md5" not in call_args
+
+    @patch("api.services.organization_services.create_organization.catalog_settings")
+    def test_create_organization_with_user_info_without_sub(
+        self, mock_catalog_settings
+    ):
+        """A user_info missing 'sub' still produces deterministic hashes."""
+        from api.services.metadata_services import calculate_md5, hash_user_id
+
+        mock_repository = MagicMock()
+        mock_repository.organization_create.return_value = {"id": "org-fallback"}
+        mock_catalog_settings.local_catalog = mock_repository
+
+        user_info = {"email": "x@example.com"}
+        create_organization(
+            name="sub-less-org",
+            title="Sub-less Org",
+            server="local",
+            user_info=user_info,
+        )
+
+        call_args = mock_repository.organization_create.call_args[1]
+        assert call_args["ndp_user_id"] == hash_user_id(user_info)
+        assert call_args["ndp_creator_md5"] == calculate_md5("unknown")
+
+    @patch("api.services.organization_services.create_organization.catalog_settings")
     def test_create_organization_returns_id_only(self, mock_catalog_settings):
         """Test that function returns only the ID, not full response."""
         mock_repository = MagicMock()


### PR DESCRIPTION
## Summary
- The `POST /organization` endpoint used to require authentication but discard the resulting `user_info`. It now forwards it to the `create_organization` service, which derives the same one-way creator hashes (`ndp_user_id` and `ndp_creator_md5`) already produced for datasets via `inject_ndp_metadata` and persists them on the organization.
- MongoDB stores the hashes as top-level fields on the organization document.
- CKAN turns them into standard CKAN organization `extras` entries (so CKAN never receives unknown top-level fields). Any caller-provided extras are preserved and the creator extras are appended.
- `hash_user_id` and `calculate_md5` are now re-exported from `api.services.metadata_services` so future callers do not have to reach into the submodule.
- No PII is stored — only the same hash family that datasets already use. Organizations created before this change stay valid and simply carry no attribution; no migration is performed.

## Backwards compatibility
- `POST /organization` request body unchanged (`name`, `title`, `description`).
- `POST /organization` response unchanged (`{id, message}`).
- `GET /organization` response unchanged (list of strings; the new field is stored but intentionally not exposed in this change).
- No new required fields anywhere; older clients keep working unchanged.

## Test plan
- [ ] `docker compose exec api python -m pytest tests/ -v` passes (1125 tests, +6 compared to 0.21.0: 3 new service tests for the hash injection path, 1 new MongoDB repo test for the persisted fields, 2 new CKAN repo tests for the extras conversion / preservation of caller extras).
- [ ] Create an organization through the existing UI form using an authenticated session and confirm the organization is created successfully (response shape unchanged).
- [ ] Inspect the stored organization document and verify that `ndp_user_id` (16-char hex) and `ndp_creator_md5` (32-char hex) are present on the MongoDB document, or that the equivalent CKAN `extras` entries are present on the CKAN org.
- [ ] Repeat the call with a second user and verify the hashes differ between the two organizations.
- [ ] Re-create an organization through any pathway that does not have `user_info` (e.g. seeding scripts) and verify no `ndp_user_id`/`ndp_creator_md5` fields are written — the path is opt-in.
- [ ] `black --check .` and `flake8 api/ tests/ --max-line-length=88` succeed (no new warnings introduced).

Closes #151.