### PR TITLE
Move Datasets into the + New menu and let owners delete and publish from Search (closes #159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-05-13
+
+### Added
+- Navigation: the "+ New" menu now hosts a "Dataset" entry between "Organization" and "Service", replacing the dedicated "Datasets" entry inside the "Resources" dropdown.
+- Search page: dataset result cards whose persisted creator hash matches the authenticated user now expose a "Yours" badge plus two inline actions:
+  - **Delete** — opens an inline confirmation panel on the same card; on success the card disappears immediately, on failure a friendly, actionable message is shown.
+  - **Publish** — only shown when the dataset has not yet been published (no `extras.status` on the dataset). Opens an inline confirmation panel; on success the card updates to reflect the new status (`submitted`) and the Publish button disappears, on failure a friendly message is shown.
+- A shared inline confirmation panel renders both delete and publish flows, with action-specific copy and palette (red for destructive, teal for publish) and a single processing/error path. Only one action can be pending per card at a time.
+
+### Changed
+- The Datasets page is now a single-purpose "register a new dataset" form, mirroring the simplified Organizations and Services creation pages. Listing moved to the Search page; deletion and publishing now happen on the dataset result cards (new in this release). Editing, tag/group/license/version inputs and the filter-by-organization controls are dropped from the page; we can revisit them as Search-card actions if it becomes a real ask. The route stays at `/datasets` so deep links keep working.
+- The "Datasets" entry has been removed from the "Resources" navigation dropdown; the page is now reached exclusively from "+ New > Dataset".
+
+### Backwards compatibility
+- No new public API surface. Dataset deletion goes through the existing `DELETE /resource?resource_id=...` endpoint (datasets are CKAN packages). Dataset publishing goes through the existing `POST /dataset/{id}/publish` endpoint, unchanged since 0.19.0.
+- The `/datasets` UI route still exists and still creates datasets; the page only drops the listing/edit/delete/publish features that became redundant once Search took over.
+- Datasets registered before the creator-hash feature do not appear under "Only mine" and never expose Delete or Publish actions on Search; no migration is performed.
+
 ## [0.25.0] - 2026-05-13
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.25.0"
+    swagger_version: str = "0.26.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/components/Navigation.js
+++ b/ui/src/components/Navigation.js
@@ -260,35 +260,6 @@ const Navigation = () => {
                     }}
                   >
                     <Link
-                      to="/datasets"
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '0.75rem',
-                        padding: '1rem 1.25rem',
-                        color: '#374151', // Always same color
-                        textDecoration: 'none',
-                        fontSize: '0.9rem',
-                        fontWeight: '500', // Always same weight
-                        backgroundColor: 'white',
-                        borderBottom: '1px solid #f3f4f6'
-                      }}
-                      onMouseOver={(e) => {
-                        e.target.style.backgroundColor = '#f9fafb';
-                        e.target.style.color = '#2563eb';
-                        e.target.style.fontWeight = '600';
-                      }}
-                      onMouseOut={(e) => {
-                        e.target.style.backgroundColor = 'white';
-                        e.target.style.color = '#374151';
-                        e.target.style.fontWeight = '500';
-                      }}
-                    >
-                      <FileText size={18} />
-                      <span>Datasets</span>
-                    </Link>
-
-                    <Link
                       to="/kafka-topics"
                       style={{
                         display: 'flex',
@@ -493,6 +464,35 @@ const Navigation = () => {
                     >
                       <Building2 size={18} />
                       <span>Organization</span>
+                    </Link>
+
+                    <Link
+                      to="/datasets"
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.75rem',
+                        padding: '1rem 1.25rem',
+                        color: '#374151',
+                        textDecoration: 'none',
+                        fontSize: '0.9rem',
+                        fontWeight: '500',
+                        backgroundColor: 'white',
+                        borderBottom: '1px solid #f3f4f6'
+                      }}
+                      onMouseOver={(e) => {
+                        e.target.style.backgroundColor = '#f9fafb';
+                        e.target.style.color = '#2563eb';
+                        e.target.style.fontWeight = '600';
+                      }}
+                      onMouseOut={(e) => {
+                        e.target.style.backgroundColor = 'white';
+                        e.target.style.color = '#374151';
+                        e.target.style.fontWeight = '500';
+                      }}
+                    >
+                      <FileText size={18} />
+                      <span>Dataset</span>
                     </Link>
 
                     <Link

--- a/ui/src/pages/DatasetManagement.js
+++ b/ui/src/pages/DatasetManagement.js
@@ -1,733 +1,182 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
-  Database,
-  Plus,
-  AlertCircle,
-  Edit3,
-  Save,
-  X,
   FileText,
-  Trash2,
-  ChevronDown,
-  ChevronRight,
-  ExternalLink,
-  Link,
-  Clock,
-  Home,
-  Send
+  AlertCircle,
+  CheckCircle,
+  Plus,
+  Trash2
 } from 'lucide-react';
-import { organizationsAPI, searchAPI, generalDatasetAPI, datasetAPI, resourcesAPI } from '../services/api';
-
-// Extract a human-readable message from an axios error so we never display
-// the meaningless string "[object Object]" when the backend returns a
-// structured detail payload (e.g. {"error": "...", "detail": "..."}).
-const formatApiError = (err) => {
-  const detail = err?.response?.data?.detail;
-  if (typeof detail === 'string') return detail;
-  if (detail && typeof detail === 'object') {
-    return detail.detail || detail.error || JSON.stringify(detail);
-  }
-  return err?.message || 'Unknown error';
-};
-
-// Map a dataset's extras.status to a small icon. The backend currently sets
-// extras.status="submitted" after a successful publish to PRE-CKAN; datasets
-// that have never been published have no status entry and are local-only.
-// Unknown values render a defensive AlertCircle so they are still visible.
-const renderDatasetStatusIcon = (status) => {
-  let Icon;
-  let color;
-  let label;
-  if (status === 'submitted') {
-    Icon = Clock;
-    color = '#f59e0b';
-    label = 'Submitted';
-  } else if (!status) {
-    Icon = Home;
-    color = '#94a3b8';
-    label = 'Local only';
-  } else {
-    Icon = AlertCircle;
-    color = '#64748b';
-    label = status;
-  }
-  return (
-    <span title={label} aria-label={`Status: ${label}`} style={{ display: 'inline-flex' }}>
-      <Icon size={16} color={color} />
-    </span>
-  );
-};
+import { useNavigate } from 'react-router-dom';
+import { generalDatasetAPI, organizationsAPI } from '../services/api';
 
 /**
- * Dataset Management component for creating and managing general datasets
- * Provides full CRUD operations for datasets with flexible schema
+ * Single-purpose page reached from the "+ New > Dataset" menu. Listing,
+ * editing, deletion and publishing live on the Search page now — this
+ * page only exposes the create form.
  */
 const DatasetManagement = () => {
-  const [datasets, setDatasets] = useState([]);
-  const [organizations, setOrganizations] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [success, setSuccess] = useState(null);
-  const [warning, setWarning] = useState(null);
-  const [showCreateForm, setShowCreateForm] = useState(false);
-  const [editingDataset, setEditingDataset] = useState(null);
-  const [selectedServer] = useState('local'); // Fixed to local for consistency
-  const [orgFilter, setOrgFilter] = useState('');
-  const [expandedDatasets, setExpandedDatasets] = useState({});
-  const [publishingIds, setPublishingIds] = useState({});
-  const [editingResource, setEditingResource] = useState(null);
-  const [resourceFormData, setResourceFormData] = useState({
-    name: '',
-    description: '',
-    url: '',
-    format: ''
-  });
-
-  // Form state for creating/editing dataset
+  const navigate = useNavigate();
   const [formData, setFormData] = useState({
     name: '',
     title: '',
     owner_org: '',
     notes: '',
-    extras: {},
-    resources: []
+    private: false
   });
-
-  // JSON editor states for complex fields
-  const [extrasJson, setExtrasJson] = useState('{}');
-  const [resourcesJson, setResourcesJson] = useState('[]');
-
-  // Extras editor: 'fields' for guided key/value rows, 'json' for raw JSON
-  const [extrasMode, setExtrasMode] = useState('fields');
+  const [resources, setResources] = useState([
+    { url: '', name: '', format: '', description: '' }
+  ]);
   const [extrasPairs, setExtrasPairs] = useState([]);
-  const [extrasModeError, setExtrasModeError] = useState(null);
+  const [organizations, setOrganizations] = useState([]);
+  const [orgsLoading, setOrgsLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(null);
 
-  /**
-   * True when value is a flat object whose values are all string/number/boolean/null.
-   * The guided key/value editor can only round-trip this shape; nested objects or
-   * arrays force the user into raw JSON mode.
-   */
-  const isFlatPrimitiveMap = (obj) => {
-    if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
-    return Object.values(obj).every((v) =>
-      v === null || ['string', 'number', 'boolean'].includes(typeof v)
-    );
-  };
+  useEffect(() => {
+    let cancelled = false;
+    organizationsAPI
+      .list({ server: 'local' })
+      .then((response) => {
+        if (cancelled) return;
+        const orgs = Array.isArray(response.data) ? response.data : [];
+        setOrganizations(orgs);
+        // Pre-select the first org so the user doesn't have to do it
+        // explicitly when there's only one realistic choice.
+        setFormData((prev) =>
+          prev.owner_org ? prev : { ...prev, owner_org: orgs[0] || '' }
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setOrganizations([]);
+      })
+      .finally(() => {
+        if (!cancelled) setOrgsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
-  const objectToPairs = (obj) => {
-    if (!obj || typeof obj !== 'object') return [];
-    return Object.entries(obj).map(([key, value]) => ({
-      key,
-      value: value === null || value === undefined ? '' : String(value)
+  const handleInputChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : value
     }));
   };
 
-  const pairsToObject = (pairs) => {
-    const out = {};
-    for (const { key, value } of pairs) {
-      const trimmed = (key || '').trim();
-      if (trimmed === '') continue;
-      out[trimmed] = value;
-    }
-    return out;
-  };
+  const updateResource = (idx, field, value) =>
+    setResources((prev) =>
+      prev.map((r, i) => (i === idx ? { ...r, [field]: value } : r))
+    );
 
-  const addExtraPair = () => {
+  const addResource = () =>
+    setResources((prev) => [
+      ...prev,
+      { url: '', name: '', format: '', description: '' }
+    ]);
+
+  const removeResource = (idx) =>
+    setResources((prev) => prev.filter((_, i) => i !== idx));
+
+  const addExtraPair = () =>
     setExtrasPairs((prev) => [...prev, { key: '', value: '' }]);
-    setExtrasModeError(null);
-  };
 
-  const removeExtraPair = (idx) => {
+  const removeExtraPair = (idx) =>
     setExtrasPairs((prev) => prev.filter((_, i) => i !== idx));
-  };
 
-  const updateExtraPair = (idx, field, value) => {
+  const updateExtraPair = (idx, field, value) =>
     setExtrasPairs((prev) =>
       prev.map((p, i) => (i === idx ? { ...p, [field]: value } : p))
     );
-  };
 
-  const switchToJsonMode = () => {
-    const obj = pairsToObject(extrasPairs);
-    setExtrasJson(JSON.stringify(obj, null, 2));
-    setExtrasMode('json');
-    setExtrasModeError(null);
-  };
-
-  const switchToFieldsMode = () => {
-    let parsed;
-    try {
-      parsed = extrasJson.trim() === '' ? {} : JSON.parse(extrasJson);
-    } catch {
-      setExtrasModeError('Cannot switch to simple fields: the JSON is invalid.');
-      return;
-    }
-    if (!isFlatPrimitiveMap(parsed)) {
-      setExtrasModeError(
-        'Cannot switch to simple fields: this metadata has nested or non-text values. Stay in advanced mode to edit it.'
-      );
-      return;
-    }
-    setExtrasPairs(objectToPairs(parsed));
-    setExtrasMode('fields');
-    setExtrasModeError(null);
-  };
-
-  // Resources editor: 'fields' for guided cards, 'json' for raw JSON array
-  const [resourcesMode, setResourcesMode] = useState('fields');
-  const [resourcesItems, setResourcesItems] = useState([]);
-  const [resourcesModeError, setResourcesModeError] = useState(null);
-
-  // The guided editor exposes the canonical resource fields. Anything else
-  // present on a loaded resource (mimetype, size, server-managed ids, …) is
-  // kept untouched in `_extra` so a fields-mode round-trip never drops data.
-  const SIMPLE_RESOURCE_FIELDS = ['name', 'url', 'format', 'description'];
-
-  const emptyResourceItem = () => ({
-    name: '',
-    url: '',
-    format: '',
-    description: '',
-    _extra: {}
-  });
-
-  const resourceToItem = (resource) => {
-    const item = emptyResourceItem();
-    if (!resource || typeof resource !== 'object') return item;
-    for (const [key, value] of Object.entries(resource)) {
-      if (SIMPLE_RESOURCE_FIELDS.includes(key)) {
-        item[key] = value === null || value === undefined ? '' : String(value);
-      } else {
-        item._extra[key] = value;
-      }
-    }
-    return item;
-  };
-
-  const itemToResource = (item) => {
-    const out = { ...(item._extra || {}) };
-    for (const f of SIMPLE_RESOURCE_FIELDS) {
-      if (item[f] !== undefined && item[f] !== null && item[f] !== '') {
-        out[f] = item[f];
-      }
+  const buildExtras = () => {
+    const out = {};
+    for (const { key, value } of extrasPairs) {
+      const trimmed = (key || '').trim();
+      if (trimmed) out[trimmed] = value;
     }
     return out;
   };
 
-  const resourcesToItems = (resources) => {
-    if (!Array.isArray(resources)) return [];
-    return resources.map(resourceToItem);
-  };
-
-  const itemsToResources = (items) =>
-    items.map(itemToResource).filter((r) => Object.keys(r).length > 0);
-
-  const addResourceItem = () => {
-    setResourcesItems((prev) => [...prev, emptyResourceItem()]);
-    setResourcesModeError(null);
-  };
-
-  const removeResourceItem = (idx) => {
-    setResourcesItems((prev) => prev.filter((_, i) => i !== idx));
-  };
-
-  const updateResourceItem = (idx, field, value) => {
-    setResourcesItems((prev) =>
-      prev.map((r, i) => (i === idx ? { ...r, [field]: value } : r))
-    );
-  };
-
-  const switchResourcesToJsonMode = () => {
-    const arr = itemsToResources(resourcesItems);
-    setResourcesJson(JSON.stringify(arr, null, 2));
-    setResourcesMode('json');
-    setResourcesModeError(null);
-  };
-
-  const switchResourcesToFieldsMode = () => {
-    let parsed;
-    try {
-      parsed = resourcesJson.trim() === '' ? [] : JSON.parse(resourcesJson);
-    } catch {
-      setResourcesModeError('Cannot switch to simple fields: the JSON is invalid.');
-      return;
+  const buildResources = () => {
+    const out = [];
+    for (const r of resources) {
+      const url = (r.url || '').trim();
+      const name = (r.name || '').trim();
+      if (!url || !name) continue;
+      const entry = { url, name };
+      if (r.format) entry.format = r.format;
+      if (r.description) entry.description = r.description;
+      out.push(entry);
     }
-    if (!Array.isArray(parsed)) {
-      setResourcesModeError(
-        'Cannot switch to simple fields: resources must be a JSON array.'
-      );
-      return;
-    }
-    if (!parsed.every((r) => r && typeof r === 'object' && !Array.isArray(r))) {
-      setResourcesModeError(
-        'Cannot switch to simple fields: every resource must be a JSON object.'
-      );
-      return;
-    }
-    setResourcesItems(resourcesToItems(parsed));
-    setResourcesMode('fields');
-    setResourcesModeError(null);
+    return out;
   };
 
-  /**
-   * Fetch organizations for dropdown
-   */
-  const fetchOrganizations = useCallback(async () => {
-    try {
-      const response = await organizationsAPI.list({ server: selectedServer });
-      setOrganizations(response.data || []);
-    } catch (err) {
-      console.error('Error fetching organizations:', err);
-    }
-  }, [selectedServer]);
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+    setSubmitting(true);
 
-  /**
-   * Fetch all datasets (filtered to show only general datasets)
-   */
-  const fetchDatasets = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      
-      // Use search to get all datasets
-      const response = await searchAPI.searchByTerms([''], null, selectedServer);
-      
-      // Filter out specific resource types to show only general datasets
-      const filteredDatasets = (response.data || []).filter(dataset => {
-        const extras = dataset.extras || {};
-        const resources = dataset.resources || [];
-        
-        // Exclude if it's a Kafka topic
-        if (extras.kafka_topic || extras.kafka_host) {
-          return false;
-        }
-        
-        // Exclude if it's in the services organization
-        if (dataset.owner_org === 'services') {
-          return false;
-        }
-        
-        // Exclude if it has S3 resources
-        if (resources.some(resource => 
-          resource.url && (
-            resource.url.startsWith('s3://') || 
-            resource.url.includes('s3.amazonaws.com') ||
-            resource.url.includes('.s3.')
-          )
-        )) {
-          return false;
-        }
-        
-        // Exclude if it's primarily a URL resource (single URL resource with no other content)
-        if (resources.length === 1 && 
-            resources[0].url && 
-            !resources[0].url.startsWith('s3://') &&
-            Object.keys(extras).length === 0 &&
-            (!dataset.notes || dataset.notes.trim() === '')) {
-          return false;
-        }
-        
-        // Include everything else (general datasets)
-        return true;
-      });
-      
-      setDatasets(filteredDatasets);
-      
-    } catch (err) {
-      console.error('Error fetching datasets:', err);
-      setError('Failed to load datasets: ' + 
-        (err.response?.data?.detail || err.message));
-    } finally {
-      setLoading(false);
-    }
-  }, [selectedServer]);
-
-  /**
-   * Fetch organizations and datasets on component mount
-   */
-  useEffect(() => {
-    fetchOrganizations();
-    fetchDatasets();
-  }, [fetchOrganizations, fetchDatasets]);
-
-  /**
-   * Handle form input changes
-   */
-  const handleInputChange = (e) => {
-    const { name, value } = e.target;
-    setFormData(prev => ({
-      ...prev,
-      [name]: value
-    }));
-  };
-
-  /**
-   * Parse JSON string safely
-   */
-  const parseJsonSafely = (jsonString, fallback = {}) => {
-    try {
-      return jsonString.trim() === '' ? fallback : JSON.parse(jsonString);
-    } catch {
-      return fallback;
-    }
-  };
-
-  /**
-   * Reset form to initial state
-   */
-  const resetForm = () => {
-    setFormData({
-      name: '',
-      title: '',
-      owner_org: '',
-      notes: '',
-      extras: {},
-      resources: []
-    });
-    setExtrasJson('{}');
-    setResourcesJson('[]');
-    setExtrasMode('fields');
-    setExtrasPairs([]);
-    setExtrasModeError(null);
-    setResourcesMode('fields');
-    setResourcesItems([]);
-    setResourcesModeError(null);
-    setEditingDataset(null);
-    setShowCreateForm(false);
-  };
-
-  /**
-   * Prepare form data for submission
-   */
-  const prepareFormData = () => {
-    // Parse JSON fields
-    const extras = extrasMode === 'fields'
-      ? pairsToObject(extrasPairs)
-      : parseJsonSafely(extrasJson, {});
-    const resources = resourcesMode === 'fields'
-      ? itemsToResources(resourcesItems)
-      : parseJsonSafely(resourcesJson, []);
-
-    // Prepare final data
-    const requestData = {
-      ...formData,
-      extras: Object.keys(extras).length > 0 ? extras : undefined,
-      resources: resources.length > 0 ? resources : undefined
+    const payload = {
+      name: formData.name,
+      title: formData.title,
+      owner_org: formData.owner_org,
+      private: Boolean(formData.private)
     };
-
-    // Remove empty fields
-    Object.keys(requestData).forEach(key => {
-      if (requestData[key] === '' || requestData[key] === undefined) {
-        delete requestData[key];
-      }
-    });
-
-    return requestData;
-  };
-
-  /**
-   * Handle form submission for creating dataset
-   */
-  const handleCreate = async (e) => {
-    e.preventDefault();
+    if (formData.notes) payload.notes = formData.notes;
+    const builtResources = buildResources();
+    if (builtResources.length > 0) payload.resources = builtResources;
+    const extras = buildExtras();
+    if (Object.keys(extras).length > 0) payload.extras = extras;
 
     try {
-      setError(null);
-      setSuccess(null);
-      setWarning(null);
-      setLoading(true);
-
-      const requestData = prepareFormData();
-      const response = await generalDatasetAPI.create(requestData, selectedServer);
-
-      const apiWarning = response?.data?.warning;
-      if (apiWarning) {
-        setWarning(`WARNING: ${apiWarning}`);
-      } else {
-        setSuccess('Dataset created successfully!');
-      }
-      resetForm();
-      fetchDatasets();
-
-    } catch (err) {
-      console.error('Error creating dataset:', err);
-      setError('Failed to create dataset: ' + formatApiError(err));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  /**
-   * Handle form submission for updating dataset
-   */
-  const handleUpdate = async (e) => {
-    e.preventDefault();
-    
-    try {
-      setError(null);
-      setSuccess(null);
-      setWarning(null);
-      setLoading(true);
-
-      const requestData = prepareFormData();
-      await generalDatasetAPI.partialUpdate(editingDataset.id, requestData, selectedServer);
-
-      setSuccess('Dataset updated successfully!');
-      resetForm();
-      fetchDatasets();
-      
-    } catch (err) {
-      console.error('Error updating dataset:', err);
-      setError('Failed to update dataset: ' + 
-        (err.response?.data?.detail || err.message));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  /**
-   * Start editing a dataset
-   */
-  const startEditing = (dataset) => {
-    setEditingDataset(dataset);
-    setFormData({
-      name: dataset.name || '',
-      title: dataset.title || '',
-      owner_org: dataset.owner_org || '',
-      notes: dataset.notes || '',
-      extras: dataset.extras || {},
-      resources: dataset.resources || []
-    });
-    
-    // Set JSON fields
-    const extras = dataset.extras || {};
-    const resources = dataset.resources || [];
-    setExtrasJson(JSON.stringify(extras, null, 2));
-    setResourcesJson(JSON.stringify(resources, null, 2));
-
-    // Default the extras editor to guided fields when the data is a flat
-    // primitive map; fall back to raw JSON for nested/non-text values.
-    if (isFlatPrimitiveMap(extras)) {
-      setExtrasPairs(objectToPairs(extras));
-      setExtrasMode('fields');
-    } else {
+      await generalDatasetAPI.create(payload, 'local');
+      setSuccess(
+        `Dataset "${formData.name}" registered. You can keep registering more or go back to Search.`
+      );
+      setFormData((prev) => ({
+        ...prev,
+        name: '',
+        title: '',
+        notes: '',
+        private: false
+        // keep owner_org selected so users registering several datasets
+        // in the same org don't have to re-pick it every time.
+      }));
+      setResources([{ url: '', name: '', format: '', description: '' }]);
       setExtrasPairs([]);
-      setExtrasMode('json');
-    }
-    setExtrasModeError(null);
-
-    // Resources always default to guided cards. Unknown fields are kept in
-    // each item's _extra bucket so they survive the round-trip.
-    setResourcesItems(resourcesToItems(resources));
-    setResourcesMode('fields');
-    setResourcesModeError(null);
-
-    setShowCreateForm(true);
-  };
-
-  /**
-   * Handle dataset deletion
-   */
-  const handlePublishDataset = async (dataset) => {
-    const displayName = dataset.title || dataset.name || 'Unnamed Dataset';
-
-    if (!window.confirm(
-      `Publish dataset "${displayName}" to PRE-CKAN?`
-    )) {
-      return;
-    }
-
-    try {
-      setError(null);
-      setSuccess(null);
-      setWarning(null);
-      setPublishingIds((prev) => ({ ...prev, [dataset.id]: true }));
-
-      const response = await generalDatasetAPI.publish(dataset.id);
-      const apiWarning = response?.data?.warning;
-
-      if (apiWarning) {
-        setWarning(`WARNING: ${apiWarning}`);
-      } else {
-        setSuccess(`Dataset "${displayName}" published successfully!`);
-      }
-
-      fetchDatasets();
     } catch (err) {
-      console.error('Error publishing dataset:', err);
-      setError(`Failed to publish dataset "${displayName}": ` + formatApiError(err));
+      const detail = err.response?.data?.detail;
+      const raw = typeof detail === 'string' ? detail : err.message;
+      const msg = raw || 'unknown error';
+      setError(
+        /already exists/i.test(msg)
+          ? `A dataset called "${formData.name}" already exists. Pick a different name.`
+          : /name/i.test(msg) && /(invalid|must contain|lowercase)/i.test(msg)
+            ? 'The dataset name is invalid. Use lowercase letters, numbers, underscores and hyphens (no spaces).'
+            : `Could not register the dataset: ${msg}.`
+      );
     } finally {
-      setPublishingIds((prev) => {
-        const next = { ...prev };
-        delete next[dataset.id];
-        return next;
-      });
-    }
-  };
-
-  const handleDeleteDataset = async (dataset) => {
-    const displayName = dataset.title || dataset.name || 'Unnamed Dataset';
-    
-    if (!window.confirm(
-      `Are you sure you want to delete dataset "${displayName}"? This will also delete all associated resources. This action cannot be undone.`
-    )) {
-      return;
-    }
-
-    try {
-      setError(null);
-      setSuccess(null);
-      setWarning(null);
-
-      // Debug: Log the dataset being deleted
-      console.log('Attempting to delete dataset with ID:', dataset.id);
-      console.log('Using endpoint: DELETE /resource?resource_id=' + dataset.id + '&server=local');
-      
-      // Use the resource deletion endpoint since datasets are resources in CKAN
-      await datasetAPI.delete(dataset.id, 'local'); // Always use local for deletion
-      
-      setSuccess(`Dataset "${displayName}" deleted successfully!`);
-      
-      // Refresh the datasets list
-      fetchDatasets();
-      
-    } catch (err) {
-      console.error('Error deleting dataset:', err);
-      console.error('Full error object:', err);
-      console.error('Error response:', err.response);
-      
-      let errorMessage = 'Failed to delete dataset: ';
-      
-      if (err.response?.status === 404) {
-        errorMessage += `Dataset "${displayName}" not found. It may have been already deleted.`;
-      } else if (err.response?.status === 405) {
-        errorMessage += 'Dataset deletion method not allowed.';
-      } else if (err.response?.status === 401) {
-        errorMessage += 'Authentication required. Please login again.';
-      } else if (err.response?.status === 403) {
-        errorMessage += 'You do not have permission to delete this dataset.';
-      } else {
-        errorMessage += (err.response?.data?.detail || err.message);
-      }
-      
-      setError(errorMessage);
-    }
-  };
-
-  /**
-   * Toggle dataset expansion to show/hide resources
-   */
-  const toggleDatasetExpansion = (datasetId) => {
-    setExpandedDatasets(prev => ({
-      ...prev,
-      [datasetId]: !prev[datasetId]
-    }));
-  };
-
-  /**
-   * Start editing a resource
-   */
-  const startEditingResource = (resource, datasetId) => {
-    setEditingResource({ ...resource, datasetId });
-    setResourceFormData({
-      name: resource.name || '',
-      description: resource.description || '',
-      url: resource.url || '',
-      format: resource.format || ''
-    });
-  };
-
-  /**
-   * Cancel resource editing
-   */
-  const cancelResourceEdit = () => {
-    setEditingResource(null);
-    setResourceFormData({
-      name: '',
-      description: '',
-      url: '',
-      format: ''
-    });
-  };
-
-  /**
-   * Handle resource form input changes
-   */
-  const handleResourceInputChange = (e) => {
-    const { name, value } = e.target;
-    setResourceFormData(prev => ({
-      ...prev,
-      [name]: value
-    }));
-  };
-
-  /**
-   * Save resource changes
-   */
-  const handleSaveResource = async () => {
-    if (!editingResource) return;
-
-    try {
-      setError(null);
-      setSuccess(null);
-      setWarning(null);
-
-      await resourcesAPI.patch(editingResource.id, resourceFormData, selectedServer);
-
-      setSuccess(`Resource "${resourceFormData.name}" updated successfully!`);
-      cancelResourceEdit();
-      fetchDatasets();
-
-    } catch (err) {
-      console.error('Error updating resource:', err);
-      setError('Failed to update resource: ' +
-        (err.response?.data?.detail || err.message));
-    }
-  };
-
-  /**
-   * Delete a resource
-   */
-  const handleDeleteResource = async (resource) => {
-    const displayName = resource.name || 'Unnamed Resource';
-
-    if (!window.confirm(
-      `Are you sure you want to delete resource "${displayName}"? This action cannot be undone.`
-    )) {
-      return;
-    }
-
-    try {
-      setError(null);
-      setSuccess(null);
-      setWarning(null);
-
-      await resourcesAPI.deleteById(resource.id, selectedServer);
-
-      setSuccess(`Resource "${displayName}" deleted successfully!`);
-      fetchDatasets();
-
-    } catch (err) {
-      console.error('Error deleting resource:', err);
-      setError('Failed to delete resource: ' +
-        (err.response?.data?.detail || err.message));
+      setSubmitting(false);
     }
   };
 
   return (
-    <div className="dataset-management-page">
-      {/* Page Header */}
+    <div style={{ maxWidth: '760px', margin: '0 auto', padding: '0 1rem' }}>
       <div className="page-header">
         <h1 className="page-title">
-          <Database size={32} style={{ marginRight: '0.5rem' }} />
-          Dataset Management
+          <FileText size={32} style={{ marginRight: '0.5rem' }} />
+          New dataset
         </h1>
         <p className="page-subtitle">
-          Create and manage general datasets (excludes URL, S3, Kafka, and Service resources)
+          Register a new dataset on the local catalog. Once created, you
+          can find it (and remove or publish it) from the Search page.
         </p>
       </div>
 
-      {/* Alert Messages */}
       {error && (
         <div className="alert alert-error">
           <AlertCircle size={20} />
@@ -737,92 +186,56 @@ const DatasetManagement = () => {
 
       {success && (
         <div className="alert alert-success">
+          <CheckCircle size={20} />
           {success}
         </div>
       )}
 
-      {warning && (
-        <div className="alert alert-warning">
-          <AlertCircle size={20} />
-          {warning}
-        </div>
-      )}
-
-      {/* Create dataset button */}
-      {!showCreateForm && (
-        <div style={{ marginBottom: '1rem' }}>
-          <button
-            onClick={() => setShowCreateForm(true)}
-            className="btn btn-primary"
-          >
-            <Plus size={16} />
-            Create Dataset
-          </button>
-        </div>
-      )}
-
-      {/* Create/Edit Dataset Form */}
-      {showCreateForm && (
-        <div className="card">
-          <div className="card-header">
-            <h3 className="card-title">
-              {editingDataset ? (
-                <>
-                  <Edit3 size={20} />
-                  Edit Dataset: {editingDataset.title}
-                </>
-              ) : (
-                <>
-                  <Plus size={20} />
-                  Create New Dataset
-                </>
-              )}
-            </h3>
-            <button
-              onClick={resetForm}
-              className="btn btn-secondary"
-            >
-              <X size={16} />
-              Cancel
-            </button>
+      <div className="card">
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label className="form-label">Name *</label>
+            <input
+              type="text"
+              name="name"
+              value={formData.name}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="my-dataset"
+              required
+            />
+            <small style={{ color: '#64748b' }}>
+              Unique identifier — lowercase letters, numbers, underscores
+              and hyphens only.
+            </small>
           </div>
 
-          <form onSubmit={editingDataset ? handleUpdate : handleCreate}>
-            {/* Basic Information */}
-            <div className="grid grid-2">
-              <div className="form-group">
-                <label className="form-label">Dataset Name *</label>
-                <input
-                  type="text"
-                  name="name"
-                  value={formData.name}
-                  onChange={handleInputChange}
-                  className="form-input"
-                  placeholder="my_dataset_name"
-                  required
-                  disabled={editingDataset} // Cannot change name when editing
-                />
-                <small style={{ color: '#64748b' }}>
-                  Unique identifier (lowercase, no spaces)
-                </small>
-              </div>
+          <div className="form-group">
+            <label className="form-label">Title *</label>
+            <input
+              type="text"
+              name="title"
+              value={formData.title}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="My Dataset"
+              required
+            />
+          </div>
 
-              <div className="form-group">
-                <label className="form-label">Dataset Title *</label>
-                <input
-                  type="text"
-                  name="title"
-                  value={formData.title}
-                  onChange={handleInputChange}
-                  className="form-input"
-                  placeholder="My Dataset Title"
-                  required
-                />
+          <div className="form-group">
+            <label className="form-label">Organization *</label>
+            {orgsLoading ? (
+              <div style={{ color: '#64748b', fontSize: '0.9rem' }}>
+                Loading organizations…
               </div>
-            </div>
-
-            <div className="form-group">
-              <label className="form-label">Organization *</label>
+            ) : organizations.length === 0 ? (
+              <div style={{ color: '#7f1d1d', fontSize: '0.9rem' }}>
+                No organizations are available on the local catalog yet.
+                Create one from "+ New → Organization" before registering
+                a dataset.
+              </div>
+            ) : (
               <select
                 name="owner_org"
                 value={formData.owner_org}
@@ -830,611 +243,202 @@ const DatasetManagement = () => {
                 className="form-select"
                 required
               >
-                <option value="">Select an organization</option>
-                {organizations.map(org => (
-                  <option key={org} value={org}>{org}</option>
+                <option value="" disabled>
+                  Choose an organization…
+                </option>
+                {organizations.map((org) => (
+                  <option key={org} value={org}>
+                    {org}
+                  </option>
                 ))}
               </select>
-            </div>
-
-            <div className="form-group">
-              <label className="form-label">Description</label>
-              <textarea
-                name="notes"
-                value={formData.notes}
-                onChange={handleInputChange}
-                className="form-input form-textarea"
-                placeholder="Description of the dataset..."
-              />
-            </div>
-
-            {/* Advanced Configuration */}
-            <div className="grid grid-2">
-              <div className="form-group">
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.25rem' }}>
-                  <label className="form-label" style={{ marginBottom: 0 }}>Extras</label>
-                  <button
-                    type="button"
-                    className="btn btn-secondary"
-                    style={{ fontSize: '0.75rem', padding: '0.25rem 0.5rem' }}
-                    onClick={extrasMode === 'fields' ? switchToJsonMode : switchToFieldsMode}
-                  >
-                    {extrasMode === 'fields' ? 'Advanced (JSON)' : 'Simple fields'}
-                  </button>
-                </div>
-
-                {extrasMode === 'fields' ? (
-                  <>
-                    {extrasPairs.length === 0 ? (
-                      <small style={{ color: '#64748b', display: 'block', marginBottom: '0.5rem' }}>
-                        No extra metadata. Click "Add field" to add one.
-                      </small>
-                    ) : (
-                      extrasPairs.map((pair, idx) => (
-                        <div key={idx} style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
-                          <input
-                            type="text"
-                            value={pair.key}
-                            onChange={(e) => updateExtraPair(idx, 'key', e.target.value)}
-                            placeholder="Key"
-                            className="form-input"
-                            style={{ flex: 1 }}
-                          />
-                          <input
-                            type="text"
-                            value={pair.value}
-                            onChange={(e) => updateExtraPair(idx, 'value', e.target.value)}
-                            placeholder="Value"
-                            className="form-input"
-                            style={{ flex: 1 }}
-                          />
-                          <button
-                            type="button"
-                            onClick={() => removeExtraPair(idx)}
-                            className="btn btn-secondary"
-                            style={{ padding: '0.5rem' }}
-                            aria-label="Remove field"
-                          >
-                            <Trash2 size={14} />
-                          </button>
-                        </div>
-                      ))
-                    )}
-                    <button
-                      type="button"
-                      onClick={addExtraPair}
-                      className="btn btn-secondary"
-                      style={{ fontSize: '0.875rem' }}
-                    >
-                      <Plus size={14} />
-                      Add field
-                    </button>
-                    <small style={{ color: '#64748b', display: 'block', marginTop: '0.5rem' }}>
-                      Additional metadata as key/value pairs.
-                    </small>
-                  </>
-                ) : (
-                  <>
-                    <textarea
-                      value={extrasJson}
-                      onChange={(e) => setExtrasJson(e.target.value)}
-                      className="form-input form-textarea"
-                      placeholder='{"version": "1.0", "project": "research"}'
-                      style={{ fontFamily: 'monospace', fontSize: '0.875rem', minHeight: '120px' }}
-                    />
-                    <small style={{ color: '#64748b' }}>
-                      Additional metadata as JSON. Use this for nested or non-text values.
-                    </small>
-                  </>
-                )}
-
-                {extrasModeError && (
-                  <small style={{ color: '#dc2626', display: 'block', marginTop: '0.5rem' }}>
-                    {extrasModeError}
-                  </small>
-                )}
-              </div>
-
-              <div className="form-group">
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.25rem' }}>
-                  <label className="form-label" style={{ marginBottom: 0 }}>Resources</label>
-                  <button
-                    type="button"
-                    className="btn btn-secondary"
-                    style={{ fontSize: '0.75rem', padding: '0.25rem 0.5rem' }}
-                    onClick={resourcesMode === 'fields' ? switchResourcesToJsonMode : switchResourcesToFieldsMode}
-                  >
-                    {resourcesMode === 'fields' ? 'Advanced (JSON)' : 'Simple fields'}
-                  </button>
-                </div>
-
-                {resourcesMode === 'fields' ? (
-                  <>
-                    {resourcesItems.length === 0 ? (
-                      <small style={{ color: '#64748b', display: 'block', marginBottom: '0.5rem' }}>
-                        No resources. Click "Add resource" to attach one.
-                      </small>
-                    ) : (
-                      resourcesItems.map((item, idx) => (
-                        <div
-                          key={idx}
-                          style={{
-                            border: '1px solid #e2e8f0',
-                            borderRadius: '6px',
-                            padding: '0.75rem',
-                            marginBottom: '0.5rem',
-                            background: '#f8fafc'
-                          }}
-                        >
-                          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
-                            <small style={{ color: '#64748b', fontWeight: 500 }}>
-                              Resource {idx + 1}
-                            </small>
-                            <button
-                              type="button"
-                              onClick={() => removeResourceItem(idx)}
-                              className="btn btn-secondary"
-                              style={{ padding: '0.25rem 0.5rem', fontSize: '0.75rem' }}
-                              aria-label="Remove resource"
-                            >
-                              <Trash2 size={12} />
-                              Remove
-                            </button>
-                          </div>
-
-                          <div className="form-group" style={{ marginBottom: '0.5rem' }}>
-                            <label className="form-label" style={{ fontSize: '0.8rem' }}>URL *</label>
-                            <input
-                              type="text"
-                              value={item.url}
-                              onChange={(e) => updateResourceItem(idx, 'url', e.target.value)}
-                              className="form-input"
-                              placeholder="http://example.com/data.csv"
-                              style={{ padding: '0.5rem' }}
-                            />
-                          </div>
-
-                          <div className="grid grid-2" style={{ marginBottom: '0.5rem' }}>
-                            <div className="form-group" style={{ marginBottom: 0 }}>
-                              <label className="form-label" style={{ fontSize: '0.8rem' }}>Name *</label>
-                              <input
-                                type="text"
-                                value={item.name}
-                                onChange={(e) => updateResourceItem(idx, 'name', e.target.value)}
-                                className="form-input"
-                                placeholder="main_data"
-                                style={{ padding: '0.5rem' }}
-                              />
-                            </div>
-                            <div className="form-group" style={{ marginBottom: 0 }}>
-                              <label className="form-label" style={{ fontSize: '0.8rem' }}>Format</label>
-                              <input
-                                type="text"
-                                value={item.format}
-                                onChange={(e) => updateResourceItem(idx, 'format', e.target.value)}
-                                className="form-input"
-                                placeholder="CSV"
-                                style={{ padding: '0.5rem' }}
-                              />
-                            </div>
-                          </div>
-
-                          <div className="form-group" style={{ marginBottom: 0 }}>
-                            <label className="form-label" style={{ fontSize: '0.8rem' }}>Description</label>
-                            <textarea
-                              value={item.description}
-                              onChange={(e) => updateResourceItem(idx, 'description', e.target.value)}
-                              className="form-input"
-                              placeholder="What is in this resource"
-                              style={{ padding: '0.5rem', minHeight: '50px' }}
-                            />
-                          </div>
-                        </div>
-                      ))
-                    )}
-                    <button
-                      type="button"
-                      onClick={addResourceItem}
-                      className="btn btn-secondary"
-                      style={{ fontSize: '0.875rem' }}
-                    >
-                      <Plus size={14} />
-                      Add resource
-                    </button>
-                    <small style={{ color: '#64748b', display: 'block', marginTop: '0.5rem' }}>
-                      Each resource is a downloadable file or link attached to the dataset.
-                    </small>
-                  </>
-                ) : (
-                  <>
-                    <textarea
-                      value={resourcesJson}
-                      onChange={(e) => setResourcesJson(e.target.value)}
-                      className="form-input form-textarea"
-                      placeholder='[{"url": "http://example.com/data.csv", "name": "main_data", "format": "CSV"}]'
-                      style={{ fontFamily: 'monospace', fontSize: '0.875rem', minHeight: '120px' }}
-                    />
-                    <small style={{ color: '#64748b' }}>
-                      List of resources as JSON array. Use this to set fields the simple editor does not expose (mimetype, size, …).
-                    </small>
-                  </>
-                )}
-
-                {resourcesModeError && (
-                  <small style={{ color: '#dc2626', display: 'block', marginTop: '0.5rem' }}>
-                    {resourcesModeError}
-                  </small>
-                )}
-              </div>
-            </div>
-
-            {/* Submit Button */}
-            <button 
-              type="submit" 
-              className="btn btn-primary"
-              disabled={loading}
-            >
-              {loading ? (
-                <>
-                  <div className="loading-spinner" />
-                  {editingDataset ? 'Updating...' : 'Creating...'}
-                </>
-              ) : (
-                <>
-                  <Save size={16} />
-                  {editingDataset ? 'Update Dataset' : 'Create Dataset'}
-                </>
-              )}
-            </button>
-          </form>
-        </div>
-      )}
-
-      {/* Datasets List */}
-      {(() => {
-        const filteredDatasets = orgFilter
-          ? datasets.filter((d) => d.owner_org === orgFilter)
-          : datasets;
-        return (
-      <div className="card">
-        <div className="card-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-          <h3 className="card-title" style={{ margin: 0 }}>
-            Datasets ({filteredDatasets.length}{orgFilter ? ` of ${datasets.length}` : ''})
-          </h3>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <label htmlFor="org-filter" style={{ fontSize: '0.875rem', color: '#64748b' }}>
-              Organization:
-            </label>
-            <select
-              id="org-filter"
-              value={orgFilter}
-              onChange={(e) => setOrgFilter(e.target.value)}
-              className="form-input"
-              style={{ minWidth: '200px', padding: '0.375rem 0.5rem' }}
-            >
-              <option value="">All organizations</option>
-              {organizations.map((org) => (
-                <option key={org} value={org}>{org}</option>
-              ))}
-            </select>
-          </div>
-        </div>
-
-        {loading && !showCreateForm ? (
-          <div style={{ textAlign: 'center', padding: '2rem' }}>
-            <div className="loading-spinner" style={{ margin: '0 auto' }}></div>
-            <p style={{ marginTop: '1rem' }}>Loading datasets...</p>
-          </div>
-        ) : filteredDatasets.length === 0 ? (
-          <div style={{ textAlign: 'center', padding: '2rem', color: '#64748b' }}>
-            <Database size={48} style={{ marginBottom: '1rem', opacity: 0.5 }} />
-            {orgFilter ? (
-              <>
-                <p>No datasets found for organization "{orgFilter}"</p>
-                <p>Try selecting a different organization or "All organizations" to see the full list.</p>
-              </>
-            ) : (
-              <>
-                <p>No general datasets found</p>
-                <p>Create your first general dataset using the form above, or check other pages for specific resource types (URL, S3, Kafka, Services)</p>
-              </>
             )}
           </div>
-        ) : (
-          <div className="table-container">
-            <table className="table">
-              <thead>
-                <tr>
-                  <th>Dataset</th>
-                  <th>Organization</th>
-                  <th>Status</th>
-                  <th>Resources</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredDatasets.map((dataset, index) => {
-                  const isExpanded = expandedDatasets[dataset.id];
-                  const hasResources = dataset.resources && dataset.resources.length > 0;
 
-                  return (
-                    <React.Fragment key={`${dataset.id}-${index}`}>
-                      <tr style={{ cursor: hasResources ? 'pointer' : 'default' }}>
-                        <td onClick={() => hasResources && toggleDatasetExpansion(dataset.id)}>
-                          <div style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem' }}>
-                            {hasResources && (
-                              <span style={{ marginTop: '0.125rem', color: '#64748b' }}>
-                                {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-                              </span>
-                            )}
-                            <div>
-                              <div style={{ fontWeight: '500', marginBottom: '0.25rem' }}>
-                                {dataset.title || dataset.name}
-                              </div>
-                              {dataset.title && dataset.name && dataset.title !== dataset.name && (
-                                <div style={{ fontSize: '0.875rem', color: '#64748b' }}>
-                                  {dataset.name}
-                                </div>
-                              )}
-                              {dataset.notes && (
-                                <div style={{
-                                  fontSize: '0.875rem',
-                                  color: '#64748b',
-                                  marginTop: '0.25rem',
-                                  maxWidth: '300px',
-                                  overflow: 'hidden',
-                                  textOverflow: 'ellipsis',
-                                  whiteSpace: 'nowrap'
-                                }}>
-                                  {dataset.notes}
-                                </div>
-                              )}
-                              <div style={{
-                                fontSize: '0.75rem',
-                                color: '#94a3b8',
-                                marginTop: '0.25rem',
-                                fontFamily: 'monospace'
-                              }}>
-                                ID: {dataset.id}
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                        <td>
-                          <span className="status-indicator status-success">
-                            {dataset.owner_org || 'No organization'}
-                          </span>
-                        </td>
-                        <td>
-                          {renderDatasetStatusIcon(dataset.extras?.status)}
-                        </td>
-                        <td>
-                          <button
-                            onClick={() => hasResources && toggleDatasetExpansion(dataset.id)}
-                            style={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: '0.25rem',
-                              background: 'none',
-                              border: 'none',
-                              cursor: hasResources ? 'pointer' : 'default',
-                              color: hasResources ? '#2563eb' : '#64748b',
-                              padding: '0.25rem 0.5rem',
-                              borderRadius: '4px'
-                            }}
-                            title={hasResources ? 'Click to expand resources' : 'No resources'}
-                          >
-                            <FileText size={14} />
-                            <span>{dataset.resources?.length || 0}</span>
-                          </button>
-                        </td>
-                        <td>
-                          <div style={{ display: 'flex', gap: '0.5rem' }}>
-                            {dataset.extras?.status !== 'submitted' && (
-                              <button
-                                onClick={() => handlePublishDataset(dataset)}
-                                className="btn btn-primary"
-                                style={{ padding: '0.375rem 0.75rem' }}
-                                title="Publish dataset to PRE-CKAN"
-                                disabled={!!publishingIds[dataset.id]}
-                              >
-                                <Send size={14} />
-                                <span style={{ fontSize: '0.75rem' }}>
-                                  {publishingIds[dataset.id] ? 'Publishing…' : 'Publish'}
-                                </span>
-                              </button>
-                            )}
-
-                            <button
-                              onClick={() => startEditing(dataset)}
-                              className="btn btn-secondary"
-                              style={{ padding: '0.375rem 0.75rem' }}
-                              title="Edit dataset"
-                            >
-                              <Edit3 size={14} />
-                              <span style={{ fontSize: '0.75rem' }}>Edit</span>
-                            </button>
-
-                            <button
-                              onClick={() => handleDeleteDataset(dataset)}
-                              className="btn btn-danger"
-                              style={{ padding: '0.375rem 0.75rem' }}
-                              title="Delete dataset"
-                            >
-                              <Trash2 size={14} />
-                              <span style={{ fontSize: '0.75rem' }}>Delete</span>
-                            </button>
-                          </div>
-                        </td>
-                      </tr>
-
-                      {/* Expanded Resources Row */}
-                      {isExpanded && hasResources && (
-                        <tr>
-                          <td colSpan="5" style={{ backgroundColor: '#f8fafc', padding: '1rem' }}>
-                            <div style={{ marginLeft: '1.5rem' }}>
-                              <h4 style={{ marginBottom: '0.75rem', color: '#374151', fontSize: '0.9rem' }}>
-                                Resources ({dataset.resources.length})
-                              </h4>
-                              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-                                {dataset.resources.map((resource, resIndex) => (
-                                  <div
-                                    key={resource.id || resIndex}
-                                    style={{
-                                      backgroundColor: 'white',
-                                      border: '1px solid #e2e8f0',
-                                      borderRadius: '8px',
-                                      padding: '1rem'
-                                    }}
-                                  >
-                                    {editingResource && editingResource.id === resource.id ? (
-                                      /* Resource Edit Form */
-                                      <div>
-                                        <div className="grid grid-2" style={{ marginBottom: '0.75rem' }}>
-                                          <div className="form-group" style={{ marginBottom: '0.5rem' }}>
-                                            <label className="form-label" style={{ fontSize: '0.8rem' }}>Name</label>
-                                            <input
-                                              type="text"
-                                              name="name"
-                                              value={resourceFormData.name}
-                                              onChange={handleResourceInputChange}
-                                              className="form-input"
-                                              style={{ padding: '0.5rem' }}
-                                            />
-                                          </div>
-                                          <div className="form-group" style={{ marginBottom: '0.5rem' }}>
-                                            <label className="form-label" style={{ fontSize: '0.8rem' }}>Format</label>
-                                            <input
-                                              type="text"
-                                              name="format"
-                                              value={resourceFormData.format}
-                                              onChange={handleResourceInputChange}
-                                              className="form-input"
-                                              style={{ padding: '0.5rem' }}
-                                            />
-                                          </div>
-                                        </div>
-                                        <div className="form-group" style={{ marginBottom: '0.5rem' }}>
-                                          <label className="form-label" style={{ fontSize: '0.8rem' }}>URL</label>
-                                          <input
-                                            type="text"
-                                            name="url"
-                                            value={resourceFormData.url}
-                                            onChange={handleResourceInputChange}
-                                            className="form-input"
-                                            style={{ padding: '0.5rem' }}
-                                          />
-                                        </div>
-                                        <div className="form-group" style={{ marginBottom: '0.75rem' }}>
-                                          <label className="form-label" style={{ fontSize: '0.8rem' }}>Description</label>
-                                          <textarea
-                                            name="description"
-                                            value={resourceFormData.description}
-                                            onChange={handleResourceInputChange}
-                                            className="form-input"
-                                            style={{ padding: '0.5rem', minHeight: '60px' }}
-                                          />
-                                        </div>
-                                        <div style={{ display: 'flex', gap: '0.5rem' }}>
-                                          <button
-                                            onClick={handleSaveResource}
-                                            className="btn btn-primary"
-                                            style={{ padding: '0.375rem 0.75rem' }}
-                                          >
-                                            <Save size={14} />
-                                            <span style={{ fontSize: '0.75rem' }}>Save</span>
-                                          </button>
-                                          <button
-                                            onClick={cancelResourceEdit}
-                                            className="btn btn-secondary"
-                                            style={{ padding: '0.375rem 0.75rem' }}
-                                          >
-                                            <X size={14} />
-                                            <span style={{ fontSize: '0.75rem' }}>Cancel</span>
-                                          </button>
-                                        </div>
-                                      </div>
-                                    ) : (
-                                      /* Resource Display */
-                                      <div>
-                                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-                                          <div style={{ flex: 1 }}>
-                                            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.25rem' }}>
-                                              <Link size={14} style={{ color: '#64748b' }} />
-                                              <span style={{ fontWeight: '500' }}>{resource.name || 'Unnamed Resource'}</span>
-                                              {resource.format && (
-                                                <span className="status-indicator status-info" style={{ fontSize: '0.7rem', padding: '0.125rem 0.375rem' }}>
-                                                  {resource.format}
-                                                </span>
-                                              )}
-                                            </div>
-                                            {resource.description && (
-                                              <p style={{ fontSize: '0.875rem', color: '#64748b', margin: '0.25rem 0' }}>
-                                                {resource.description}
-                                              </p>
-                                            )}
-                                            {resource.url && (
-                                              <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.5rem' }}>
-                                                <a
-                                                  href={resource.url}
-                                                  target="_blank"
-                                                  rel="noopener noreferrer"
-                                                  style={{
-                                                    fontSize: '0.8rem',
-                                                    color: '#2563eb',
-                                                    textDecoration: 'none',
-                                                    display: 'flex',
-                                                    alignItems: 'center',
-                                                    gap: '0.25rem'
-                                                  }}
-                                                >
-                                                  <ExternalLink size={12} />
-                                                  {resource.url.length > 60 ? resource.url.substring(0, 60) + '...' : resource.url}
-                                                </a>
-                                              </div>
-                                            )}
-                                            <div style={{ fontSize: '0.7rem', color: '#94a3b8', marginTop: '0.25rem', fontFamily: 'monospace' }}>
-                                              ID: {resource.id}
-                                            </div>
-                                          </div>
-                                          <div style={{ display: 'flex', gap: '0.5rem' }}>
-                                            <button
-                                              onClick={() => startEditingResource(resource, dataset.id)}
-                                              className="btn btn-secondary"
-                                              style={{ padding: '0.25rem 0.5rem' }}
-                                              title="Edit resource"
-                                            >
-                                              <Edit3 size={12} />
-                                            </button>
-                                            <button
-                                              onClick={() => handleDeleteResource(resource)}
-                                              className="btn btn-danger"
-                                              style={{ padding: '0.25rem 0.5rem' }}
-                                              title="Delete resource"
-                                            >
-                                              <Trash2 size={12} />
-                                            </button>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    )}
-                                  </div>
-                                ))}
-                              </div>
-                            </div>
-                          </td>
-                        </tr>
-                      )}
-                    </React.Fragment>
-                  );
-                })}
-              </tbody>
-            </table>
+          <div className="form-group">
+            <label className="form-label">Description</label>
+            <textarea
+              name="notes"
+              value={formData.notes}
+              onChange={handleInputChange}
+              className="form-input form-textarea"
+              placeholder="What does this dataset contain?"
+            />
           </div>
-        )}
+
+          <div className="form-group">
+            <label
+              className="form-label"
+              style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem' }}
+            >
+              <input
+                type="checkbox"
+                name="private"
+                checked={formData.private}
+                onChange={handleInputChange}
+                style={{ accentColor: '#2563eb' }}
+              />
+              Private dataset
+            </label>
+            <small style={{ color: '#64748b', display: 'block', marginTop: '0.25rem' }}>
+              Private datasets are only visible to members of the owning
+              organization.
+            </small>
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">Resources</label>
+            <small style={{ color: '#64748b', display: 'block', marginBottom: '0.5rem' }}>
+              Files or URLs that belong to the dataset. Rows with no URL
+              or name are ignored.
+            </small>
+            {resources.map((resource, idx) => (
+              <div
+                key={idx}
+                style={{
+                  background: '#f8fafc',
+                  border: '1px solid #e2e8f0',
+                  borderRadius: '8px',
+                  padding: '0.75rem',
+                  marginBottom: '0.5rem'
+                }}
+              >
+                <div
+                  style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.5rem' }}
+                >
+                  <span style={{ fontWeight: 500, color: '#475569', fontSize: '0.85rem' }}>
+                    Resource #{idx + 1}
+                  </span>
+                  {resources.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => removeResource(idx)}
+                      className="btn btn-secondary"
+                      style={{ padding: '0.25rem 0.5rem', fontSize: '0.8rem' }}
+                      aria-label="Remove this resource"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  )}
+                </div>
+                <div style={{ display: 'grid', gap: '0.5rem' }}>
+                  <input
+                    type="text"
+                    value={resource.url}
+                    onChange={(e) => updateResource(idx, 'url', e.target.value)}
+                    className="form-input"
+                    placeholder="URL (e.g. https://example.com/data.csv or s3://bucket/key)"
+                  />
+                  <input
+                    type="text"
+                    value={resource.name}
+                    onChange={(e) => updateResource(idx, 'name', e.target.value)}
+                    className="form-input"
+                    placeholder="Resource name"
+                  />
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 2fr', gap: '0.5rem' }}>
+                    <input
+                      type="text"
+                      value={resource.format}
+                      onChange={(e) => updateResource(idx, 'format', e.target.value)}
+                      className="form-input"
+                      placeholder="Format (CSV, JSON, …)"
+                    />
+                    <input
+                      type="text"
+                      value={resource.description}
+                      onChange={(e) =>
+                        updateResource(idx, 'description', e.target.value)
+                      }
+                      className="form-input"
+                      placeholder="Description (optional)"
+                    />
+                  </div>
+                </div>
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={addResource}
+              className="btn btn-secondary"
+              style={{ marginTop: '0.25rem' }}
+            >
+              <Plus size={16} />
+              Add resource
+            </button>
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">Additional metadata</label>
+            <small style={{ color: '#64748b', display: 'block', marginBottom: '0.5rem' }}>
+              Optional key/value pairs that will be stored on the dataset.
+            </small>
+            {extrasPairs.map((pair, idx) => (
+              <div key={idx} style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
+                <input
+                  type="text"
+                  value={pair.key}
+                  onChange={(e) => updateExtraPair(idx, 'key', e.target.value)}
+                  className="form-input"
+                  placeholder="key"
+                  style={{ flex: 1 }}
+                />
+                <input
+                  type="text"
+                  value={pair.value}
+                  onChange={(e) => updateExtraPair(idx, 'value', e.target.value)}
+                  className="form-input"
+                  placeholder="value"
+                  style={{ flex: 1 }}
+                />
+                <button
+                  type="button"
+                  onClick={() => removeExtraPair(idx)}
+                  className="btn btn-secondary"
+                  style={{ padding: '0.5rem 0.75rem' }}
+                  aria-label="Remove this pair"
+                >
+                  <Trash2 size={16} />
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={addExtraPair}
+              className="btn btn-secondary"
+              style={{ marginTop: '0.25rem' }}
+            >
+              <Plus size={16} />
+              Add field
+            </button>
+          </div>
+
+          <div style={{ display: 'flex', gap: '1rem' }}>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={submitting || orgsLoading || organizations.length === 0}
+            >
+              {submitting ? (
+                <>
+                  <div className="loading-spinner" />
+                  Registering
+                </>
+              ) : (
+                'Register dataset'
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() => navigate('/')}
+              className="btn btn-secondary"
+              disabled={submitting}
+            >
+              Back to Search
+            </button>
+          </div>
+        </form>
       </div>
-        );
-      })()}
     </div>
   );
 };

--- a/ui/src/pages/Search.js
+++ b/ui/src/pages/Search.js
@@ -8,9 +8,16 @@ import {
   ExternalLink,
   Database,
   Building2,
-  Trash2
+  Trash2,
+  UploadCloud
 } from 'lucide-react';
-import { searchAPI, organizationsAPI, userAPI, resourcesAPI } from '../services/api';
+import {
+  searchAPI,
+  organizationsAPI,
+  userAPI,
+  resourcesAPI,
+  generalDatasetAPI
+} from '../services/api';
 
 const MODES = [
   { id: 'both', label: 'All' },
@@ -335,6 +342,56 @@ const Search = () => {
     setServiceResults((prev) => prev.filter((item) => item.id !== service.id));
   };
 
+  const friendlyDatasetDeleteError = (err, datasetName) => {
+    const status = err.response?.status;
+    const detail = err.response?.data?.detail;
+    const raw = (typeof detail === 'string' ? detail : err.message) || '';
+    if (status === 401) return 'You need to log in again to delete datasets.';
+    if (status === 403)
+      return `You don't have permission to delete "${datasetName}".`;
+    if (status === 404 || /not found/i.test(raw))
+      return `"${datasetName}" no longer exists. It may have been deleted already.`;
+    if (/scheme|unreachable|configured/i.test(raw))
+      return 'The local catalog is not reachable right now. Try again in a moment.';
+    return `Could not delete "${datasetName}". Please try again later.`;
+  };
+
+  const handleDeleteDataset = async (dataset) => {
+    // Datasets are CKAN packages; deletion goes through the same
+    // resource-by-id endpoint that services use.
+    await resourcesAPI.deleteById(dataset.id, 'local');
+    setDatasetResults((prev) => prev.filter((item) => item.id !== dataset.id));
+  };
+
+  const friendlyDatasetPublishError = (err, datasetName) => {
+    const status = err.response?.status;
+    const detail = err.response?.data?.detail;
+    const raw = (typeof detail === 'string' ? detail : err.message) || '';
+    if (status === 401) return 'You need to log in again to publish datasets.';
+    if (status === 403)
+      return `You don't have permission to publish "${datasetName}".`;
+    if (status === 404 || /not found/i.test(raw))
+      return `"${datasetName}" no longer exists. It may have been deleted.`;
+    if (/already.*(published|submitted)/i.test(raw))
+      return `"${datasetName}" has already been published.`;
+    if (/pre[- ]?ckan/i.test(raw) || /disabled/i.test(raw))
+      return 'Publishing to the global catalog is not available right now. Try again later.';
+    return `Could not publish "${datasetName}". Please try again later.`;
+  };
+
+  const handlePublishDataset = async (dataset) => {
+    await generalDatasetAPI.publish(dataset.id);
+    // Reflect the new status on the rendered card so the Publish action
+    // disappears and the user sees the dataset move out of "local only".
+    setDatasetResults((prev) =>
+      prev.map((item) =>
+        item.id === dataset.id
+          ? { ...item, extras: { ...(item.extras || {}), status: 'submitted' } }
+          : item
+      )
+    );
+  };
+
   const clearTerm = () => {
     setSearchTerm('');
     inputRef.current?.focus();
@@ -470,6 +527,12 @@ const Search = () => {
           items={datasetResults}
           emptyMessage="No datasets matched your search."
           isService={false}
+          myUserHash={myUserHash}
+          canDelete={server === 'local'}
+          onDelete={handleDeleteDataset}
+          mapDeleteError={friendlyDatasetDeleteError}
+          onPublish={handlePublishDataset}
+          mapPublishError={friendlyDatasetPublishError}
         />
       )}
 
@@ -738,7 +801,9 @@ const ResultsSection = ({
   myUserHash,
   canDelete,
   onDelete,
-  mapDeleteError
+  mapDeleteError,
+  onPublish,
+  mapPublishError
 }) => (
   <div style={{ marginBottom: '2rem' }}>
     <div
@@ -795,6 +860,8 @@ const ResultsSection = ({
             canDelete={canDelete}
             onDelete={onDelete}
             mapDeleteError={mapDeleteError}
+            onPublish={onPublish}
+            mapPublishError={mapPublishError}
           />
         ))}
       </div>
@@ -808,35 +875,62 @@ const ResultCard = ({
   myUserHash,
   canDelete,
   onDelete,
-  mapDeleteError
+  mapDeleteError,
+  onPublish,
+  mapPublishError
 }) => {
   const [expanded, setExpanded] = useState(false);
-  const [confirmOpen, setConfirmOpen] = useState(false);
-  const [deleting, setDeleting] = useState(false);
-  const [deleteError, setDeleteError] = useState(null);
+  // pendingAction can be null | 'delete' | 'publish'. Only one
+  // confirmation panel can be open at a time per card.
+  const [pendingAction, setPendingAction] = useState(null);
+  const [processing, setProcessing] = useState(false);
+  const [actionError, setActionError] = useState(null);
   const resources = item.resources || [];
   const hasExtras = item.extras && Object.keys(item.extras).length > 0;
   const showResources = resources.length > 0;
   const canToggle = showResources || hasExtras;
   // A result card is "owned" by the current user when its persisted
   // creator hash matches and the surrounding section allows deletion
-  // (currently: services on the local server only).
+  // (currently: services or datasets on the local server only).
   const isOwned = Boolean(
     canDelete && myUserHash && item.extras?.ndp_user_id === myUserHash
   );
+  // Publishing only makes sense for datasets that have never been
+  // pushed to the global catalog. Services don't have a publish step.
+  const canPublish = Boolean(
+    isOwned && !isService && onPublish && !item.extras?.status
+  );
   const itemLabel = item.title || item.name || 'this item';
 
-  const handleConfirmDelete = async () => {
-    setDeleting(true);
-    setDeleteError(null);
+  const openAction = (action) => {
+    setActionError(null);
+    setPendingAction(action);
+  };
+  const closeAction = () => {
+    if (processing) return;
+    setActionError(null);
+    setPendingAction(null);
+  };
+
+  const handleConfirm = async () => {
+    if (!pendingAction) return;
+    setProcessing(true);
+    setActionError(null);
     try {
-      await onDelete(item);
-      // On success the parent unmounts us; nothing else to do here.
+      if (pendingAction === 'delete') {
+        await onDelete(item);
+        // Parent unmounts the card; nothing else to do.
+      } else if (pendingAction === 'publish') {
+        await onPublish(item);
+        // Parent updates the dataset's status; close the panel.
+        setPendingAction(null);
+        setProcessing(false);
+      }
     } catch (err) {
-      setDeleteError(
-        mapDeleteError ? mapDeleteError(err, itemLabel) : err.message
-      );
-      setDeleting(false);
+      const mapper =
+        pendingAction === 'delete' ? mapDeleteError : mapPublishError;
+      setActionError(mapper ? mapper(err, itemLabel) : err.message);
+      setProcessing(false);
     }
   };
 
@@ -907,7 +1001,7 @@ const ResultCard = ({
         </div>
       </div>
 
-      {(canToggle || isOwned) && (
+      {(canToggle || isOwned || canPublish) && (
         <div
           style={{
             marginTop: '0.75rem',
@@ -921,13 +1015,13 @@ const ResultCard = ({
             <button
               type="button"
               onClick={() => setExpanded((v) => !v)}
-              disabled={deleting}
+              disabled={processing}
               style={{
                 background: 'transparent',
                 border: 'none',
                 color: '#2563eb',
                 padding: 0,
-                cursor: deleting ? 'not-allowed' : 'pointer',
+                cursor: processing ? 'not-allowed' : 'pointer',
                 fontSize: '0.85rem',
                 fontWeight: 500
               }}
@@ -943,14 +1037,34 @@ const ResultCard = ({
             </button>
           )}
 
-          {isOwned && !confirmOpen && (
+          {canPublish && pendingAction !== 'publish' && (
             <button
               type="button"
-              onClick={() => {
-                setDeleteError(null);
-                setConfirmOpen(true);
+              onClick={() => openAction('publish')}
+              disabled={processing}
+              style={{
+                background: 'transparent',
+                border: 'none',
+                padding: 0,
+                color: '#0f766e',
+                fontSize: '0.85rem',
+                fontWeight: 500,
+                cursor: processing ? 'not-allowed' : 'pointer',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '0.25rem'
               }}
-              disabled={deleting}
+            >
+              <UploadCloud size={14} />
+              Publish
+            </button>
+          )}
+
+          {isOwned && pendingAction !== 'delete' && (
+            <button
+              type="button"
+              onClick={() => openAction('delete')}
+              disabled={processing}
               style={{
                 background: 'transparent',
                 border: 'none',
@@ -958,7 +1072,7 @@ const ResultCard = ({
                 color: '#b91c1c',
                 fontSize: '0.85rem',
                 fontWeight: 500,
-                cursor: deleting ? 'not-allowed' : 'pointer',
+                cursor: processing ? 'not-allowed' : 'pointer',
                 display: 'inline-flex',
                 alignItems: 'center',
                 gap: '0.25rem'
@@ -1002,88 +1116,131 @@ const ResultCard = ({
         </div>
       )}
 
-      {isOwned && confirmOpen && (
-        <div
-          role="alertdialog"
-          aria-label={`Confirm deleting ${itemLabel}`}
+      {pendingAction && (
+        <ActionConfirmPanel
+          action={pendingAction}
+          itemLabel={itemLabel}
+          processing={processing}
+          actionError={actionError}
+          onConfirm={handleConfirm}
+          onCancel={closeAction}
+        />
+      )}
+    </div>
+  );
+};
+
+const ActionConfirmPanel = ({
+  action,
+  itemLabel,
+  processing,
+  actionError,
+  onConfirm,
+  onCancel
+}) => {
+  const isDelete = action === 'delete';
+  const palette = isDelete
+    ? {
+        background: '#fef2f2',
+        border: '#fecaca',
+        text: '#7f1d1d',
+        button: '#dc2626'
+      }
+    : {
+        background: '#ecfdf5',
+        border: '#a7f3d0',
+        text: '#065f46',
+        button: '#0f766e'
+      };
+  const verb = isDelete ? 'Delete' : 'Publish';
+  const verbProgressive = isDelete ? 'Deleting' : 'Publishing';
+  const description = isDelete ? (
+    <>
+      Delete <strong>{itemLabel}</strong>? This cannot be undone.
+    </>
+  ) : (
+    <>
+      Publish <strong>{itemLabel}</strong> to the global catalog?
+    </>
+  );
+
+  return (
+    <div
+      role="alertdialog"
+      aria-label={`Confirm ${verb.toLowerCase()} for ${itemLabel}`}
+      style={{
+        marginTop: '0.75rem',
+        background: palette.background,
+        border: `1px solid ${palette.border}`,
+        borderRadius: '8px',
+        padding: '0.75rem'
+      }}
+    >
+      <div style={{ color: palette.text, fontSize: '0.85rem', marginBottom: '0.6rem' }}>
+        {description}
+      </div>
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={processing}
           style={{
-            marginTop: '0.75rem',
-            background: '#fef2f2',
-            border: '1px solid #fecaca',
-            borderRadius: '8px',
-            padding: '0.75rem'
+            background: palette.button,
+            color: 'white',
+            border: 'none',
+            borderRadius: '6px',
+            padding: '0.35rem 0.75rem',
+            fontSize: '0.85rem',
+            fontWeight: 600,
+            cursor: processing ? 'not-allowed' : 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '0.4rem'
           }}
         >
-          <div style={{ color: '#7f1d1d', fontSize: '0.85rem', marginBottom: '0.6rem' }}>
-            Delete <strong>{itemLabel}</strong>? This cannot be undone.
-          </div>
-          <div style={{ display: 'flex', gap: '0.5rem' }}>
-            <button
-              type="button"
-              onClick={handleConfirmDelete}
-              disabled={deleting}
-              style={{
-                background: '#dc2626',
-                color: 'white',
-                border: 'none',
-                borderRadius: '6px',
-                padding: '0.35rem 0.75rem',
-                fontSize: '0.85rem',
-                fontWeight: 600,
-                cursor: deleting ? 'not-allowed' : 'pointer',
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: '0.4rem'
-              }}
-            >
-              {deleting ? (
-                <>
-                  <div className="loading-spinner" />
-                  Deleting
-                </>
-              ) : (
-                <>
-                  <Trash2 size={14} />
-                  Delete
-                </>
-              )}
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                setConfirmOpen(false);
-                setDeleteError(null);
-              }}
-              disabled={deleting}
-              style={{
-                background: 'white',
-                color: '#374151',
-                border: '1px solid #d1d5db',
-                borderRadius: '6px',
-                padding: '0.35rem 0.75rem',
-                fontSize: '0.85rem',
-                fontWeight: 500,
-                cursor: deleting ? 'not-allowed' : 'pointer'
-              }}
-            >
-              Cancel
-            </button>
-          </div>
-          {deleteError && (
-            <div
-              style={{
-                marginTop: '0.6rem',
-                color: '#7f1d1d',
-                fontSize: '0.8rem',
-                display: 'flex',
-                alignItems: 'flex-start',
-                gap: '0.4rem'
-              }}
-            >
-              <AlertCircle size={14} style={{ marginTop: '2px', flexShrink: 0 }} />
-              <span>{deleteError}</span>
-            </div>
+          {processing ? (
+            <>
+              <div className="loading-spinner" />
+              {verbProgressive}
+            </>
+          ) : (
+            <>
+              {isDelete ? <Trash2 size={14} /> : <UploadCloud size={14} />}
+              {verb}
+            </>
           )}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={processing}
+          style={{
+            background: 'white',
+            color: '#374151',
+            border: '1px solid #d1d5db',
+            borderRadius: '6px',
+            padding: '0.35rem 0.75rem',
+            fontSize: '0.85rem',
+            fontWeight: 500,
+            cursor: processing ? 'not-allowed' : 'pointer'
+          }}
+        >
+          Cancel
+        </button>
+      </div>
+      {actionError && (
+        <div
+          style={{
+            marginTop: '0.6rem',
+            color: palette.text,
+            fontSize: '0.8rem',
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: '0.4rem'
+          }}
+        >
+          <AlertCircle size={14} style={{ marginTop: '2px', flexShrink: 0 }} />
+          <span>{actionError}</span>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Removed the "Datasets" entry from the "Resources" navigation dropdown; the "+ New" menu now hosts a "Dataset" item between "Organization" and "Service".
- Simplified the `/datasets` page into a single-purpose "register a new dataset" form. Listing moved to Search a few releases back; deletion and publishing now happen on the dataset result cards (new in this release).
- Search dataset cards owned by the authenticated user now show a "Yours" badge and two inline actions:
  - **Delete** — opens an inline confirmation panel (red palette); on success the card disappears immediately, on failure a friendly, actionable message is shown.
  - **Publish** — only shown for datasets without `extras.status` (= local-only). Opens an inline confirmation panel (teal palette); on success the card updates to reflect the new status (`submitted`) and the Publish button disappears, on failure a friendly message is shown.
- Both delete and publish flows are rendered by the same `ActionConfirmPanel`. Each card has a single `pendingAction` slot, so only one confirmation can be open at a time per card.

## Backwards compatibility
- No new public API surface. Dataset deletion goes through the existing `DELETE /resource?resource_id=...` endpoint (datasets are CKAN packages). Dataset publishing goes through the existing `POST /dataset/{id}/publish` endpoint (unchanged since 0.19.0).
- The `/datasets` UI route still exists and still creates datasets; the page only drops listing/edit/delete/publish/filter-by-org and a handful of rarely used optional inputs (tags, groups, license, version) — easy to bring back if anyone misses them.
- Datasets registered before the creator-hash feature do not appear under "Only mine" and never expose Delete or Publish actions on Search; no migration is performed.
- No required parameters added, no fields removed, no type changes.

## Test plan
- [x] UI build: `react-scripts build` succeeds (-3.07 kB net vs 0.25.0 thanks to the simplified Datasets page).
- [x] End-to-end smoke test with `raul`/`raul`:
  - Create org → create dataset under that org with `POST /dataset` (resources included).
  - Verify the persisted dataset carries `extras.ndp_user_id = b752c92cf1a051d2` (raul's hash) and no `status` extra.
  - `POST /dataset/{id}/publish` → 201, the dataset gains `extras.status = "submitted"`.
  - `DELETE /resource?resource_id=...&server=local` → 200, the dataset is gone.
  - Empty-org cleanup `DELETE /organization/X?cascade=false` → 200.
- [x] UI smoke test (local container):
  - "+ New > Dataset" lands on the simplified registration form. Org dropdown is populated.
  - Created dataset appears in Search > Datasets with "Yours" + "Publish" + "Delete".
  - Inline Publish confirmation: Cancel restores, Confirm publishes and the Publish button disappears (status now "submitted").
  - Inline Delete confirmation: Cancel restores, Confirm removes the card from the rendered list.
  - Only one confirmation panel can be open at a time per card.

Closes #159.