### PR TITLE
Add an Only mine filter to the Search page (closes #153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-05-13
+
+### Added
+- Search page has a new "Only mine" toggle alongside the existing scope/server filters. When active, every result group (datasets, services and organizations) is restricted to items whose persisted creator hash matches the authenticated user. The toggle relies on the one-way hash that the EP already stores; no PII is involved.
+- `GET /organization` accepts a new optional `mine=true` query parameter. When set, the response is filtered server-side to organizations whose `ndp_user_id` extra (CKAN) or top-level `ndp_user_id` field (MongoDB) matches the requester's hash. The response shape stays `List[str]`. Requires a Bearer token; the endpoint stays anonymous-friendly when `mine` is not used.
+- `GET /user/info` now also returns the requesting user's own `ndp_user_id` (the same hash that the EP persists alongside resources). The UI uses this so it can filter datasets/services client-side without re-deriving the hash in the browser. Upstream payloads that already carry an `ndp_user_id` are preserved as-is.
+
+### Backwards compatibility
+- All changes are additive. No required parameters, no fields removed, no type changes.
+- `GET /organization` keeps working without authentication when `mine` is not passed; the response shape is unchanged.
+- `GET /user/info` keeps every field the auth service was returning and only adds `ndp_user_id` on top. Clients that ignore unknown fields are unaffected.
+- Items registered before the corresponding creator-hash feature simply do not appear under "Only mine"; no migration is performed.
+
 ## [0.22.0] - 2026-05-12
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.22.0"
+    swagger_version: str = "0.23.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/routes/search_routes/list_organizations_route.py
+++ b/api/routes/search_routes/list_organizations_route.py
@@ -1,12 +1,37 @@
 # api/routes/search_routes/list_organizations_route.py
-from typing import List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from api.config.ckan_settings import ckan_settings
 from api.services import organization_services
+from api.services.auth_services.get_current_user import get_current_user
+from api.services.metadata_services import hash_user_id
 
 router = APIRouter()
+
+# This route used to be fully unauthenticated. We only need a user
+# identity when the caller asks for ``?mine=true``, so we don't want to
+# start rejecting anonymous callers — that would be a breaking change
+# for anyone consuming ``GET /organization`` without a token.
+_optional_bearer = HTTPBearer(auto_error=False)
+
+
+def _get_optional_user(
+    creds: Optional[HTTPAuthorizationCredentials] = Depends(_optional_bearer),
+) -> Optional[Dict[str, Any]]:
+    """
+    Resolve user info if a Bearer token is provided; return ``None``
+    otherwise. Reuses the same validation logic as the required-auth
+    dependencies, so behavior with a token matches the rest of the API.
+    """
+    if creds is None:
+        return None
+    try:
+        return get_current_user(creds)
+    except HTTPException:
+        return None
 
 
 @router.get(
@@ -42,6 +67,16 @@ async def list_organizations(
             "Specify the server to list organizations from. Defaults to " "'local'."
         ),
     ),
+    mine: bool = Query(
+        False,
+        description=(
+            "When true, only return organizations created by the "
+            "authenticated user. Requires a Bearer token; orgs created "
+            "before the creator-hash feature carry no attribution and "
+            "are never included."
+        ),
+    ),
+    user_info: Optional[Dict[str, Any]] = Depends(_get_optional_user),
 ):
     """
     Endpoint to list all organizations. Optionally, filter organizations
@@ -53,6 +88,11 @@ async def list_organizations(
         A string to filter organizations by name (case-insensitive).
     server : Literal['local', 'global', 'pre_ckan']
         The CKAN server to list organizations from. Defaults to 'local'.
+    mine : bool
+        If true, restrict the result to organizations that carry the
+        authenticated user's creator hash. Requires a Bearer token.
+    user_info : Optional[Dict[str, Any]]
+        Authenticated user info, when a Bearer token is present.
 
     Returns
     -------
@@ -71,8 +111,22 @@ async def list_organizations(
             status_code=400, detail="Pre-CKAN is disabled and cannot be used."
         )
 
+    user_hash: Optional[str] = None
+    if mine:
+        if not user_info:
+            raise HTTPException(
+                status_code=401,
+                detail=(
+                    "Authentication required to filter organizations by "
+                    "'mine'. Provide a valid Bearer token."
+                ),
+            )
+        user_hash = hash_user_id(user_info)
+
     try:
-        organizations = organization_services.list_organization(name, server)
+        organizations = organization_services.list_organization(
+            name=name, server=server, user_hash=user_hash
+        )
         return organizations
     except Exception as e:
         # Convert the internal CKAN error to a more user-friendly message

--- a/api/routes/user_routes/user_info.py
+++ b/api/routes/user_routes/user_info.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 from fastapi import APIRouter, Depends
 
 from api.services.auth_services import get_user_for_endpoint_access
+from api.services.metadata_services import hash_user_id
 
 router = APIRouter()
 
@@ -92,6 +93,14 @@ async def get_user_info(
     satisfy any of the configured authorization paths are rejected
     with a 403 response.
 
+    On top of the upstream payload, the response is enriched with the
+    user's own ``ndp_user_id`` — the same SHA-256-based hash that the EP
+    persists alongside resources created by this user. The hash is
+    derived from the ``sub`` claim and is *not* PII; surfacing it here
+    lets clients (notably the Search UI) filter resources by the
+    "creator hash" they already see in resource extras without having
+    to compute the hash themselves.
+
     Parameters
     ----------
     user_info : Dict[str, Any]
@@ -100,7 +109,8 @@ async def get_user_info(
     Returns
     -------
     Dict[str, Any]
-        Complete user information as returned by the authentication service
+        Complete user information as returned by the authentication
+        service, plus a top-level ``ndp_user_id`` field.
 
     Raises
     ------
@@ -109,4 +119,9 @@ async def get_user_info(
         403: If the user is not authorized to access this Endpoint
         502: If authentication service is unavailable
     """
-    return user_info
+    # Additive enrichment — never overwrite an upstream value that
+    # happens to share the name, to keep this strictly backwards
+    # compatible if the auth service ever starts returning it itself.
+    enriched = dict(user_info)
+    enriched.setdefault("ndp_user_id", hash_user_id(user_info))
+    return enriched

--- a/api/services/organization_services/list_organization.py
+++ b/api/services/organization_services/list_organization.py
@@ -1,10 +1,32 @@
 # api/services/organization_services/list_organization.py
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from api.config import catalog_settings
 
 
-def list_organization(name: Optional[str] = None, server: str = "global") -> List[str]:
+def _extract_ndp_user_id(org: Dict[str, Any]) -> Optional[str]:
+    """
+    Read ``ndp_user_id`` from a full organization payload, regardless of
+    which backend produced it.
+
+    - MongoDB stores it as a top-level field on the org doc.
+    - CKAN stores it as a ``{"key": "ndp_user_id", "value": "..."}`` entry
+      inside the org's ``extras`` list.
+    """
+    top_level = org.get("ndp_user_id")
+    if top_level:
+        return top_level
+    for extra in org.get("extras") or []:
+        if isinstance(extra, dict) and extra.get("key") == "ndp_user_id":
+            return extra.get("value")
+    return None
+
+
+def list_organization(
+    name: Optional[str] = None,
+    server: str = "global",
+    user_hash: Optional[str] = None,
+) -> List[str]:
     """
     Retrieve a list of all organizations from the specified catalog,
     optionally filtered by name.
@@ -16,6 +38,11 @@ def list_organization(name: Optional[str] = None, server: str = "global") -> Lis
     server : str
         The catalog to use. Can be 'local', 'global', or 'pre_ckan'.
         Defaults to 'global'.
+    user_hash : Optional[str]
+        When provided, only organizations whose persisted
+        ``ndp_user_id`` matches this value are returned. The caller is
+        responsible for computing the hash from the authenticated
+        user's ``sub`` — the service stays oblivious to identities.
 
     Returns
     -------
@@ -39,7 +66,21 @@ def list_organization(name: Optional[str] = None, server: str = "global") -> Lis
         repository = catalog_settings.local_catalog
 
     try:
-        organizations = repository.organization_list(all_fields=False)
+        if user_hash:
+            # We need each org's creator hash to compare, so we have to
+            # ask the backend for full org payloads. CKAN needs to be
+            # explicitly told to include extras; MongoDB's full-fields
+            # mode already returns the top-level ``ndp_user_id``.
+            full_orgs = repository.organization_list(
+                all_fields=True, include_extras=True
+            )
+            organizations = [
+                org.get("name")
+                for org in full_orgs
+                if org.get("name") and _extract_ndp_user_id(org) == user_hash
+            ]
+        else:
+            organizations = repository.organization_list(all_fields=False)
 
         # Filter the organizations if a name is provided
         if name:

--- a/tests/test_list_organization_service.py
+++ b/tests/test_list_organization_service.py
@@ -155,3 +155,76 @@ class TestListOrganization:
         result = list_organization(name="organization", server="global")
 
         assert result == ["my-organization", "your-organization"]
+
+    @patch("api.services.organization_services.list_organization.catalog_settings")
+    def test_list_organization_with_user_hash_mongo_shape(self, mock_catalog_settings):
+        """When user_hash is set, MongoDB-style docs are filtered by their top-level ndp_user_id."""
+        mock_repository = MagicMock()
+        mock_repository.organization_list.return_value = [
+            {"name": "alpha", "ndp_user_id": "abc1234567890def"},
+            {"name": "beta", "ndp_user_id": "deadbeefcafef00d"},
+            {"name": "gamma"},  # legacy org with no creator hash
+        ]
+        mock_catalog_settings.global_catalog = mock_repository
+
+        result = list_organization(server="global", user_hash="abc1234567890def")
+
+        assert result == ["alpha"]
+        mock_repository.organization_list.assert_called_once_with(
+            all_fields=True, include_extras=True
+        )
+
+    @patch("api.services.organization_services.list_organization.catalog_settings")
+    def test_list_organization_with_user_hash_ckan_shape(self, mock_catalog_settings):
+        """When user_hash is set, CKAN-style docs are filtered by the ndp_user_id extra."""
+        mock_repository = MagicMock()
+        mock_repository.organization_list.return_value = [
+            {
+                "name": "alpha",
+                "extras": [
+                    {"key": "ndp_user_id", "value": "abc1234567890def"},
+                    {"key": "ndp_creator_md5", "value": "ignored"},
+                ],
+            },
+            {
+                "name": "beta",
+                "extras": [{"key": "ndp_user_id", "value": "deadbeefcafef00d"}],
+            },
+            # legacy org: no extras at all
+            {"name": "gamma", "extras": []},
+        ]
+        mock_catalog_settings.global_catalog = mock_repository
+
+        result = list_organization(server="global", user_hash="abc1234567890def")
+
+        assert result == ["alpha"]
+
+    @patch("api.services.organization_services.list_organization.catalog_settings")
+    def test_list_organization_with_user_hash_and_name_filter(
+        self, mock_catalog_settings
+    ):
+        """Name filter is applied on top of the creator-hash filter."""
+        mock_repository = MagicMock()
+        mock_repository.organization_list.return_value = [
+            {"name": "alpha-team", "ndp_user_id": "h"},
+            {"name": "beta-team", "ndp_user_id": "h"},
+            {"name": "alpha-archive", "ndp_user_id": "other"},
+        ]
+        mock_catalog_settings.global_catalog = mock_repository
+
+        result = list_organization(name="alpha", server="global", user_hash="h")
+
+        assert result == ["alpha-team"]
+
+    @patch("api.services.organization_services.list_organization.catalog_settings")
+    def test_list_organization_without_user_hash_does_not_request_extras(
+        self, mock_catalog_settings
+    ):
+        """The pre-existing call shape is preserved when user_hash is not provided."""
+        mock_repository = MagicMock()
+        mock_repository.organization_list.return_value = ["org1", "org2"]
+        mock_catalog_settings.global_catalog = mock_repository
+
+        list_organization(server="global")
+
+        mock_repository.organization_list.assert_called_once_with(all_fields=False)

--- a/tests/test_user_info_route.py
+++ b/tests/test_user_info_route.py
@@ -1,0 +1,51 @@
+# tests/test_user_info_route.py
+"""Tests for the GET /user/info route enrichment."""
+
+import asyncio
+
+from api.routes.user_routes.user_info import get_user_info
+from api.services.metadata_services import hash_user_id
+
+
+def _call(user_info):
+    return asyncio.run(get_user_info(user_info=user_info))
+
+
+def test_user_info_response_is_enriched_with_ndp_user_id():
+    """The enriched response carries the same hash datasets/orgs persist."""
+    upstream = {
+        "sub": "user-sub-abc123",
+        "username": "raul",
+        "email": "raul@example.com",
+        "roles": ["user"],
+        "groups": [],
+    }
+
+    response = _call(upstream)
+
+    assert response["ndp_user_id"] == hash_user_id(upstream)
+    # Original upstream fields are preserved unchanged.
+    for key, value in upstream.items():
+        assert response[key] == value
+
+
+def test_user_info_response_does_not_overwrite_upstream_ndp_user_id():
+    """If the upstream payload already carries ndp_user_id, we don't clobber it."""
+    upstream = {
+        "sub": "user-sub-abc123",
+        "ndp_user_id": "upstream-override-value",
+    }
+
+    response = _call(upstream)
+
+    assert response["ndp_user_id"] == "upstream-override-value"
+
+
+def test_user_info_response_is_a_copy_not_a_mutation():
+    """We must not mutate the dict the auth dependency handed us."""
+    upstream = {"sub": "user-sub-abc123"}
+
+    response = _call(upstream)
+
+    assert "ndp_user_id" in response
+    assert "ndp_user_id" not in upstream

--- a/ui/src/pages/Search.js
+++ b/ui/src/pages/Search.js
@@ -9,7 +9,7 @@ import {
   Database,
   Building2
 } from 'lucide-react';
-import { searchAPI, organizationsAPI } from '../services/api';
+import { searchAPI, organizationsAPI, userAPI } from '../services/api';
 
 const MODES = [
   { id: 'both', label: 'All' },
@@ -37,26 +37,63 @@ const Search = () => {
   // term is ignored, so clicking "View datasets" on an org card lists every
   // dataset of that org without forcing the user to retype anything.
   const [ownerOrgFilter, setOwnerOrgFilter] = useState(null);
+  // "Only mine" toggle: filters every result group to items whose
+  // ndp_user_id matches the authenticated user's hash. Orgs filter
+  // server-side; datasets/services filter client-side using the hash
+  // that comes back in /user/info.
+  const [onlyMine, setOnlyMine] = useState(false);
+  const [myUserHash, setMyUserHash] = useState(null);
   const inputRef = useRef(null);
+  // Monotonically-increasing id of the most recent search request.
+  // Only the latest request is allowed to update state, so a slow
+  // response that arrives after the user has already changed a filter
+  // can never overwrite the new search or leave loading stuck on.
+  const searchRequestIdRef = useRef(0);
 
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
 
-  const fetchDatasets = async (term, selectedServer, ownerOrg) => {
+  // Fetch the user's own ndp_user_id once on mount. The backend
+  // enriches /user/info with this hash, so the UI does not have to
+  // decode the JWT or compute SHA-256 in the browser.
+  useEffect(() => {
+    let cancelled = false;
+    userAPI
+      .getUserInfo()
+      .then((response) => {
+        if (!cancelled) setMyUserHash(response.data?.ndp_user_id || null);
+      })
+      .catch(() => {
+        if (!cancelled) setMyUserHash(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Client-side filter applied when "Only mine" is on. Items missing
+  // a creator hash (legacy data) are intentionally excluded.
+  const keepOnlyMine = (items, mine, hash) =>
+    !mine || !hash ? items : items.filter((item) => item.extras?.ndp_user_id === hash);
+
+  const fetchDatasets = async (term, selectedServer, ownerOrg, mine, hash) => {
+    let raw;
     if (ownerOrg) {
       const response = await searchAPI.searchAdvanced({
         owner_org: ownerOrg,
         search_term: term || undefined,
         server: selectedServer
       });
-      return (response.data || []).filter((item) => item.owner_org !== 'services');
+      raw = (response.data || []).filter((item) => item.owner_org !== 'services');
+    } else {
+      const response = await searchAPI.searchByTerms([term], null, selectedServer);
+      raw = (response.data || []).filter((item) => item.owner_org !== 'services');
     }
-    const response = await searchAPI.searchByTerms([term], null, selectedServer);
-    return (response.data || []).filter((item) => item.owner_org !== 'services');
+    return keepOnlyMine(raw, mine, hash);
   };
 
-  const fetchServices = async (term, selectedServer, ownerOrg) => {
+  const fetchServices = async (term, selectedServer, ownerOrg, mine, hash) => {
     // Services always live in the "services" org; an external ownerOrg filter
     // doesn't make sense for them, so we silently skip when one is active.
     if (ownerOrg && ownerOrg !== 'services') return [];
@@ -65,26 +102,45 @@ const Search = () => {
       search_term: term,
       server: selectedServer
     });
-    return (response.data || []).filter((item) => item.owner_org === 'services');
+    const raw = (response.data || []).filter((item) => item.owner_org === 'services');
+    return keepOnlyMine(raw, mine, hash);
   };
 
-  const fetchOrganizations = async (term, selectedServer) => {
+  const fetchOrganizations = async (term, selectedServer, mine) => {
     const params = { server: selectedServer };
     if (term) params.name = term;
+    if (mine) params.mine = true;
     const response = await organizationsAPI.list(params);
     return Array.isArray(response.data) ? response.data : [];
   };
 
-  const runSearch = async ({ term, currentMode, currentServer, currentOwnerOrg }) => {
+  const runSearch = async ({
+    term,
+    currentMode,
+    currentServer,
+    currentOwnerOrg,
+    currentOnlyMine,
+    currentUserHash
+  }) => {
     const trimmed = (term || '').trim();
     // Term is required unless the query already has another scope: a
-    // selected organization filter, or the "Organizations" mode (which can
-    // list every organization on the server).
-    if (!trimmed && !currentOwnerOrg && currentMode !== 'organizations') {
+    // selected organization filter, the "Organizations" mode (which can
+    // list every organization on the server), or an active "Only mine"
+    // toggle (which is itself a scope — the user wants their own items).
+    if (
+      !trimmed &&
+      !currentOwnerOrg &&
+      currentMode !== 'organizations' &&
+      !currentOnlyMine
+    ) {
       setError('Please enter a search term');
       return;
     }
 
+    // Claim a fresh request id. If the user changes a filter while we
+    // are still awaiting the network, a newer call will bump this id
+    // and our late response will be discarded below.
+    const requestId = ++searchRequestIdRef.current;
     setLoading(true);
     setError(null);
 
@@ -103,15 +159,35 @@ const Search = () => {
         p.then((data) => ({ ok: true, data })).catch((err) => ({ ok: false, err }));
       const [datasetsRes, servicesRes, orgsRes] = await Promise.all([
         wantDatasets
-          ? safe(fetchDatasets(trimmed, currentServer, currentOwnerOrg))
+          ? safe(
+              fetchDatasets(
+                trimmed,
+                currentServer,
+                currentOwnerOrg,
+                currentOnlyMine,
+                currentUserHash
+              )
+            )
           : Promise.resolve({ ok: true, data: [] }),
         wantServices
-          ? safe(fetchServices(trimmed, currentServer, currentOwnerOrg))
+          ? safe(
+              fetchServices(
+                trimmed,
+                currentServer,
+                currentOwnerOrg,
+                currentOnlyMine,
+                currentUserHash
+              )
+            )
           : Promise.resolve({ ok: true, data: [] }),
         wantOrgs
-          ? safe(fetchOrganizations(trimmed, currentServer))
+          ? safe(fetchOrganizations(trimmed, currentServer, currentOnlyMine))
           : Promise.resolve({ ok: true, data: [] })
       ]);
+
+      // If a newer request has been issued in the meantime, drop our
+      // results on the floor — we don't own the UI any more.
+      if (requestId !== searchRequestIdRef.current) return;
 
       const requested = [
         wantDatasets && datasetsRes,
@@ -126,6 +202,7 @@ const Search = () => {
       setOrganizationResults(orgsRes.ok ? orgsRes.data : []);
       setHasSearched(true);
     } catch (err) {
+      if (requestId !== searchRequestIdRef.current) return;
       const status = err.response?.status;
       let message = 'Search failed';
       if (status === 422) message += ': validation error — check your search parameters';
@@ -134,7 +211,10 @@ const Search = () => {
       else if (err.message) message += `: ${err.message}`;
       setError(message);
     } finally {
-      setLoading(false);
+      // Only the latest request clears the loading flag, so loading
+      // tracks the freshest in-flight search rather than the order in
+      // which responses come back.
+      if (requestId === searchRequestIdRef.current) setLoading(false);
     }
   };
 
@@ -144,36 +224,23 @@ const Search = () => {
       term: searchTerm,
       currentMode: mode,
       currentServer: server,
-      currentOwnerOrg: ownerOrgFilter
+      currentOwnerOrg: ownerOrgFilter,
+      currentOnlyMine: onlyMine,
+      currentUserHash: myUserHash
     });
   };
 
+  // Handlers below mutate filter state only. The effect right after the
+  // component body picks up the change and re-runs the search, so any
+  // stale results from a previous mode never linger on screen.
   const handleViewDatasetsInOrg = (orgName) => {
+    setSearchTerm('');
     setOwnerOrgFilter(orgName);
     setMode('datasets');
-    runSearch({
-      term: '',
-      currentMode: 'datasets',
-      currentServer: server,
-      currentOwnerOrg: orgName
-    });
   };
 
   const handleClearOrgFilter = () => {
     setOwnerOrgFilter(null);
-    if (searchTerm.trim()) {
-      runSearch({
-        term: searchTerm,
-        currentMode: mode,
-        currentServer: server,
-        currentOwnerOrg: null
-      });
-    } else {
-      setDatasetResults([]);
-      setServiceResults([]);
-      setOrganizationResults([]);
-      setHasSearched(false);
-    }
   };
 
   const clearTerm = () => {
@@ -181,8 +248,50 @@ const Search = () => {
     inputRef.current?.focus();
   };
 
+  // Re-run the search whenever any of the filter toggles change after the
+  // first search. This keeps the "Found X results" summary and the
+  // rendered groups consistent with the toggles the user just clicked —
+  // without it, switching from Organizations to Datasets would leave the
+  // counts and the (empty) result groups out of sync. Initial mount
+  // (hasSearched=false) does nothing, so this never fires on its own.
+  useEffect(() => {
+    if (!hasSearched) return;
+    const trimmed = searchTerm.trim();
+    // No scope at all? Reset to the pre-search hero instead of letting
+    // runSearch surface a validation error from a state the user
+    // arrived at by clearing the org filter.
+    if (!trimmed && !ownerOrgFilter && mode !== 'organizations' && !onlyMine) {
+      setDatasetResults([]);
+      setServiceResults([]);
+      setOrganizationResults([]);
+      setHasSearched(false);
+      setError(null);
+      return;
+    }
+    runSearch({
+      term: searchTerm,
+      currentMode: mode,
+      currentServer: server,
+      currentOwnerOrg: ownerOrgFilter,
+      currentOnlyMine: onlyMine,
+      currentUserHash: myUserHash
+    });
+    // runSearch is a stable in-component function; we intentionally
+    // watch only the filter inputs so typing in the bar does not
+    // trigger a request on every keystroke.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, server, ownerOrgFilter, onlyMine]);
+
+  // Count only what is *actually visible* given the current mode, so the
+  // summary never claims results from a hidden group.
+  const datasetsVisible = mode === 'datasets' || mode === 'both';
+  const servicesVisible = mode === 'services' || mode === 'both';
+  const orgsVisible =
+    mode === 'organizations' || (mode === 'both' && !ownerOrgFilter);
   const totalResults =
-    datasetResults.length + serviceResults.length + organizationResults.length;
+    (datasetsVisible ? datasetResults.length : 0) +
+    (servicesVisible ? serviceResults.length : 0) +
+    (orgsVisible ? organizationResults.length : 0);
   const compact = hasSearched || loading;
 
   return (
@@ -230,7 +339,15 @@ const Search = () => {
             loading={loading}
           />
 
-          <FilterRow mode={mode} setMode={setMode} server={server} setServer={setServer} />
+          <FilterRow
+            mode={mode}
+            setMode={setMode}
+            server={server}
+            setServer={setServer}
+            onlyMine={onlyMine}
+            onToggleOnlyMine={setOnlyMine}
+            canOnlyMine={Boolean(myUserHash)}
+          />
 
           {ownerOrgFilter && mode !== 'organizations' && (
             <OrgFilterChip orgName={ownerOrgFilter} onClear={handleClearOrgFilter} />
@@ -369,7 +486,15 @@ const SearchBar = ({ inputRef, value, onChange, onClear, loading }) => (
   </div>
 );
 
-const FilterRow = ({ mode, setMode, server, setServer }) => (
+const FilterRow = ({
+  mode,
+  setMode,
+  server,
+  setServer,
+  onlyMine,
+  onToggleOnlyMine,
+  canOnlyMine
+}) => (
   <div
     style={{
       marginTop: '1rem',
@@ -383,7 +508,47 @@ const FilterRow = ({ mode, setMode, server, setServer }) => (
     <SegmentedControl options={MODES} value={mode} onChange={setMode} />
     <span style={{ color: '#cbd5e1' }}>·</span>
     <SegmentedControl options={SERVERS} value={server} onChange={setServer} subtle />
+    <span style={{ color: '#cbd5e1' }}>·</span>
+    <OnlyMineToggle
+      checked={onlyMine}
+      onChange={onToggleOnlyMine}
+      disabled={!canOnlyMine}
+    />
   </div>
+);
+
+const OnlyMineToggle = ({ checked, onChange, disabled }) => (
+  <label
+    title={
+      disabled
+        ? 'Unavailable: could not load your user identity'
+        : 'Show only items I created'
+    }
+    style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '0.4rem',
+      padding: '0.4rem 0.9rem',
+      borderRadius: '999px',
+      border: '1px solid #e2e8f0',
+      background: checked ? '#eff6ff' : 'transparent',
+      color: disabled ? '#cbd5e1' : checked ? '#1d4ed8' : '#475569',
+      fontSize: '0.85rem',
+      fontWeight: checked ? 600 : 500,
+      cursor: disabled ? 'not-allowed' : 'pointer',
+      transition: 'all 0.15s ease',
+      userSelect: 'none'
+    }}
+  >
+    <input
+      type="checkbox"
+      checked={checked}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.checked)}
+      style={{ accentColor: '#2563eb', cursor: disabled ? 'not-allowed' : 'pointer' }}
+    />
+    Only mine
+  </label>
 );
 
 const SegmentedControl = ({ options, value, onChange, subtle }) => (


### PR DESCRIPTION
## Summary
- New "Only mine" toggle on the Search page, sitting alongside the existing mode and server filters. When enabled, every result group is restricted to items whose persisted creator hash matches the authenticated user.
- For organizations the filter is applied server-side via a new optional `GET /organization?mine=true` query parameter; for datasets and services the UI applies the filter client-side against the `extras.ndp_user_id` field that the EP already populates on every resource registration.
- `GET /user/info` is enriched with the requesting user's `ndp_user_id` so the UI can do the client-side comparison without decoding the JWT or recomputing SHA-256 in the browser. Upstream payloads that already carry the field are preserved unchanged.
- Switching mode/server/scope after a search now auto-re-runs the search, so the "Found X results" summary and the rendered groups can never be out of sync with the active filters. The results count is also clamped to what is actually visible for the current mode as a safety net.
- A request-id guard makes sure that, when the user changes a filter while a previous request is still in flight, the late response is dropped — the loading spinner always tracks the freshest in-flight search instead of being stuck waiting for a stale one.

## Backwards compatibility
- All changes are additive. No required parameters, no fields removed, no type changes.
- `GET /organization` still works without authentication when `mine` is not passed; the response shape is unchanged (`List[str]`). A Bearer token is required only for `mine=true`.
- `GET /user/info` keeps every field the auth service returns; only adds `ndp_user_id` on top, and only if it isn't already present upstream.
- Items registered before the corresponding creator-hash feature simply do not appear under "Only mine"; no migration is performed.

## Test plan
- [x] Backend: `docker compose exec api python -m pytest tests/ -v` → **1132 tests pass** (+7 over 0.22.0: 4 service tests for the `user_hash` filter shapes, 3 route tests for the `/user/info` enrichment).
- [x] Lint: `black --check .` clean; no new `flake8` warnings.
- [x] Smoke test with `raul`/`raul` (sub `6bfaa6c3-...`):
  - `GET /user/info` returns `ndp_user_id = b752c92cf1a051d2`.
  - `GET /organization?server=local` → 5 orgs.
  - `GET /organization?server=local&mine=true` → only `test-creator-hash-1778661766` (the org `raul` created).
  - `GET /organization?server=local&mine=true` without a token → **401**.
  - `GET /organization?server=local` without a token → **200** (no breaking change).
- [x] UI smoke test (local container):
  - Toggle disabled until `/user/info` resolves.
  - "Only mine" + Datasets → only `raul-mine-test-dataset-...`.
  - "Only mine" + Services → only `raul-mine-test-service-...`.
  - "Only mine" + Organizations → only `test-creator-hash-...`.
  - "Only mine" + All → all three groups, only `raul`'s items in each.
  - Switching between modes auto-re-runs the search; "Found X" stays consistent with the rendered groups.
  - Rapid toggling no longer leaves the spinner stuck.

Closes #153.