### PR TITLE
Move Services into the + New menu and let owners delete from Search (closes #157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-05-13
+
+### Added
+- Navigation: the "+ New" menu now hosts a "Service" entry next to the existing "Organization" entry, replacing the dedicated "Services" top-level link.
+- Search page: service result cards whose persisted creator hash matches the authenticated user expose a "Yours" badge and a "Delete" action. Clicking Delete opens an inline confirmation panel on the same card (no `window.confirm`, no full-screen modal). On success the card disappears immediately; on failure the panel surfaces a friendly, actionable message instead of the raw backend string.
+
+### Changed
+- The Services page is now a single-purpose "register a new service" form, mirroring the simplified Organizations creation page. Listing, editing and deletion have moved to the Search page (listing was already there; deletion is new with this release). The route stays at `/services` so deep links keep working.
+- The "Services" entry has been removed from the navigation bar; the page is now reached exclusively from "+ New > Service".
+
+### Backwards compatibility
+- No new API surface: service deletion goes through the existing dataset-deletion endpoint (services are CKAN packages under the `services` organization).
+- The `/services` UI route still exists and still creates services; the page only drops the listing/edit/delete features that became redundant once Search took over.
+- Services registered before the creator-hash feature simply do not appear under "Only mine" and never expose a Delete action on Search; no migration is performed.
+
 ## [0.24.0] - 2026-05-13
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.24.0"
+    swagger_version: str = "0.25.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/components/Navigation.js
+++ b/ui/src/components/Navigation.js
@@ -406,38 +406,6 @@ const Navigation = () => {
                 )}
               </div>
 
-              {/* Services */}
-              <Link
-                to="/services"
-                onMouseEnter={handleOtherNavEnter}
-                style={{
-                  color: '#6b7280', // Always same color
-                  textDecoration: 'none',
-                  padding: '0.5rem 0.75rem',
-                  borderRadius: '8px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '0.5rem',
-                  fontSize: '0.95rem',
-                  whiteSpace: 'nowrap',
-                  fontWeight: '500', // Always same weight
-                  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-                  backgroundColor: 'transparent',
-                  transition: 'all 0.2s ease'
-                }}
-                onMouseOver={(e) => {
-                  e.target.style.color = '#374151';
-                  e.target.style.fontWeight = '600';
-                }}
-                onMouseOut={(e) => {
-                  e.target.style.color = '#6b7280';
-                  e.target.style.fontWeight = '500';
-                }}
-              >
-                <Settings size={18} />
-                <span>Services</span>
-              </Link>
-
               {/* + New menu (compact entry point for create flows) */}
               <div
                 style={{ position: 'relative' }}
@@ -509,7 +477,8 @@ const Navigation = () => {
                         textDecoration: 'none',
                         fontSize: '0.9rem',
                         fontWeight: '500',
-                        backgroundColor: 'white'
+                        backgroundColor: 'white',
+                        borderBottom: '1px solid #f3f4f6'
                       }}
                       onMouseOver={(e) => {
                         e.target.style.backgroundColor = '#f9fafb';
@@ -524,6 +493,34 @@ const Navigation = () => {
                     >
                       <Building2 size={18} />
                       <span>Organization</span>
+                    </Link>
+
+                    <Link
+                      to="/services"
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.75rem',
+                        padding: '1rem 1.25rem',
+                        color: '#374151',
+                        textDecoration: 'none',
+                        fontSize: '0.9rem',
+                        fontWeight: '500',
+                        backgroundColor: 'white'
+                      }}
+                      onMouseOver={(e) => {
+                        e.target.style.backgroundColor = '#f9fafb';
+                        e.target.style.color = '#2563eb';
+                        e.target.style.fontWeight = '600';
+                      }}
+                      onMouseOut={(e) => {
+                        e.target.style.backgroundColor = 'white';
+                        e.target.style.color = '#374151';
+                        e.target.style.fontWeight = '500';
+                      }}
+                    >
+                      <Settings size={18} />
+                      <span>Service</span>
                     </Link>
                   </div>
                 )}

--- a/ui/src/pages/Search.js
+++ b/ui/src/pages/Search.js
@@ -10,7 +10,7 @@ import {
   Building2,
   Trash2
 } from 'lucide-react';
-import { searchAPI, organizationsAPI, userAPI } from '../services/api';
+import { searchAPI, organizationsAPI, userAPI, resourcesAPI } from '../services/api';
 
 const MODES = [
   { id: 'both', label: 'All' },
@@ -312,6 +312,29 @@ const Search = () => {
     });
   };
 
+  // Services are CKAN packages under owner_org="services", so deletion
+  // reuses the existing dataset-delete endpoint — no new API surface.
+  const friendlyServiceDeleteError = (err, serviceName) => {
+    const status = err.response?.status;
+    const detail = err.response?.data?.detail;
+    const raw = (typeof detail === 'string' ? detail : err.message) || '';
+    if (status === 401) return 'You need to log in again to delete services.';
+    if (status === 403)
+      return `You don't have permission to delete "${serviceName}".`;
+    if (status === 404 || /not found/i.test(raw))
+      return `"${serviceName}" no longer exists. It may have been deleted already.`;
+    if (/scheme|unreachable|configured/i.test(raw))
+      return 'The local catalog is not reachable right now. Try again in a moment.';
+    return `Could not delete "${serviceName}". Please try again later.`;
+  };
+
+  const handleDeleteService = async (service) => {
+    // Services are CKAN packages under owner_org="services"; the catalog
+    // exposes deletion through the resource endpoint identified by id.
+    await resourcesAPI.deleteById(service.id, 'local');
+    setServiceResults((prev) => prev.filter((item) => item.id !== service.id));
+  };
+
   const clearTerm = () => {
     setSearchTerm('');
     inputRef.current?.focus();
@@ -457,6 +480,10 @@ const Search = () => {
           items={serviceResults}
           emptyMessage="No services matched your search."
           isService
+          myUserHash={myUserHash}
+          canDelete={server === 'local'}
+          onDelete={handleDeleteService}
+          mapDeleteError={friendlyServiceDeleteError}
         />
       )}
 
@@ -702,7 +729,17 @@ const ResultsSummary = ({ total, mode, term, ownerOrg }) => {
   );
 };
 
-const ResultsSection = ({ title, icon, items, emptyMessage, isService }) => (
+const ResultsSection = ({
+  title,
+  icon,
+  items,
+  emptyMessage,
+  isService,
+  myUserHash,
+  canDelete,
+  onDelete,
+  mapDeleteError
+}) => (
   <div style={{ marginBottom: '2rem' }}>
     <div
       style={{
@@ -750,19 +787,58 @@ const ResultsSection = ({ title, icon, items, emptyMessage, isService }) => (
     ) : (
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
         {items.map((item, index) => (
-          <ResultCard key={item.id || `${title}-${index}`} item={item} isService={isService} />
+          <ResultCard
+            key={item.id || `${title}-${index}`}
+            item={item}
+            isService={isService}
+            myUserHash={myUserHash}
+            canDelete={canDelete}
+            onDelete={onDelete}
+            mapDeleteError={mapDeleteError}
+          />
         ))}
       </div>
     )}
   </div>
 );
 
-const ResultCard = ({ item, isService }) => {
+const ResultCard = ({
+  item,
+  isService,
+  myUserHash,
+  canDelete,
+  onDelete,
+  mapDeleteError
+}) => {
   const [expanded, setExpanded] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState(null);
   const resources = item.resources || [];
   const hasExtras = item.extras && Object.keys(item.extras).length > 0;
   const showResources = resources.length > 0;
   const canToggle = showResources || hasExtras;
+  // A result card is "owned" by the current user when its persisted
+  // creator hash matches and the surrounding section allows deletion
+  // (currently: services on the local server only).
+  const isOwned = Boolean(
+    canDelete && myUserHash && item.extras?.ndp_user_id === myUserHash
+  );
+  const itemLabel = item.title || item.name || 'this item';
+
+  const handleConfirmDelete = async () => {
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      await onDelete(item);
+      // On success the parent unmounts us; nothing else to do here.
+    } catch (err) {
+      setDeleteError(
+        mapDeleteError ? mapDeleteError(err, itemLabel) : err.message
+      );
+      setDeleting(false);
+    }
+  };
 
   return (
     <div
@@ -792,6 +868,9 @@ const ResultCard = ({ item, isService }) => {
               <Badge color="#0f766e" background="#ecfdf5">
                 {item.extras.service_type}
               </Badge>
+            )}
+            {isOwned && (
+              <Badge color="#1d4ed8" background="#eff6ff">Yours</Badge>
             )}
           </div>
 
@@ -828,30 +907,68 @@ const ResultCard = ({ item, isService }) => {
         </div>
       </div>
 
-      {canToggle && (
-        <button
-          type="button"
-          onClick={() => setExpanded((v) => !v)}
+      {(canToggle || isOwned) && (
+        <div
           style={{
             marginTop: '0.75rem',
-            background: 'transparent',
-            border: 'none',
-            color: '#2563eb',
-            padding: 0,
-            cursor: 'pointer',
-            fontSize: '0.85rem',
-            fontWeight: 500
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '0.9rem',
+            alignItems: 'center'
           }}
         >
-          {expanded
-            ? 'Hide details'
-            : `Show ${[
-                showResources && `${resources.length} ${isService ? 'endpoint' : 'resource'}${resources.length === 1 ? '' : 's'}`,
-                hasExtras && 'metadata'
-              ]
-                .filter(Boolean)
-                .join(' & ')}`}
-        </button>
+          {canToggle && (
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              disabled={deleting}
+              style={{
+                background: 'transparent',
+                border: 'none',
+                color: '#2563eb',
+                padding: 0,
+                cursor: deleting ? 'not-allowed' : 'pointer',
+                fontSize: '0.85rem',
+                fontWeight: 500
+              }}
+            >
+              {expanded
+                ? 'Hide details'
+                : `Show ${[
+                    showResources && `${resources.length} ${isService ? 'endpoint' : 'resource'}${resources.length === 1 ? '' : 's'}`,
+                    hasExtras && 'metadata'
+                  ]
+                    .filter(Boolean)
+                    .join(' & ')}`}
+            </button>
+          )}
+
+          {isOwned && !confirmOpen && (
+            <button
+              type="button"
+              onClick={() => {
+                setDeleteError(null);
+                setConfirmOpen(true);
+              }}
+              disabled={deleting}
+              style={{
+                background: 'transparent',
+                border: 'none',
+                padding: 0,
+                color: '#b91c1c',
+                fontSize: '0.85rem',
+                fontWeight: 500,
+                cursor: deleting ? 'not-allowed' : 'pointer',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '0.25rem'
+              }}
+            >
+              <Trash2 size={14} />
+              Delete
+            </button>
+          )}
+        </div>
       )}
 
       {expanded && showResources && (
@@ -882,6 +999,91 @@ const ResultCard = ({ item, isService }) => {
               </div>
             ))}
           </div>
+        </div>
+      )}
+
+      {isOwned && confirmOpen && (
+        <div
+          role="alertdialog"
+          aria-label={`Confirm deleting ${itemLabel}`}
+          style={{
+            marginTop: '0.75rem',
+            background: '#fef2f2',
+            border: '1px solid #fecaca',
+            borderRadius: '8px',
+            padding: '0.75rem'
+          }}
+        >
+          <div style={{ color: '#7f1d1d', fontSize: '0.85rem', marginBottom: '0.6rem' }}>
+            Delete <strong>{itemLabel}</strong>? This cannot be undone.
+          </div>
+          <div style={{ display: 'flex', gap: '0.5rem' }}>
+            <button
+              type="button"
+              onClick={handleConfirmDelete}
+              disabled={deleting}
+              style={{
+                background: '#dc2626',
+                color: 'white',
+                border: 'none',
+                borderRadius: '6px',
+                padding: '0.35rem 0.75rem',
+                fontSize: '0.85rem',
+                fontWeight: 600,
+                cursor: deleting ? 'not-allowed' : 'pointer',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '0.4rem'
+              }}
+            >
+              {deleting ? (
+                <>
+                  <div className="loading-spinner" />
+                  Deleting
+                </>
+              ) : (
+                <>
+                  <Trash2 size={14} />
+                  Delete
+                </>
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setConfirmOpen(false);
+                setDeleteError(null);
+              }}
+              disabled={deleting}
+              style={{
+                background: 'white',
+                color: '#374151',
+                border: '1px solid #d1d5db',
+                borderRadius: '6px',
+                padding: '0.35rem 0.75rem',
+                fontSize: '0.85rem',
+                fontWeight: 500,
+                cursor: deleting ? 'not-allowed' : 'pointer'
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+          {deleteError && (
+            <div
+              style={{
+                marginTop: '0.6rem',
+                color: '#7f1d1d',
+                fontSize: '0.8rem',
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: '0.4rem'
+              }}
+            >
+              <AlertCircle size={14} style={{ marginTop: '2px', flexShrink: 0 }} />
+              <span>{deleteError}</span>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/ui/src/pages/Services.js
+++ b/ui/src/pages/Services.js
@@ -1,480 +1,122 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import {
-  Settings,
-  Plus,
-  AlertCircle,
-  Save,
-  X,
-  Trash2,
-  ExternalLink,
-  FileText,
-  Server,
-  Edit3
-} from 'lucide-react';
-import { servicesAPI, searchAPI, resourcesAPI, BASE_URL } from '../services/api';
+import React, { useState } from 'react';
+import { Settings, AlertCircle, CheckCircle, Plus, Trash2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { servicesAPI } from '../services/api';
 
 /**
- * Services page component for managing registered services
- * Allows creating, listing, editing, and deleting services in CKAN
- * Enhanced to match the structure and functionality of other resource pages
+ * Single-purpose page reached from the "+ New > Service" menu. Listing
+ * and deletion live on the Search page now — this page only exposes the
+ * create form.
  */
 const Services = () => {
-  const [services, setServices] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [success, setSuccess] = useState(null);
-  const [showCreateForm, setShowCreateForm] = useState(false);
-  const [editingService, setEditingService] = useState(null);
-
-  const [selectedServer] = useState('local'); // Fixed to local for consistency
-
-  // Form state for creating/editing service
+  const navigate = useNavigate();
   const [formData, setFormData] = useState({
     service_name: '',
     service_title: '',
-    owner_org: 'services', // Always 'services' as per API requirement
     service_url: '',
     service_type: '',
     notes: '',
-    extras: {},
     health_check_url: '',
     documentation_url: ''
   });
-
-  // JSON editor state for extras
-  const [extrasJson, setExtrasJson] = useState('{}');
-
-  // Extras editor: 'fields' for guided key/value rows, 'json' for raw JSON
-  const [extrasMode, setExtrasMode] = useState('fields');
   const [extrasPairs, setExtrasPairs] = useState([]);
-  const [extrasModeError, setExtrasModeError] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(null);
 
-  // True when value is a flat object whose values are all string/number/boolean/null.
-  // The guided key/value editor can only round-trip this shape; nested objects or
-  // arrays force the user into raw JSON mode.
-  const isFlatPrimitiveMap = (obj) => {
-    if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
-    return Object.values(obj).every((v) =>
-      v === null || ['string', 'number', 'boolean'].includes(typeof v)
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const addExtraPair = () =>
+    setExtrasPairs((prev) => [...prev, { key: '', value: '' }]);
+
+  const removeExtraPair = (idx) =>
+    setExtrasPairs((prev) => prev.filter((_, i) => i !== idx));
+
+  const updateExtraPair = (idx, field, value) =>
+    setExtrasPairs((prev) =>
+      prev.map((p, i) => (i === idx ? { ...p, [field]: value } : p))
     );
-  };
 
-  const objectToPairs = (obj) => {
-    if (!obj || typeof obj !== 'object') return [];
-    return Object.entries(obj).map(([key, value]) => ({
-      key,
-      value: value === null || value === undefined ? '' : String(value)
-    }));
-  };
-
-  const pairsToObject = (pairs) => {
+  const buildExtras = () => {
     const out = {};
-    for (const { key, value } of pairs) {
+    for (const { key, value } of extrasPairs) {
       const trimmed = (key || '').trim();
-      if (trimmed === '') continue;
-      out[trimmed] = value;
+      if (trimmed) out[trimmed] = value;
     }
     return out;
   };
 
-  const addExtraPair = () => {
-    setExtrasPairs((prev) => [...prev, { key: '', value: '' }]);
-    setExtrasModeError(null);
-  };
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+    setSubmitting(true);
 
-  const removeExtraPair = (idx) => {
-    setExtrasPairs((prev) => prev.filter((_, i) => i !== idx));
-  };
-
-  const updateExtraPair = (idx, field, value) => {
-    setExtrasPairs((prev) =>
-      prev.map((p, i) => (i === idx ? { ...p, [field]: value } : p))
-    );
-  };
-
-  const switchExtrasToJsonMode = () => {
-    const obj = pairsToObject(extrasPairs);
-    setExtrasJson(JSON.stringify(obj, null, 2));
-    setExtrasMode('json');
-    setExtrasModeError(null);
-  };
-
-  const switchExtrasToFieldsMode = () => {
-    let parsed;
-    try {
-      parsed = extrasJson.trim() === '' ? {} : JSON.parse(extrasJson);
-    } catch {
-      setExtrasModeError('Cannot switch to simple fields: the JSON is invalid.');
-      return;
-    }
-    if (!isFlatPrimitiveMap(parsed)) {
-      setExtrasModeError(
-        'Cannot switch to simple fields: this metadata has nested or non-text values. Stay in advanced mode to edit it.'
-      );
-      return;
-    }
-    setExtrasPairs(objectToPairs(parsed));
-    setExtrasMode('fields');
-    setExtrasModeError(null);
-  };
-
-  // Available service types
-  const serviceTypes = [
-    'API',
-    'Web Service',
-    'Microservice',
-    'Database',
-    'Authentication Service',
-    'Storage Service',
-    'Analytics Service',
-    'Monitoring Service',
-    'Other'
-  ];
-
-  /**
-   * Fetch all services (filtered from all datasets)
-   */
-  const fetchServices = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      
-      // Use search to get all datasets, then filter for services
-      const response = await searchAPI.searchByTerms([''], null, selectedServer);
-      
-      // Filter to show only services (owner_org === 'services')
-      const filteredServices = (response.data || []).filter(dataset => {
-        return dataset.owner_org === 'services';
-      });
-      
-      console.log('All datasets:', response.data); // Debug
-      console.log('Filtered services:', filteredServices); // Debug
-      
-      setServices(filteredServices);
-      
-    } catch (err) {
-      console.error('Error fetching services:', err);
-      setError('Failed to load services: ' + 
-        (err.response?.data?.detail || err.message));
-    } finally {
-      setLoading(false);
-    }
-  }, [selectedServer]);
-
-  /**
-   * Fetch services on component mount
-   */
-  useEffect(() => {
-    fetchServices();
-  }, [fetchServices]);
-
-  /**
-   * Handle form input changes
-   */
-  const handleInputChange = (e) => {
-    const { name, value } = e.target;
-    setFormData(prev => ({
-      ...prev,
-      [name]: value
-    }));
-  };
-
-  /**
-   * Parse JSON string safely
-   */
-  const parseJsonSafely = (jsonString, fallback = {}) => {
-    try {
-      return jsonString.trim() === '' ? fallback : JSON.parse(jsonString);
-    } catch {
-      return fallback;
-    }
-  };
-
-  /**
-   * Reset form to initial state
-   */
-  const resetForm = () => {
-    setFormData({
-      service_name: '',
-      service_title: '',
+    const payload = {
+      service_name: formData.service_name,
+      service_title: formData.service_title,
+      // Services always live under the "services" org by API contract,
+      // so we set it on the client and don't expose it as an input.
       owner_org: 'services',
-      service_url: '',
-      service_type: '',
-      notes: '',
-      extras: {},
-      health_check_url: '',
-      documentation_url: ''
-    });
-    setExtrasJson('{}');
-    setExtrasMode('fields');
-    setExtrasPairs([]);
-    setExtrasModeError(null);
-    setEditingService(null);
-    setShowCreateForm(false);
-  };
-
-  /**
-   * Prepare form data for submission
-   */
-  const prepareFormData = () => {
-    // Build extras from whichever editor mode is active
-    const extras = extrasMode === 'fields'
-      ? pairsToObject(extrasPairs)
-      : parseJsonSafely(extrasJson, {});
-
-    // Prepare data
-    const requestData = {
-      ...formData,
-      extras: Object.keys(extras).length > 0 ? extras : undefined
+      service_url: formData.service_url
     };
-
-    // Remove empty fields
-    Object.keys(requestData).forEach(key => {
-      if (requestData[key] === '' || requestData[key] === undefined) {
-        delete requestData[key];
-      }
-    });
-
-    return requestData;
-  };
-
-  /**
-   * Handle form submission for creating service
-   */
-  const handleCreate = async (e) => {
-    e.preventDefault();
+    if (formData.service_type) payload.service_type = formData.service_type;
+    if (formData.notes) payload.notes = formData.notes;
+    if (formData.health_check_url)
+      payload.health_check_url = formData.health_check_url;
+    if (formData.documentation_url)
+      payload.documentation_url = formData.documentation_url;
+    const extras = buildExtras();
+    if (Object.keys(extras).length > 0) payload.extras = extras;
 
     try {
-      setError(null);
-      setSuccess(null);
-      setLoading(true);
-
-      const requestData = prepareFormData();
-      await servicesAPI.create(requestData, selectedServer);
-
-      setSuccess('Service registered successfully!');
-      resetForm();
-      fetchServices();
-
-    } catch (err) {
-      console.error('Error creating service:', err);
-      setError('Failed to register service: ' +
-        (err.response?.data?.detail || err.message));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  /**
-   * Handle form submission for updating service
-   */
-  const handleUpdate = async (e) => {
-    e.preventDefault();
-
-    try {
-      setError(null);
-      setSuccess(null);
-      setLoading(true);
-
-      if (!editingService || !editingService.id) {
-        throw new Error('Invalid service ID for update operation');
-      }
-
-      const requestData = prepareFormData();
-
-      // Ensure all critical fields are present for update
-      const updateData = {
-        service_name: formData.service_name || editingService.name,
-        service_title: formData.service_title || editingService.title,
-        owner_org: formData.owner_org || editingService.owner_org,
-        service_url: formData.service_url || (editingService.resources?.[0]?.url),
-        ...(formData.service_type && { service_type: formData.service_type }),
-        ...(formData.notes && { notes: formData.notes }),
-        ...(formData.health_check_url && { health_check_url: formData.health_check_url }),
-        ...(formData.documentation_url && { documentation_url: formData.documentation_url }),
-        ...(requestData.extras && { extras: requestData.extras })
-      };
-
-      await servicesAPI.update(editingService.id, updateData, selectedServer);
-
-      setSuccess('Service updated successfully!');
-      resetForm();
-      fetchServices();
-
-    } catch (err) {
-      console.error('Error updating service:', err);
-      setError('Failed to update service: ' +
-        (err.response?.data?.detail || err.message));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  /**
-   * Start editing a service
-   */
-  const startEditing = (service) => {
-    setEditingService(service);
-    const extras = service.extras || {};
-    const firstResource = service.resources && service.resources[0];
-
-    // Extract service-specific fields from extras
-    const serviceType = extras.service_type || '';
-    const healthCheckUrl = extras.health_check_url || '';
-    const documentationUrl = extras.documentation_url || '';
-
-    // Create clean extras without service-specific fields
-    const cleanExtras = { ...extras };
-    delete cleanExtras.service_type;
-    delete cleanExtras.health_check_url;
-    delete cleanExtras.documentation_url;
-
-    const editFormData = {
-      service_name: service.name || '',
-      service_title: service.title || '',
-      owner_org: service.owner_org || 'services',
-      service_url: firstResource?.url || '',
-      service_type: serviceType,
-      notes: service.notes || '',
-      extras: cleanExtras,
-      health_check_url: healthCheckUrl,
-      documentation_url: documentationUrl
-    };
-
-    setFormData(editFormData);
-
-    // Default the extras editor to guided fields when the data is a flat
-    // primitive map; otherwise keep the raw JSON view so nothing is dropped.
-    setExtrasJson(JSON.stringify(cleanExtras, null, 2));
-    if (isFlatPrimitiveMap(cleanExtras)) {
-      setExtrasPairs(objectToPairs(cleanExtras));
-      setExtrasMode('fields');
-    } else {
+      await servicesAPI.create(payload, 'local');
+      setSuccess(
+        `Service "${formData.service_name}" registered. You can keep registering more or go back to Search.`
+      );
+      setFormData({
+        service_name: '',
+        service_title: '',
+        service_url: '',
+        service_type: '',
+        notes: '',
+        health_check_url: '',
+        documentation_url: ''
+      });
       setExtrasPairs([]);
-      setExtrasMode('json');
-    }
-    setExtrasModeError(null);
-
-    setShowCreateForm(true);
-  };
-
-  /**
-   * Handle service deletion
-   */
-  const handleDeleteService = async (service) => {
-    const displayName = service.title || service.name || 'Unnamed Service';
-    
-    if (!window.confirm(
-      `Are you sure you want to delete service "${displayName}"? This will also delete all associated resources. This action cannot be undone.`
-    )) {
-      return;
-    }
-
-    try {
-      setError(null);
-      setSuccess(null);
-      
-      // Debug: Log the service being deleted
-      console.log('Attempting to delete service with ID:', service.id);
-      console.log('Using endpoint: DELETE /resource?resource_id=' + service.id + '&server=local');
-      
-      // Use the resource deletion endpoint since datasets are resources in CKAN
-      await resourcesAPI.deleteById(service.id, 'local');
-      
-      setSuccess(`Service "${displayName}" deleted successfully!`);
-      
-      // Refresh the services list
-      fetchServices();
-      
     } catch (err) {
-      console.error('Error deleting service:', err);
-      console.error('Full error object:', err);
-      console.error('Error response:', err.response);
-      
-      let errorMessage = 'Failed to delete service: ';
-      
-      if (err.response?.status === 404) {
-        errorMessage += `Service "${displayName}" not found. It may have been already deleted.`;
-      } else if (err.response?.status === 405) {
-        errorMessage += 'Service deletion method not allowed.';
-      } else if (err.response?.status === 401) {
-        errorMessage += 'Authentication required. Please login again.';
-      } else if (err.response?.status === 403) {
-        errorMessage += 'You do not have permission to delete this service.';
-      } else {
-        errorMessage += (err.response?.data?.detail || err.message);
-      }
-      
-      setError(errorMessage);
+      const detail = err.response?.data?.detail;
+      const raw = typeof detail === 'string' ? detail : err.message;
+      const msg = raw || 'unknown error';
+      setError(
+        /already exists/i.test(msg)
+          ? `A service called "${formData.service_name}" already exists. Pick a different name.`
+          : /name/i.test(msg) && /invalid/i.test(msg)
+            ? 'The service name is invalid. Use lowercase letters, numbers and hyphens (no spaces).'
+            : `Could not register the service: ${msg}.`
+      );
+    } finally {
+      setSubmitting(false);
     }
-  };
-
-  /**
-   * Get service type badge color
-   */
-  const getServiceTypeBadge = (service) => {
-    const extras = service.extras || {};
-    const serviceType = extras.service_type || 'Unknown';
-    
-    const typeColors = {
-      'API': 'status-info',
-      'Web Service': 'status-success',
-      'Microservice': 'status-warning',
-      'Database': 'status-error',
-      'Authentication Service': 'status-info',
-      'Storage Service': 'status-success',
-      'Analytics Service': 'status-warning',
-      'Monitoring Service': 'status-error',
-      'Other': 'status-info'
-    };
-    
-    return {
-      type: serviceType,
-      color: typeColors[serviceType] || 'status-info'
-    };
-  };
-
-  /**
-   * Get the main service URL from resources
-   */
-  const getMainServiceUrl = (service) => {
-    const firstResource = service.resources && service.resources[0];
-    return firstResource?.url || 'No URL';
-  };
-
-  /**
-   * Get documentation URL from service extras
-   */
-  const getDocumentationUrl = (service) => {
-    const extras = service.extras || {};
-    return extras.documentation_url || null;
-  };
-
-  /**
-   * Get health check status (placeholder for future implementation)
-   */
-  const getHealthStatus = (service) => {
-    const extras = service.extras || {};
-    if (extras.health_check_url) {
-      return { status: 'Unknown', color: 'status-warning' };
-    }
-    return { status: 'No Health Check', color: 'status-info' };
   };
 
   return (
-    <div className="services-page">
-      {/* Page Header */}
+    <div style={{ maxWidth: '720px', margin: '0 auto', padding: '0 1rem' }}>
       <div className="page-header">
         <h1 className="page-title">
           <Settings size={32} style={{ marginRight: '0.5rem' }} />
-          Services Registry
+          New service
         </h1>
         <p className="page-subtitle">
-          Register and manage services in your system
+          Register a new service on the local catalog. Once created, you
+          can find it (and remove it if you change your mind) from the
+          Search page.
         </p>
       </div>
 
-      {/* Alert Messages */}
       {error && (
         <div className="alert alert-error">
           <AlertCircle size={20} />
@@ -484,449 +126,176 @@ const Services = () => {
 
       {success && (
         <div className="alert alert-success">
+          <CheckCircle size={20} />
           {success}
         </div>
       )}
 
-      {/* Register service button */}
-      {!showCreateForm && (
-        <div style={{ marginBottom: '1rem' }}>
-          <button
-            onClick={() => setShowCreateForm(true)}
-            className="btn btn-primary"
-          >
-            <Plus size={16} />
-            Register Service
-          </button>
-        </div>
-      )}
-
-      {/* Create/Edit Service Form */}
-      {showCreateForm && (
-        <div className="card">
-          <div className="card-header">
-            <h3 className="card-title">
-              {editingService ? (
-                <>
-                  <Edit3 size={20} />
-                  Edit Service
-                </>
-              ) : (
-                <>
-                  <Plus size={20} />
-                  Register New Service
-                </>
-              )}
-            </h3>
-            <button
-              onClick={resetForm}
-              className="btn btn-secondary"
-            >
-              <X size={16} />
-              Cancel
-            </button>
+      <div className="card">
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label className="form-label">Service name *</label>
+            <input
+              type="text"
+              name="service_name"
+              value={formData.service_name}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="my-service"
+              required
+            />
+            <small style={{ color: '#64748b' }}>
+              Unique identifier — lowercase, numbers and hyphens only.
+            </small>
           </div>
 
-          <form onSubmit={editingService ? handleUpdate : handleCreate}>
-            {/* Basic Information */}
-            <div className="grid grid-2">
-              <div className="form-group">
-                <label className="form-label">Service Name *</label>
+          <div className="form-group">
+            <label className="form-label">Title *</label>
+            <input
+              type="text"
+              name="service_title"
+              value={formData.service_title}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="My Service"
+              required
+            />
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">Service URL *</label>
+            <input
+              type="url"
+              name="service_url"
+              value={formData.service_url}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="https://api.example.com/my-service"
+              required
+            />
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">Service type</label>
+            <input
+              type="text"
+              name="service_type"
+              value={formData.service_type}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="API, Web Service, Microservice…"
+            />
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">Description</label>
+            <textarea
+              name="notes"
+              value={formData.notes}
+              onChange={handleInputChange}
+              className="form-input form-textarea"
+              placeholder="What is this service for?"
+            />
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">Health check URL</label>
+            <input
+              type="url"
+              name="health_check_url"
+              value={formData.health_check_url}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="https://api.example.com/my-service/health"
+            />
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">Documentation URL</label>
+            <input
+              type="url"
+              name="documentation_url"
+              value={formData.documentation_url}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="https://docs.example.com/my-service"
+            />
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">Additional metadata</label>
+            <small style={{ color: '#64748b', display: 'block', marginBottom: '0.5rem' }}>
+              Optional key/value pairs that will be stored on the service.
+            </small>
+            {extrasPairs.map((pair, idx) => (
+              <div
+                key={idx}
+                style={{
+                  display: 'flex',
+                  gap: '0.5rem',
+                  marginBottom: '0.5rem'
+                }}
+              >
                 <input
                   type="text"
-                  name="service_name"
-                  value={formData.service_name}
-                  onChange={handleInputChange}
+                  value={pair.key}
+                  onChange={(e) => updateExtraPair(idx, 'key', e.target.value)}
                   className="form-input"
-                  placeholder="user_auth_api"
-                  required
+                  placeholder="key"
+                  style={{ flex: 1 }}
                 />
-                <small style={{ color: '#64748b' }}>
-                  Unique identifier for the service
-                </small>
-              </div>
-
-              <div className="form-group">
-                <label className="form-label">Service Title *</label>
                 <input
                   type="text"
-                  name="service_title"
-                  value={formData.service_title}
-                  onChange={handleInputChange}
+                  value={pair.value}
+                  onChange={(e) => updateExtraPair(idx, 'value', e.target.value)}
                   className="form-input"
-                  placeholder="User Authentication API"
-                  required
+                  placeholder="value"
+                  style={{ flex: 1 }}
                 />
-              </div>
-            </div>
-
-            {/* Service URL and Type */}
-            <div className="grid grid-2">
-              <div className="form-group">
-                <label className="form-label">Service URL *</label>
-                <input
-                  type="url"
-                  name="service_url"
-                  value={formData.service_url}
-                  onChange={handleInputChange}
-                  className="form-input"
-                  placeholder="https://api.example.com/auth"
-                  required
-                />
-                <small style={{ color: '#64748b' }}>
-                  Main endpoint URL for the service
-                </small>
-              </div>
-
-              <div className="form-group">
-                <label className="form-label">Service Type</label>
-                <select
-                  name="service_type"
-                  value={formData.service_type}
-                  onChange={handleInputChange}
-                  className="form-select"
-                >
-                  <option value="">Select service type</option>
-                  {serviceTypes.map(type => (
-                    <option key={type} value={type}>{type}</option>
-                  ))}
-                </select>
-              </div>
-            </div>
-
-            {/* Additional URLs */}
-            <div className="grid grid-2">
-              <div className="form-group">
-                <label className="form-label">Health Check URL</label>
-                <input
-                  type="url"
-                  name="health_check_url"
-                  value={formData.health_check_url}
-                  onChange={handleInputChange}
-                  className="form-input"
-                  placeholder="https://api.example.com/auth/health"
-                />
-                <small style={{ color: '#64748b' }}>
-                  URL for service health monitoring
-                </small>
-              </div>
-
-              <div className="form-group">
-                <label className="form-label">Documentation URL</label>
-                <input
-                  type="url"
-                  name="documentation_url"
-                  value={formData.documentation_url}
-                  onChange={handleInputChange}
-                  className="form-input"
-                  placeholder="https://docs.example.com/auth-api"
-                />
-                <small style={{ color: '#64748b' }}>
-                  URL to service documentation
-                </small>
-              </div>
-            </div>
-
-            <div className="form-group">
-              <label className="form-label">Description</label>
-              <textarea
-                name="notes"
-                value={formData.notes}
-                onChange={handleInputChange}
-                className="form-input form-textarea"
-                placeholder="Description of the service..."
-              />
-            </div>
-
-            {/* Extras Configuration */}
-            <div className="form-group">
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.25rem' }}>
-                <label className="form-label" style={{ marginBottom: 0 }}>Additional Metadata</label>
                 <button
                   type="button"
+                  onClick={() => removeExtraPair(idx)}
                   className="btn btn-secondary"
-                  style={{ fontSize: '0.75rem', padding: '0.25rem 0.5rem' }}
-                  onClick={extrasMode === 'fields' ? switchExtrasToJsonMode : switchExtrasToFieldsMode}
+                  style={{ padding: '0.5rem 0.75rem' }}
+                  aria-label="Remove this pair"
                 >
-                  {extrasMode === 'fields' ? 'Advanced (JSON)' : 'Simple fields'}
+                  <Trash2 size={16} />
                 </button>
               </div>
-
-              {extrasMode === 'fields' ? (
-                <>
-                  {extrasPairs.length === 0 ? (
-                    <small style={{ color: '#64748b', display: 'block', marginBottom: '0.5rem' }}>
-                      No additional metadata. Click "Add field" to add one.
-                    </small>
-                  ) : (
-                    extrasPairs.map((pair, idx) => (
-                      <div key={idx} style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
-                        <input
-                          type="text"
-                          value={pair.key}
-                          onChange={(e) => updateExtraPair(idx, 'key', e.target.value)}
-                          placeholder="Key"
-                          className="form-input"
-                          style={{ flex: 1 }}
-                        />
-                        <input
-                          type="text"
-                          value={pair.value}
-                          onChange={(e) => updateExtraPair(idx, 'value', e.target.value)}
-                          placeholder="Value"
-                          className="form-input"
-                          style={{ flex: 1 }}
-                        />
-                        <button
-                          type="button"
-                          onClick={() => removeExtraPair(idx)}
-                          className="btn btn-secondary"
-                          style={{ padding: '0.5rem' }}
-                          aria-label="Remove field"
-                        >
-                          <Trash2 size={14} />
-                        </button>
-                      </div>
-                    ))
-                  )}
-                  <button
-                    type="button"
-                    onClick={addExtraPair}
-                    className="btn btn-secondary"
-                    style={{ fontSize: '0.875rem' }}
-                  >
-                    <Plus size={14} />
-                    Add field
-                  </button>
-                  <small style={{ color: '#64748b', display: 'block', marginTop: '0.5rem' }}>
-                    Additional metadata as key/value pairs (version, environment, etc.).
-                  </small>
-                </>
-              ) : (
-                <>
-                  <textarea
-                    value={extrasJson}
-                    onChange={(e) => setExtrasJson(e.target.value)}
-                    className="form-input form-textarea"
-                    placeholder='{"version": "2.1.0", "environment": "production"}'
-                    style={{ fontFamily: 'monospace', fontSize: '0.875rem', minHeight: '120px' }}
-                  />
-                  <small style={{ color: '#64748b' }}>
-                    Additional metadata as JSON. Use this for nested or non-text values.
-                  </small>
-                </>
-              )}
-
-              {extrasModeError && (
-                <small style={{ color: '#dc2626', display: 'block', marginTop: '0.5rem' }}>
-                  {extrasModeError}
-                </small>
-              )}
-            </div>
-
-            {/* Submit Button */}
+            ))}
             <button
-              type="submit"
-              className="btn btn-primary"
-              disabled={loading}
+              type="button"
+              onClick={addExtraPair}
+              className="btn btn-secondary"
+              style={{ marginTop: '0.25rem' }}
             >
-              {loading ? (
+              <Plus size={16} />
+              Add field
+            </button>
+          </div>
+
+          <div style={{ display: 'flex', gap: '1rem' }}>
+            <button type="submit" className="btn btn-primary" disabled={submitting}>
+              {submitting ? (
                 <>
                   <div className="loading-spinner" />
-                  {editingService ? 'Updating...' : 'Registering...'}
+                  Registering
                 </>
               ) : (
-                <>
-                  <Save size={16} />
-                  {editingService ? 'Update Service' : 'Register Service'}
-                </>
+                'Register service'
               )}
             </button>
-          </form>
-        </div>
-      )}
-
-      {/* Services List */}
-      <div className="card">
-        <div className="card-header">
-          <h3 className="card-title">
-            Registered Services ({services.length})
-          </h3>
-        </div>
-
-        {loading && !showCreateForm ? (
-          <div style={{ textAlign: 'center', padding: '2rem' }}>
-            <div className="loading-spinner" style={{ margin: '0 auto' }}></div>
-            <p style={{ marginTop: '1rem' }}>Loading services...</p>
+            <button
+              type="button"
+              onClick={() => navigate('/')}
+              className="btn btn-secondary"
+              disabled={submitting}
+            >
+              Back to Search
+            </button>
           </div>
-        ) : services.length === 0 ? (
-          <div style={{ textAlign: 'center', padding: '2rem', color: '#64748b' }}>
-            <Server size={48} style={{ marginBottom: '1rem', opacity: 0.5 }} />
-            <p>No services registered</p>
-            <p>Register your first service using the form above</p>
-          </div>
-        ) : (
-          <div className="table-container">
-            <table className="table">
-              <thead>
-                <tr>
-                  <th>Service</th>
-                  <th>Type</th>
-                  <th>URL</th>
-                  <th>Documentation</th>
-                  <th>Health Status</th>
-                  <th>Resources</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {services.map((service, index) => {
-                  const serviceTypeBadge = getServiceTypeBadge(service);
-                  const serviceUrl = getMainServiceUrl(service);
-                  const documentationUrl = getDocumentationUrl(service);
-                  const healthStatus = getHealthStatus(service);
-
-                  return (
-                    <tr key={`${service.id}-${index}`}>
-                      <td>
-                        <div>
-                          <div style={{ fontWeight: '500', marginBottom: '0.25rem' }}>
-                            {service.title || service.name}
-                          </div>
-                          {service.title && service.name && service.title !== service.name && (
-                            <div style={{ fontSize: '0.875rem', color: '#64748b' }}>
-                              {service.name}
-                            </div>
-                          )}
-                          {service.notes && (
-                            <div style={{ 
-                              fontSize: '0.875rem', 
-                              color: '#64748b',
-                              marginTop: '0.25rem',
-                              maxWidth: '200px',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              whiteSpace: 'nowrap'
-                            }}>
-                              {service.notes}
-                            </div>
-                          )}
-                          <div style={{ 
-                            fontSize: '0.75rem', 
-                            color: '#94a3b8',
-                            marginTop: '0.25rem',
-                            fontFamily: 'monospace'
-                          }}>
-                            ID: {service.id}
-                          </div>
-                        </div>
-                      </td>
-                      <td>
-                        <span className={`status-indicator ${serviceTypeBadge.color}`}>
-                          {serviceTypeBadge.type}
-                        </span>
-                      </td>
-                      <td>
-                        {serviceUrl !== 'No URL' && service.name ? (
-                          <a
-                            href={`${BASE_URL}/services/redirect/${service.name}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            style={{
-                              color: '#2563eb',
-                              textDecoration: 'none',
-                              fontSize: '0.875rem',
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: '0.25rem',
-                              maxWidth: '200px',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              whiteSpace: 'nowrap'
-                            }}
-                            title={`Proxied through ${BASE_URL}/services/redirect/${service.name} → ${serviceUrl}`}
-                          >
-                            <ExternalLink size={12} />
-                            Access Service
-                          </a>
-                        ) : (
-                          <span style={{ color: '#94a3b8', fontSize: '0.875rem' }}>
-                            No URL
-                          </span>
-                        )}
-                      </td>
-                      <td>
-                        {documentationUrl ? (
-                          <a
-                            href={documentationUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            style={{
-                              color: '#2563eb',
-                              textDecoration: 'none',
-                              fontSize: '0.875rem',
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: '0.25rem',
-                              maxWidth: '200px',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              whiteSpace: 'nowrap'
-                            }}
-                            title={documentationUrl}
-                          >
-                            <FileText size={12} />
-                            View Docs
-                          </a>
-                        ) : (
-                          <span style={{ color: '#94a3b8', fontSize: '0.875rem' }}>
-                            No Docs
-                          </span>
-                        )}
-                      </td>
-                      <td>
-                        <span className={`status-indicator ${healthStatus.color}`}>
-                          {healthStatus.status}
-                        </span>
-                      </td>
-                      <td>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-                          <FileText size={14} />
-                          <span>{service.resources?.length || 0}</span>
-                        </div>
-                      </td>
-                      <td>
-                        <div style={{ display: 'flex', gap: '0.5rem' }}>
-                          <button
-                            onClick={() => startEditing(service)}
-                            className="btn btn-secondary"
-                            style={{ padding: '0.375rem 0.75rem' }}
-                            title="Edit service"
-                          >
-                            <Edit3 size={14} />
-                            <span style={{ fontSize: '0.75rem' }}>Edit</span>
-                          </button>
-                          <button
-                            onClick={() => handleDeleteService(service)}
-                            className="btn btn-danger"
-                            style={{ padding: '0.375rem 0.75rem' }}
-                            title="Delete service"
-                          >
-                            <Trash2 size={14} />
-                            <span style={{ fontSize: '0.75rem' }}>Delete</span>
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
+        </form>
       </div>
-
-
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Removed the "Services" entry from the top navigation; the "+ New" dropdown now hosts a "Service" item next to the existing "Organization" item.
- Simplified the `/services` page into a single-purpose "register a new service" form. Listing moved to Search a few releases back; deletion now happens on the service result cards (this PR). Edit is dropped from the page; we can revisit it as an action on Search cards if it becomes a real ask.
- Search service cards owned by the authenticated user now show a "Yours" badge and a "Delete" action. Clicking Delete opens an inline confirmation panel on the same card (no `window.confirm`, no full-screen modal). On success the card disappears immediately; on failure the user sees a friendly, actionable message instead of the raw backend string.
- Service deletion goes through the existing `resourcesAPI.deleteById` wrapper (`DELETE /resource?resource_id=...`), since services are CKAN packages under the `services` org. No new API surface.

## Backwards compatibility
- No public API contract changes. Service deletion reuses an endpoint already in use elsewhere in the UI.
- The `/services` UI route still exists and still creates services; the page only drops the listing/edit/delete features that became redundant once Search took over.
- Services registered before the creator-hash feature simply do not appear under "Only mine" and never expose a Delete action on Search; no migration is performed.
- No fields removed, no types changed, no required parameters added.

## Test plan
- [x] UI build: `react-scripts build` succeeds (-0.93 kB net vs 0.24.0 thanks to the simplified Services page).
- [x] End-to-end smoke test with `raul`/`raul`:
  - Create a service via `POST /services` → the catalog persists `extras.ndp_user_id = b752c92cf1a051d2` (raul's hash).
  - Search the service: card shows the "Yours" badge.
  - Delete the service via `DELETE /resource?resource_id=...&server=local` → `200`, card disappears, subsequent search returns 0.
  - Deleting a non-existent service surfaces the friendly "no longer exists" message.
- [x] UI smoke test (local container):
  - "+ New" dropdown shows "Organization" and "Service".
  - "Service" lands on the simplified registration form.
  - Created service appears in Search > Services with "Yours" + "Delete".
  - Inline confirm panel: Cancel restores the card; Delete removes it on success.

Closes #157.