### PR TITLE
Replace Organizations nav with + New menu and let owners delete from Search (closes #155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-05-13
+
+### Added
+- Navigation: new "+ New" dropdown replaces the old "Organizations" entry. It currently contains a single "Organization" item that takes the user to the simplified organization-creation page; the menu is wired so adding more entries (Dataset, Service, etc.) later is a single-line change.
+- Search page: organization result cards that belong to the authenticated user now show a "Delete" action and a "Yours" badge. Clicking Delete opens an in-line confirmation panel on the card itself (no `window.confirm`, no full-screen modal). On success the card disappears immediately; on failure the panel shows a friendly, actionable error message rather than the raw backend string.
+- `DELETE /organization/{name}` accepts a new optional `cascade` query parameter (default `true`, the legacy behavior). When `cascade=false`, the endpoint deletes only the organization and refuses with `409 Conflict` if the organization still owns datasets. The error payload includes the dataset count so callers can render a helpful message. The Search UI always passes `cascade=false`, so users never lose datasets by clicking Delete.
+
+### Changed
+- The Organizations page is now a focused "create a new organization" form. The list-and-delete role it played before moved to the Search page (listing was already there; deletion is new). The route stays at `/organizations` so the "+ New > Organization" item lands there.
+- The Organizations entry has been removed from the navigation bar; the page is now reached exclusively from "+ New > Organization".
+
+### Backwards compatibility
+- The new `cascade` parameter defaults to `true`, matching the legacy "delete the organization and every dataset it owns" behavior. Existing API clients are unaffected.
+- The HTTP path and response shape of `DELETE /organization/{name}` are unchanged; `cascade=false` introduces a new `409` response code in addition to the existing `200/400/404`.
+- The `/organizations` UI route still exists and still creates organizations; the create-only redesign drops listing/delete features that are now duplicated on Search.
+
 ## [0.23.0] - 2026-05-13
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.23.0"
+    swagger_version: str = "0.24.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/routes/delete_routes/delete_organization_route.py
+++ b/api/routes/delete_routes/delete_organization_route.py
@@ -49,13 +49,25 @@ async def delete_organization(
     server: Literal["local"] = Query(
         "local", description="Choose 'local'. Defaults to 'local'."
     ),
+    cascade: bool = Query(
+        True,
+        description=(
+            "When true (default, legacy behavior), every dataset owned "
+            "by the organization is deleted before the organization "
+            "itself. When false, the call refuses to delete an "
+            "organization that still has datasets inside, so the caller "
+            "can clean them up explicitly before retrying."
+        ),
+    ),
 ):
     """
     Endpoint to delete an organization in CKAN by its name.
 
     If ?server=pre_ckan is used, it will delete from the pre-CKAN instance
     if enabled. Returns a 400 error if pre_ckan is disabled or missing a
-    valid scheme. Raises a 404 if the organization does not exist.
+    valid scheme. Raises a 404 if the organization does not exist. With
+    ?cascade=false, returns a 409 when the organization still has
+    datasets owned by it.
     """
     try:
         repository = None
@@ -67,7 +79,9 @@ async def delete_organization(
             repository = CKANRepository(ckan_settings.pre_ckan)
 
         organization_services.delete_organization(
-            organization_name=organization_name, repository=repository
+            organization_name=organization_name,
+            repository=repository,
+            cascade=cascade,
         )
         return {"message": "Organization deleted successfully"}
 
@@ -75,6 +89,11 @@ async def delete_organization(
         error_msg = str(e)
         if "Organization not found" in error_msg:
             raise HTTPException(status_code=404, detail="Organization not found")
+        if "still has" in error_msg.lower() and "dataset" in error_msg.lower():
+            # 409 Conflict — the org cannot be deleted in its current
+            # state. The error string is small and machine-readable so
+            # UI callers can map it to a friendly message.
+            raise HTTPException(status_code=409, detail=error_msg)
         if "No scheme supplied" in error_msg:
             raise HTTPException(
                 status_code=400,

--- a/api/services/organization_services/delete_organization.py
+++ b/api/services/organization_services/delete_organization.py
@@ -2,12 +2,27 @@
 from api.config import catalog_settings
 
 
-def delete_organization(organization_name: str, repository=None):
+def delete_organization(organization_name: str, repository=None, cascade: bool = True):
     """
     Delete an organization from catalog by its name.
 
     Uses the configured catalog backend (CKAN or MongoDB) unless a specific
     repository is provided.
+
+    Parameters
+    ----------
+    organization_name : str
+        Organization name to delete.
+    repository : optional
+        Backend repository to act on. Falls back to the configured local
+        catalog.
+    cascade : bool
+        When True (default, legacy behavior), also delete every dataset
+        owned by the organization before removing the organization. When
+        False, refuse to delete an organization that still has datasets
+        inside — the caller can clean them up first and retry. This
+        narrower mode is what the UI uses, so users do not lose data by
+        clicking "Delete" on an organization card.
     """
     if repository is None:
         repository = catalog_settings.local_catalog
@@ -17,13 +32,23 @@ def delete_organization(organization_name: str, repository=None):
         organization = repository.organization_show(id=organization_name)
         organization_id = organization["id"]
 
-        # Delete all datasets associated with the organization
+        # Inspect datasets owned by the org so we can either delete them
+        # (cascade) or refuse the call (no cascade).
         datasets = repository.package_search(
             fq=f"owner_org:{organization_id}", rows=1000
         )
-        for dataset in datasets["results"]:
-            # Use package_delete for repository pattern
-            repository.package_delete(id=dataset["id"])
+        dataset_results = datasets.get("results", []) or []
+
+        if not cascade and dataset_results:
+            raise Exception(
+                f"Organization still has {len(dataset_results)} dataset(s) "
+                "inside; delete them first or call with cascade=true"
+            )
+
+        if cascade:
+            for dataset in dataset_results:
+                # Use package_delete for repository pattern
+                repository.package_delete(id=dataset["id"])
 
         # Delete the organization
         repository.organization_delete(id=organization_id)
@@ -39,4 +64,8 @@ def delete_organization(organization_name: str, repository=None):
         error_msg = str(e).lower()
         if "not found" in error_msg:
             raise Exception("Organization not found")
+        if "still has" in error_msg and "dataset" in error_msg:
+            # Surface the dataset-count message untouched so the route
+            # and the UI can recognize it for a friendly error.
+            raise
         raise Exception(f"Error deleting organization: {str(e)}")

--- a/tests/test_delete_organization_service.py
+++ b/tests/test_delete_organization_service.py
@@ -146,6 +146,52 @@ class TestDeleteOrganization:
         assert "Permission denied" in str(exc_info.value)
 
     @patch("api.services.organization_services.delete_organization.catalog_settings")
+    def test_delete_organization_no_cascade_refuses_when_datasets_exist(
+        self, mock_catalog_settings
+    ):
+        """cascade=False blocks deletion when the org still owns datasets."""
+        mock_repository = MagicMock()
+        mock_repository.organization_show.return_value = {
+            "id": "blocked-org",
+            "name": "blocked",
+        }
+        mock_repository.package_search.return_value = {
+            "count": 2,
+            "results": [{"id": "ds-1"}, {"id": "ds-2"}],
+        }
+        mock_catalog_settings.local_catalog = mock_repository
+
+        with pytest.raises(Exception) as exc_info:
+            delete_organization("blocked", cascade=False)
+
+        message = str(exc_info.value).lower()
+        assert "still has" in message
+        assert "dataset" in message
+        # No deletion calls must have happened.
+        mock_repository.package_delete.assert_not_called()
+        mock_repository.organization_delete.assert_not_called()
+
+    @patch("api.services.organization_services.delete_organization.catalog_settings")
+    def test_delete_organization_no_cascade_deletes_when_empty(
+        self, mock_catalog_settings
+    ):
+        """cascade=False still deletes an empty org and leaves no datasets behind."""
+        mock_repository = MagicMock()
+        mock_repository.organization_show.return_value = {
+            "id": "empty-org",
+            "name": "empty",
+        }
+        mock_repository.package_search.return_value = {"count": 0, "results": []}
+        mock_repository.organization_delete.return_value = None
+        mock_repository.organization_purge.return_value = None
+        mock_catalog_settings.local_catalog = mock_repository
+
+        delete_organization("empty", cascade=False)
+
+        mock_repository.package_delete.assert_not_called()
+        mock_repository.organization_delete.assert_called_once_with(id="empty-org")
+
+    @patch("api.services.organization_services.delete_organization.catalog_settings")
     def test_delete_organization_dataset_deletion_order(self, mock_catalog_settings):
         """Test that datasets are deleted before organization."""
         deletion_order = []

--- a/ui/src/components/Navigation.js
+++ b/ui/src/components/Navigation.js
@@ -13,7 +13,8 @@ import {
   FolderOpen,
   ChevronDown,
   HardDrive,
-  ShieldAlert
+  ShieldAlert,
+  Plus
 } from 'lucide-react';
 import { isAccessRequestAdmin, userAPI } from '../services/api';
 
@@ -26,6 +27,10 @@ const Navigation = () => {
   const dropdownRef = useRef(null);
   const buttonRef = useRef(null);
   const timeoutRef = useRef(null);
+  const [isNewMenuOpen, setIsNewMenuOpen] = useState(false);
+  const newMenuRef = useRef(null);
+  const newButtonRef = useRef(null);
+  const newTimeoutRef = useRef(null);
   const [isAdmin, setIsAdmin] = useState(false);
 
   // Determine admin status from the current token's /user/info response so
@@ -45,25 +50,32 @@ const Navigation = () => {
     };
   }, []);
 
-  // Clear timeout on unmount
+  // Clear timeouts on unmount
   useEffect(() => {
     return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      if (newTimeoutRef.current) clearTimeout(newTimeoutRef.current);
     };
   }, []);
 
-  // Close dropdown when clicking outside
+  // Close dropdowns when clicking outside
   useEffect(() => {
     const handleClickOutside = (event) => {
       if (
-        dropdownRef.current && 
+        dropdownRef.current &&
         !dropdownRef.current.contains(event.target) &&
         buttonRef.current &&
         !buttonRef.current.contains(event.target)
       ) {
         setIsDropdownOpen(false);
+      }
+      if (
+        newMenuRef.current &&
+        !newMenuRef.current.contains(event.target) &&
+        newButtonRef.current &&
+        !newButtonRef.current.contains(event.target)
+      ) {
+        setIsNewMenuOpen(false);
       }
     };
 
@@ -79,6 +91,7 @@ const Navigation = () => {
       clearTimeout(timeoutRef.current);
     }
     setIsDropdownOpen(true);
+    setIsNewMenuOpen(false);
   };
 
   const handleDropdownLeave = () => {
@@ -88,12 +101,24 @@ const Navigation = () => {
     }, 150);
   };
 
-  // Handle mouse entering other nav items - close dropdown immediately
-  const handleOtherNavEnter = () => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
+  const handleNewMenuEnter = () => {
+    if (newTimeoutRef.current) clearTimeout(newTimeoutRef.current);
+    setIsNewMenuOpen(true);
     setIsDropdownOpen(false);
+  };
+
+  const handleNewMenuLeave = () => {
+    newTimeoutRef.current = setTimeout(() => {
+      setIsNewMenuOpen(false);
+    }, 150);
+  };
+
+  // Handle mouse entering other nav items - close dropdowns immediately
+  const handleOtherNavEnter = () => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    if (newTimeoutRef.current) clearTimeout(newTimeoutRef.current);
+    setIsDropdownOpen(false);
+    setIsNewMenuOpen(false);
   };
 
   const handleLogout = () => {
@@ -173,38 +198,6 @@ const Navigation = () => {
               >
                 <Search size={18} />
                 <span>Search</span>
-              </Link>
-
-              {/* Organizations */}
-              <Link
-                to="/organizations"
-                onMouseEnter={handleOtherNavEnter}
-                style={{
-                  color: '#6b7280', // Always same color
-                  textDecoration: 'none',
-                  padding: '0.5rem 0.75rem',
-                  borderRadius: '8px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '0.5rem',
-                  fontSize: '0.95rem',
-                  whiteSpace: 'nowrap',
-                  fontWeight: '500', // Always same weight
-                  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-                  backgroundColor: 'transparent',
-                  transition: 'all 0.2s ease'
-                }}
-                onMouseOver={(e) => {
-                  e.target.style.color = '#374151';
-                  e.target.style.fontWeight = '600';
-                }}
-                onMouseOut={(e) => {
-                  e.target.style.color = '#6b7280';
-                  e.target.style.fontWeight = '500';
-                }}
-              >
-                <Building2 size={18} />
-                <span>Organizations</span>
               </Link>
 
               {/* Resources Dropdown */}
@@ -444,6 +437,97 @@ const Navigation = () => {
                 <Settings size={18} />
                 <span>Services</span>
               </Link>
+
+              {/* + New menu (compact entry point for create flows) */}
+              <div
+                style={{ position: 'relative' }}
+                onMouseEnter={handleNewMenuEnter}
+                onMouseLeave={handleNewMenuLeave}
+              >
+                <button
+                  ref={newButtonRef}
+                  style={{
+                    color: isNewMenuOpen ? '#374151' : '#6b7280',
+                    background: 'none',
+                    border: 'none',
+                    padding: '0.5rem 0.75rem',
+                    borderRadius: '8px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.4rem',
+                    fontSize: '0.95rem',
+                    fontWeight: isNewMenuOpen ? '600' : '500',
+                    fontFamily:
+                      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+                    cursor: 'pointer',
+                    backgroundColor: 'transparent',
+                    transition: 'all 0.2s ease',
+                    whiteSpace: 'nowrap'
+                  }}
+                  onMouseOver={(e) => {
+                    if (!isNewMenuOpen) {
+                      e.target.style.color = '#374151';
+                      e.target.style.fontWeight = '600';
+                    }
+                  }}
+                  onMouseOut={(e) => {
+                    if (!isNewMenuOpen) {
+                      e.target.style.color = '#6b7280';
+                      e.target.style.fontWeight = '500';
+                    }
+                  }}
+                >
+                  <Plus size={18} />
+                  <span>New</span>
+                  <ChevronDown size={16} />
+                </button>
+
+                {isNewMenuOpen && (
+                  <div
+                    ref={newMenuRef}
+                    style={{
+                      position: 'absolute',
+                      top: '100%',
+                      left: '0',
+                      backgroundColor: 'white',
+                      borderRadius: '10px',
+                      boxShadow: '0 10px 25px rgba(0, 0, 0, 0.15)',
+                      border: '1px solid #e5e7eb',
+                      minWidth: '220px',
+                      zIndex: 1000,
+                      marginTop: '0.5rem'
+                    }}
+                  >
+                    <Link
+                      to="/organizations"
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.75rem',
+                        padding: '1rem 1.25rem',
+                        color: '#374151',
+                        textDecoration: 'none',
+                        fontSize: '0.9rem',
+                        fontWeight: '500',
+                        backgroundColor: 'white'
+                      }}
+                      onMouseOver={(e) => {
+                        e.target.style.backgroundColor = '#f9fafb';
+                        e.target.style.color = '#2563eb';
+                        e.target.style.fontWeight = '600';
+                      }}
+                      onMouseOut={(e) => {
+                        e.target.style.backgroundColor = 'white';
+                        e.target.style.color = '#374151';
+                        e.target.style.fontWeight = '500';
+                      }}
+                    >
+                      <Building2 size={18} />
+                      <span>Organization</span>
+                    </Link>
+                  </div>
+                )}
+              </div>
 
               {/* Dashboard (admin only) */}
               {isAdmin && (

--- a/ui/src/pages/Organizations.js
+++ b/ui/src/pages/Organizations.js
@@ -1,146 +1,65 @@
-import React, { useState, useEffect } from 'react';
-import { Building2, Plus, Trash2, Search, AlertCircle } from 'lucide-react';
+import React, { useState } from 'react';
+import { Building2, AlertCircle, CheckCircle } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { organizationsAPI } from '../services/api';
 
 /**
- * Organizations page component for managing organizations
- * Allows creating, listing, and deleting organizations
+ * Single-purpose page reached from the "+ New > Organization" menu.
+ * Listing and deletion live on the Search page now — this page only
+ * exposes the create form.
  */
 const Organizations = () => {
-  const [organizations, setOrganizations] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({ name: '', title: '', description: '' });
+  const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
-  const [showCreateForm, setShowCreateForm] = useState(false);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [selectedServer, setSelectedServer] = useState('global');
 
-  // Form state for creating new organization
-  const [formData, setFormData] = useState({
-    name: '',
-    title: '',
-    description: ''
-  });
-
-  /**
-   * Fetch organizations list on component mount and when server changes
-   */
-  useEffect(() => {
-    fetchOrganizations();
-    // fetchOrganizations is defined inline and reads searchTerm at call time;
-    // the effect should only re-run when the server changes, so we leave the
-    // function out of the deps to avoid a fetch on every keystroke.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedServer]);
-
-  /**
-   * Fetch organizations from the API
-   */
-  const fetchOrganizations = async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      
-      const response = await organizationsAPI.list({
-        server: selectedServer,
-        name: searchTerm || undefined
-      });
-      
-      setOrganizations(response.data || []);
-    } catch (err) {
-      console.error('Error fetching organizations:', err);
-      setError('Failed to load organizations: ' + 
-        (err.response?.data?.detail || err.message));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  /**
-   * Handle form input changes
-   */
   const handleInputChange = (e) => {
     const { name, value } = e.target;
-    setFormData(prev => ({
-      ...prev,
-      [name]: value
-    }));
+    setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  /**
-   * Handle form submission for creating organization
-   */
   const handleSubmit = async (e) => {
     e.preventDefault();
-    
+    setError(null);
+    setSuccess(null);
+    setSubmitting(true);
     try {
-      setError(null);
-      setSuccess(null);
-      
       await organizationsAPI.create(formData, 'local');
-      
-      setSuccess('Organization created successfully!');
+      setSuccess(
+        `Organization "${formData.name}" created. You can keep creating more or go back to Search.`
+      );
       setFormData({ name: '', title: '', description: '' });
-      setShowCreateForm(false);
-      
-      // Refresh the list if viewing local server
-      if (selectedServer === 'local') {
-        fetchOrganizations();
-      }
     } catch (err) {
-      console.error('Error creating organization:', err);
-      setError('Failed to create organization: ' + 
-        (err.response?.data?.detail || err.message));
+      const detail = err.response?.data?.detail;
+      const raw = typeof detail === 'string' ? detail : err.message;
+      setError(
+        raw && /already exists/i.test(raw)
+          ? `An organization called "${formData.name}" already exists. Pick a different name.`
+          : raw && /name/i.test(raw) && /invalid/i.test(raw)
+            ? 'The name is invalid. Use lowercase letters, numbers and hyphens (no spaces).'
+            : `Could not create the organization: ${raw || 'unknown error'}.`
+      );
+    } finally {
+      setSubmitting(false);
     }
-  };
-
-  /**
-   * Handle organization deletion
-   */
-  const handleDelete = async (orgName) => {
-    if (!window.confirm(`Are you sure you want to delete organization "${orgName}"? This will also delete all associated datasets and resources.`)) {
-      return;
-    }
-
-    try {
-      setError(null);
-      setSuccess(null);
-      
-      await organizationsAPI.delete(orgName, 'local');
-      
-      setSuccess(`Organization "${orgName}" deleted successfully!`);
-      
-      // Refresh the list
-      fetchOrganizations();
-    } catch (err) {
-      console.error('Error deleting organization:', err);
-      setError('Failed to delete organization: ' + 
-        (err.response?.data?.detail || err.message));
-    }
-  };
-
-  /**
-   * Handle search
-   */
-  const handleSearch = (e) => {
-    e.preventDefault();
-    fetchOrganizations();
   };
 
   return (
-    <div className="organizations-page">
-      {/* Page Header */}
+    <div style={{ maxWidth: '640px', margin: '0 auto', padding: '0 1rem' }}>
       <div className="page-header">
         <h1 className="page-title">
           <Building2 size={32} style={{ marginRight: '0.5rem' }} />
-          Organizations
+          New organization
         </h1>
         <p className="page-subtitle">
-          Manage organizations in your CKAN instance
+          Register a new organization on the local catalog. Once created,
+          you can find it (and remove it if you change your mind) from the
+          Search page.
         </p>
       </div>
 
-      {/* Alert Messages */}
       {error && (
         <div className="alert alert-error">
           <AlertCircle size={20} />
@@ -150,181 +69,74 @@ const Organizations = () => {
 
       {success && (
         <div className="alert alert-success">
+          <CheckCircle size={20} />
           {success}
         </div>
       )}
 
-      {/* Controls */}
       <div className="card">
-        <div className="card-header">
-          <h3 className="card-title">Controls</h3>
-          <button
-            onClick={() => setShowCreateForm(!showCreateForm)}
-            className="btn btn-primary"
-          >
-            <Plus size={16} />
-            Create Organization
-          </button>
-        </div>
-
-        {/* Server Selection */}
-        <div className="form-group">
-          <label className="form-label">Server</label>
-          <select
-            value={selectedServer}
-            onChange={(e) => setSelectedServer(e.target.value)}
-            className="form-select"
-          >
-            <option value="global">Global</option>
-            <option value="local">Local</option>
-            <option value="pre_ckan">Pre-CKAN</option>
-          </select>
-        </div>
-
-        {/* Search */}
-        <form onSubmit={handleSearch} style={{ display: 'flex', gap: '1rem' }}>
-          <div className="form-group" style={{ flex: 1, marginBottom: 0 }}>
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label className="form-label">Name *</label>
             <input
               type="text"
-              placeholder="Search organizations by name..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
+              name="name"
+              value={formData.name}
+              onChange={handleInputChange}
               className="form-input"
+              placeholder="my-organization"
+              required
+            />
+            <small style={{ color: '#64748b' }}>
+              Unique identifier — lowercase, numbers and hyphens only.
+            </small>
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">Title *</label>
+            <input
+              type="text"
+              name="title"
+              value={formData.title}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="My Organization"
+              required
             />
           </div>
-          <button type="submit" className="btn btn-secondary">
-            <Search size={16} />
-            Search
-          </button>
+
+          <div className="form-group">
+            <label className="form-label">Description</label>
+            <textarea
+              name="description"
+              value={formData.description}
+              onChange={handleInputChange}
+              className="form-input form-textarea"
+              placeholder="What is this organization for?"
+            />
+          </div>
+
+          <div style={{ display: 'flex', gap: '1rem' }}>
+            <button type="submit" className="btn btn-primary" disabled={submitting}>
+              {submitting ? (
+                <>
+                  <div className="loading-spinner" />
+                  Creating
+                </>
+              ) : (
+                'Create organization'
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() => navigate('/')}
+              className="btn btn-secondary"
+              disabled={submitting}
+            >
+              Back to Search
+            </button>
+          </div>
         </form>
-      </div>
-
-      {/* Create Organization Form */}
-      {showCreateForm && (
-        <div className="card">
-          <div className="card-header">
-            <h3 className="card-title">Create New Organization</h3>
-          </div>
-
-          <form onSubmit={handleSubmit}>
-            <div className="form-group">
-              <label className="form-label">Name *</label>
-              <input
-                type="text"
-                name="name"
-                value={formData.name}
-                onChange={handleInputChange}
-                className="form-input"
-                placeholder="organization_name"
-                required
-              />
-              <small style={{ color: '#64748b' }}>
-                Unique identifier (lowercase, no spaces)
-              </small>
-            </div>
-
-            <div className="form-group">
-              <label className="form-label">Title *</label>
-              <input
-                type="text"
-                name="title"
-                value={formData.title}
-                onChange={handleInputChange}
-                className="form-input"
-                placeholder="Organization Title"
-                required
-              />
-            </div>
-
-            <div className="form-group">
-              <label className="form-label">Description</label>
-              <textarea
-                name="description"
-                value={formData.description}
-                onChange={handleInputChange}
-                className="form-input form-textarea"
-                placeholder="Organization description..."
-              />
-            </div>
-
-            <div style={{ display: 'flex', gap: '1rem' }}>
-              <button type="submit" className="btn btn-primary">
-                Create Organization
-              </button>
-              <button
-                type="button"
-                onClick={() => setShowCreateForm(false)}
-                className="btn btn-secondary"
-              >
-                Cancel
-              </button>
-            </div>
-          </form>
-        </div>
-      )}
-
-      {/* Organizations List */}
-      <div className="card">
-        <div className="card-header">
-          <h3 className="card-title">
-            Organizations ({organizations.length})
-          </h3>
-        </div>
-
-        {loading ? (
-          <div style={{ textAlign: 'center', padding: '2rem' }}>
-            <div className="loading-spinner" style={{ margin: '0 auto' }}></div>
-            <p style={{ marginTop: '1rem' }}>Loading organizations...</p>
-          </div>
-        ) : organizations.length === 0 ? (
-          <div style={{ textAlign: 'center', padding: '2rem', color: '#64748b' }}>
-            <Building2 size={48} style={{ marginBottom: '1rem', opacity: 0.5 }} />
-            <p>No organizations found</p>
-            {searchTerm && (
-              <p>Try adjusting your search term or check a different server</p>
-            )}
-          </div>
-        ) : (
-          <div className="table-container">
-            <table className="table">
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>Server</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {organizations.map((org, index) => (
-                  <tr key={`${org}-${index}`}>
-                    <td>
-                      <div>
-                        <div style={{ fontWeight: '500' }}>{org}</div>
-                      </div>
-                    </td>
-                    <td>
-                      <span className="status-indicator status-success">
-                        {selectedServer}
-                      </span>
-                    </td>
-                    <td>
-                      {selectedServer === 'local' && (
-                        <button
-                          onClick={() => handleDelete(org)}
-                          className="btn btn-danger"
-                          style={{ padding: '0.5rem' }}
-                          title="Delete organization"
-                        >
-                          <Trash2 size={16} />
-                        </button>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/ui/src/pages/Search.js
+++ b/ui/src/pages/Search.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Search as SearchIcon,
   AlertCircle,
@@ -7,7 +7,8 @@ import {
   X,
   ExternalLink,
   Database,
-  Building2
+  Building2,
+  Trash2
 } from 'lucide-react';
 import { searchAPI, organizationsAPI, userAPI } from '../services/api';
 
@@ -43,6 +44,11 @@ const Search = () => {
   // that comes back in /user/info.
   const [onlyMine, setOnlyMine] = useState(false);
   const [myUserHash, setMyUserHash] = useState(null);
+  // Names of organizations the current user owns on the *local* catalog.
+  // The Search page uses this to show a Delete action on org cards that
+  // belong to the user. Only local because the delete endpoint targets
+  // the local catalog only.
+  const [myLocalOrgNames, setMyLocalOrgNames] = useState(() => new Set());
   const inputRef = useRef(null);
   // Monotonically-increasing id of the most recent search request.
   // Only the latest request is allowed to update state, so a slow
@@ -71,6 +77,26 @@ const Search = () => {
       cancelled = true;
     };
   }, []);
+
+  // Refresh the list of *my* local orgs. We keep this separate from the
+  // main Search results so we can flag owned orgs even when the user is
+  // browsing the unfiltered list (the server-side ?mine=true filter only
+  // applies to the org list endpoint itself).
+  const refreshMyLocalOrgs = useCallback(async () => {
+    if (!myUserHash) return;
+    try {
+      const response = await organizationsAPI.list({ server: 'local', mine: true });
+      const names = Array.isArray(response.data) ? response.data : [];
+      setMyLocalOrgNames(new Set(names));
+    } catch {
+      // A failure here only means the Delete button stays hidden — it's
+      // a degraded experience, not a broken page, so we swallow it.
+    }
+  }, [myUserHash]);
+
+  useEffect(() => {
+    refreshMyLocalOrgs();
+  }, [refreshMyLocalOrgs]);
 
   // Client-side filter applied when "Only mine" is on. Items missing
   // a creator hash (legacy data) are intentionally excluded.
@@ -243,6 +269,49 @@ const Search = () => {
     setOwnerOrgFilter(null);
   };
 
+  // Translate backend errors into something a non-engineer can act on.
+  // The patterns map to the messages CKAN and our Mongo backend emit
+  // for the most common failure cases.
+  const friendlyDeleteError = (err, orgName) => {
+    const status = err.response?.status;
+    const detail = err.response?.data?.detail;
+    const raw = (typeof detail === 'string' ? detail : err.message) || '';
+    if (status === 401) return 'You need to log in again to delete organizations.';
+    if (status === 403)
+      return `You don't have permission to delete "${orgName}".`;
+    if (status === 404 || /not found/i.test(raw))
+      return `"${orgName}" no longer exists. It may have been deleted already.`;
+    if (status === 409 || /still has/i.test(raw)) {
+      // Try to extract the dataset count from the backend message so the
+      // user knows exactly how much cleanup is left to do.
+      const match = /(\d+)\s+dataset/i.exec(raw);
+      const count = match ? Number(match[1]) : null;
+      const suffix = count
+        ? `${count} dataset${count === 1 ? '' : 's'}`
+        : 'datasets';
+      return `"${orgName}" still has ${suffix} inside. Delete the datasets first, then try again.`;
+    }
+    if (/scheme|unreachable|configured/i.test(raw))
+      return 'The local catalog is not reachable right now. Try again in a moment.';
+    return `Could not delete "${orgName}". Please try again later.`;
+  };
+
+  const handleDeleteOrg = async (orgName) => {
+    // cascade:false → only the organization is deleted; datasets owned
+    // by it are left in place. The user gets a friendly error if any
+    // datasets are still there.
+    await organizationsAPI.delete(orgName, 'local', { cascade: false });
+    // Optimistically drop the org from the rendered list and from the
+    // owned-orgs set so the card disappears immediately on success.
+    setOrganizationResults((prev) => prev.filter((name) => name !== orgName));
+    setMyLocalOrgNames((prev) => {
+      if (!prev.has(orgName)) return prev;
+      const next = new Set(prev);
+      next.delete(orgName);
+      return next;
+    });
+  };
+
   const clearTerm = () => {
     setSearchTerm('');
     inputRef.current?.focus();
@@ -399,6 +468,10 @@ const Search = () => {
           <OrganizationsSection
             items={organizationResults}
             onViewDatasets={handleViewDatasetsInOrg}
+            ownedOrgNames={myLocalOrgNames}
+            canDelete={server === 'local'}
+            onDelete={handleDeleteOrg}
+            mapDeleteError={friendlyDeleteError}
           />
         )}
     </div>
@@ -922,7 +995,14 @@ const OrgFilterChip = ({ orgName, onClear }) => (
   </div>
 );
 
-const OrganizationsSection = ({ items, onViewDatasets }) => (
+const OrganizationsSection = ({
+  items,
+  onViewDatasets,
+  ownedOrgNames,
+  canDelete,
+  onDelete,
+  mapDeleteError
+}) => (
   <div style={{ marginBottom: '2rem' }}>
     <div
       style={{
@@ -980,6 +1060,9 @@ const OrganizationsSection = ({ items, onViewDatasets }) => (
             key={orgName}
             orgName={orgName}
             onViewDatasets={onViewDatasets}
+            isOwned={Boolean(canDelete && ownedOrgNames?.has(orgName))}
+            onDelete={onDelete}
+            mapDeleteError={mapDeleteError}
           />
         ))}
       </div>
@@ -987,49 +1070,191 @@ const OrganizationsSection = ({ items, onViewDatasets }) => (
   </div>
 );
 
-const OrganizationCard = ({ orgName, onViewDatasets }) => (
-  <div
-    style={{
-      background: 'white',
-      border: '1px solid #e2e8f0',
-      borderRadius: '10px',
-      padding: '1rem 1.1rem',
-      display: 'flex',
-      flexDirection: 'column',
-      gap: '0.6rem'
-    }}
-  >
-    <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-      <Badge color="#0f766e" background="#ecfdf5">Organization</Badge>
-    </div>
+const OrganizationCard = ({
+  orgName,
+  onViewDatasets,
+  isOwned,
+  onDelete,
+  mapDeleteError
+}) => {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState(null);
+
+  const handleConfirm = async () => {
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      await onDelete(orgName);
+      // On success the parent removes us from the list, so no need to
+      // touch local state — the card unmounts.
+    } catch (err) {
+      setDeleteError(mapDeleteError ? mapDeleteError(err, orgName) : err.message);
+      setDeleting(false);
+    }
+  };
+
+  return (
     <div
       style={{
-        fontSize: '1.05rem',
-        fontWeight: 600,
-        color: '#0f172a',
-        wordBreak: 'break-word'
+        background: 'white',
+        border: '1px solid #e2e8f0',
+        borderRadius: '10px',
+        padding: '1rem 1.1rem',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.6rem'
       }}
     >
-      {orgName}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <Badge color="#0f766e" background="#ecfdf5">Organization</Badge>
+        {isOwned && (
+          <Badge color="#1d4ed8" background="#eff6ff">Yours</Badge>
+        )}
+      </div>
+      <div
+        style={{
+          fontSize: '1.05rem',
+          fontWeight: 600,
+          color: '#0f172a',
+          wordBreak: 'break-word'
+        }}
+      >
+        {orgName}
+      </div>
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem' }}>
+        <button
+          type="button"
+          onClick={() => onViewDatasets(orgName)}
+          disabled={deleting}
+          style={{
+            background: 'transparent',
+            border: 'none',
+            padding: 0,
+            color: '#2563eb',
+            fontSize: '0.85rem',
+            fontWeight: 500,
+            cursor: deleting ? 'not-allowed' : 'pointer'
+          }}
+        >
+          View datasets in this org →
+        </button>
+
+        {isOwned && !confirmOpen && (
+          <button
+            type="button"
+            onClick={() => {
+              setDeleteError(null);
+              setConfirmOpen(true);
+            }}
+            disabled={deleting}
+            style={{
+              background: 'transparent',
+              border: 'none',
+              padding: 0,
+              color: '#b91c1c',
+              fontSize: '0.85rem',
+              fontWeight: 500,
+              cursor: deleting ? 'not-allowed' : 'pointer',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '0.25rem'
+            }}
+          >
+            <Trash2 size={14} />
+            Delete
+          </button>
+        )}
+      </div>
+
+      {confirmOpen && (
+        <div
+          role="alertdialog"
+          aria-label={`Confirm deleting ${orgName}`}
+          style={{
+            marginTop: '0.25rem',
+            background: '#fef2f2',
+            border: '1px solid #fecaca',
+            borderRadius: '8px',
+            padding: '0.75rem'
+          }}
+        >
+          <div style={{ color: '#7f1d1d', fontSize: '0.85rem', marginBottom: '0.6rem' }}>
+            Delete <strong>{orgName}</strong>? This cannot be undone. Datasets
+            inside the organization are <strong>not</strong> deleted.
+          </div>
+          <div style={{ display: 'flex', gap: '0.5rem' }}>
+            <button
+              type="button"
+              onClick={handleConfirm}
+              disabled={deleting}
+              style={{
+                background: '#dc2626',
+                color: 'white',
+                border: 'none',
+                borderRadius: '6px',
+                padding: '0.35rem 0.75rem',
+                fontSize: '0.85rem',
+                fontWeight: 600,
+                cursor: deleting ? 'not-allowed' : 'pointer',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '0.4rem'
+              }}
+            >
+              {deleting ? (
+                <>
+                  <div className="loading-spinner" />
+                  Deleting
+                </>
+              ) : (
+                <>
+                  <Trash2 size={14} />
+                  Delete
+                </>
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setConfirmOpen(false);
+                setDeleteError(null);
+              }}
+              disabled={deleting}
+              style={{
+                background: 'white',
+                color: '#374151',
+                border: '1px solid #d1d5db',
+                borderRadius: '6px',
+                padding: '0.35rem 0.75rem',
+                fontSize: '0.85rem',
+                fontWeight: 500,
+                cursor: deleting ? 'not-allowed' : 'pointer'
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+          {deleteError && (
+            <div
+              style={{
+                marginTop: '0.6rem',
+                color: '#7f1d1d',
+                fontSize: '0.8rem',
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: '0.4rem'
+              }}
+            >
+              <AlertCircle size={14} style={{ marginTop: '2px', flexShrink: 0 }} />
+              <span>{deleteError}</span>
+            </div>
+          )}
+        </div>
+      )}
     </div>
-    <button
-      type="button"
-      onClick={() => onViewDatasets(orgName)}
-      style={{
-        marginTop: '0.1rem',
-        alignSelf: 'flex-start',
-        background: 'transparent',
-        border: 'none',
-        padding: 0,
-        color: '#2563eb',
-        fontSize: '0.85rem',
-        fontWeight: 500,
-        cursor: 'pointer'
-      }}
-    >
-      View datasets in this org →
-    </button>
-  </div>
-);
+  );
+};
 
 export default Search;

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -86,9 +86,12 @@ export const organizationsAPI = {
   create: (data, server = 'local') => 
     apiClient.post('/organization', data, { params: { server } }),
   
-  delete: (organizationName, server = 'local') => 
-    apiClient.delete(`/organization/${organizationName}`, { 
-      params: { server } 
+  // `cascade` defaults to true for backwards-compatibility with the
+  // existing API contract; callers that want a "delete the org only"
+  // semantic (the UI does) should pass `{ cascade: false }`.
+  delete: (organizationName, server = 'local', { cascade = true } = {}) =>
+    apiClient.delete(`/organization/${organizationName}`, {
+      params: { server, cascade }
     }),
 };
 


### PR DESCRIPTION
## Summary
- Removed the "Organizations" entry from the top navigation and added a "+ New" dropdown with a single "Organization" item that lands on the simplified creation page. New creation types can be added later without redesigning the nav.
- Simplified the `/organizations` page to a single-purpose "create a new organization" form. The listing role moves to the Search page (already there since 0.23.0) and the delete role moves into the org result cards.
- Search organization cards owned by the authenticated user now show a "Yours" badge and a "Delete" action. Clicking Delete opens an inline confirmation panel on the same card (no `window.confirm`, no full-screen modal). On success the card disappears; on failure the user sees a friendly, actionable message ("X still has 1 dataset inside. Delete the datasets first, then try again.", auth errors, catalog unreachable, etc.) instead of the raw backend string.
- `DELETE /organization/{name}` accepts a new optional `cascade` query parameter. Default is `true` (legacy behavior). With `cascade=false`, the call only deletes the organization and refuses with `409 Conflict` if the organization still has datasets inside, returning the exact count in the message. The Search UI always sends `cascade=false`, so users cannot lose datasets by clicking Delete.

## Backwards compatibility
- `DELETE /organization/{name}` defaults to `cascade=true` (legacy "delete the org and every dataset it owns"). Existing API clients are unaffected.
- The HTTP path of `DELETE /organization/{name}` is unchanged; `cascade=false` adds a new `409` response code on top of the existing `200/400/404`.
- The `/organizations` UI route still exists and still creates organizations; the page only drops the listing/delete features that became redundant after Search took over.
- No fields removed, no types changed, no required parameters added.

## Test plan
- [x] Backend: `docker compose exec api python -m pytest tests/ -v` → **1134 tests pass** (+2 over 0.23.0; both cover the new `cascade=False` branches).
- [x] Lint: `black --check .` clean. `flake8` shows only one preexisting warning (`'api.config.catalog_settings' imported but unused`) already present on `main`.
- [x] End-to-end smoke test with `raul`/`raul`:
  - Create org + dataset inside.
  - `DELETE /organization/X?cascade=false` → **409** with `"Organization still has 1 dataset(s) inside; delete them first or call with cascade=true"`. Dataset is intact.
  - `DELETE /organization/X?cascade=false` on an empty org → **200**.
  - Default `DELETE /organization/X` (`cascade=true`) still cascades.
- [x] UI smoke test (local container):
  - "+ New" dropdown shows "Organization"; selecting it lands on the simplified create form.
  - Creating an organization succeeds and the page shows a friendly confirmation.
  - Search > Organizations: the new org appears with "Yours" + "Delete" on local server.
  - Click Delete → inline confirmation panel; Cancel closes it; Delete removes the card.
  - When deleting an org that has a dataset, the panel shows the friendly "still has N datasets" message and the card stays.

Closes #155.