### PR TITLE
Allow publishing a dataset from the create form (closes #161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-05-14
+
+### Added
+- "+ New > Dataset" form gains a "Publish to the global catalog after creation" checkbox. When checked, the form first registers the dataset on the local catalog and then chains a publish call to `POST /dataset/{id}/publish`. A helper line below the checkbox tells the user the dataset will not appear in the global catalog until an administrator approves the submission.
+- The success banner after submission reflects what actually happened: it mentions both registration and the pending approval when publish was requested, and surfaces any warning returned by the publish endpoint (for example, a name collision that caused PRE-CKAN to publish the dataset under a timestamped variant).
+- If registration succeeds but the publish call fails, the form surfaces a non-fatal yellow warning instead of a destructive error: the local dataset is kept and the user is told they can retry from the Search page.
+
+### Backwards compatibility
+- All changes are UI-only and additive. No backend changes.
+- When the checkbox is left unchecked, the form behaves exactly as it did in 0.26.0 — single registration call against the local catalog.
+
 ## [0.26.0] - 2026-05-13
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.26.0"
+    swagger_version: str = "0.27.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/pages/DatasetManagement.js
+++ b/ui/src/pages/DatasetManagement.js
@@ -21,8 +21,13 @@ const DatasetManagement = () => {
     title: '',
     owner_org: '',
     notes: '',
-    private: false
+    private: false,
+    // When true, after a successful create we chain a publish call to
+    // the global catalog. The user still has to wait for an admin to
+    // approve the submission before the dataset becomes visible.
+    publishToGlobal: false
   });
+  const [warning, setWarning] = useState(null);
   const [resources, setResources] = useState([
     { url: '', name: '', format: '', description: '' }
   ]);
@@ -118,6 +123,7 @@ const DatasetManagement = () => {
     e.preventDefault();
     setError(null);
     setSuccess(null);
+    setWarning(null);
     setSubmitting(true);
 
     const payload = {
@@ -132,36 +138,78 @@ const DatasetManagement = () => {
     const extras = buildExtras();
     if (Object.keys(extras).length > 0) payload.extras = extras;
 
+    const datasetName = formData.name;
+    const wantsPublish = Boolean(formData.publishToGlobal);
+    let createdDatasetId = null;
+
     try {
-      await generalDatasetAPI.create(payload, 'local');
-      setSuccess(
-        `Dataset "${formData.name}" registered. You can keep registering more or go back to Search.`
-      );
-      setFormData((prev) => ({
-        ...prev,
-        name: '',
-        title: '',
-        notes: '',
-        private: false
-        // keep owner_org selected so users registering several datasets
-        // in the same org don't have to re-pick it every time.
-      }));
-      setResources([{ url: '', name: '', format: '', description: '' }]);
-      setExtrasPairs([]);
+      const createResponse = await generalDatasetAPI.create(payload, 'local');
+      createdDatasetId = createResponse?.data?.id || null;
     } catch (err) {
       const detail = err.response?.data?.detail;
       const raw = typeof detail === 'string' ? detail : err.message;
       const msg = raw || 'unknown error';
       setError(
         /already exists/i.test(msg)
-          ? `A dataset called "${formData.name}" already exists. Pick a different name.`
+          ? `A dataset called "${datasetName}" already exists. Pick a different name.`
           : /name/i.test(msg) && /(invalid|must contain|lowercase)/i.test(msg)
             ? 'The dataset name is invalid. Use lowercase letters, numbers, underscores and hyphens (no spaces).'
             : `Could not register the dataset: ${msg}.`
       );
-    } finally {
       setSubmitting(false);
+      return;
     }
+
+    // From here on the dataset exists locally. Any publish failure is
+    // surfaced as a non-fatal warning so the user knows the local
+    // registration was kept and the publish action is still available
+    // from the Search page.
+    let publishWarning = null;
+    let publishError = null;
+    if (wantsPublish && createdDatasetId) {
+      try {
+        const publishResponse = await generalDatasetAPI.publish(createdDatasetId);
+        publishWarning = publishResponse?.data?.warning || null;
+      } catch (err) {
+        const detail = err.response?.data?.detail;
+        const raw = typeof detail === 'string' ? detail : err.message;
+        publishError =
+          `Dataset "${datasetName}" was registered, but it could not be ` +
+          `published to the global catalog: ${raw || 'unknown error'}. You can ` +
+          'try the Publish action from the Search page later.';
+      }
+    }
+
+    if (publishError) {
+      setWarning(publishError);
+    } else if (wantsPublish) {
+      const tail = publishWarning
+        ? ` (note: ${publishWarning})`
+        : '';
+      setSuccess(
+        `Dataset "${datasetName}" registered and submitted to the global ` +
+          `catalog. It will only appear there once an administrator approves ` +
+          `the submission.${tail}`
+      );
+    } else {
+      setSuccess(
+        `Dataset "${datasetName}" registered. You can keep registering more or go back to Search.`
+      );
+    }
+
+    setFormData((prev) => ({
+      ...prev,
+      name: '',
+      title: '',
+      notes: '',
+      private: false,
+      publishToGlobal: false
+      // keep owner_org selected so users registering several datasets
+      // in the same org don't have to re-pick it every time.
+    }));
+    setResources([{ url: '', name: '', format: '', description: '' }]);
+    setExtrasPairs([]);
+    setSubmitting(false);
   };
 
   return (
@@ -181,6 +229,26 @@ const DatasetManagement = () => {
         <div className="alert alert-error">
           <AlertCircle size={20} />
           {error}
+        </div>
+      )}
+
+      {warning && (
+        <div
+          style={{
+            background: '#fffbeb',
+            border: '1px solid #fde68a',
+            color: '#78350f',
+            borderRadius: '8px',
+            padding: '0.75rem 1rem',
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: '0.5rem',
+            marginBottom: '1rem',
+            fontSize: '0.9rem'
+          }}
+        >
+          <AlertCircle size={20} style={{ marginTop: '2px', flexShrink: 0 }} />
+          <span>{warning}</span>
         </div>
       )}
 
@@ -283,6 +351,26 @@ const DatasetManagement = () => {
             <small style={{ color: '#64748b', display: 'block', marginTop: '0.25rem' }}>
               Private datasets are only visible to members of the owning
               organization.
+            </small>
+          </div>
+
+          <div className="form-group">
+            <label
+              className="form-label"
+              style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem' }}
+            >
+              <input
+                type="checkbox"
+                name="publishToGlobal"
+                checked={formData.publishToGlobal}
+                onChange={handleInputChange}
+                style={{ accentColor: '#2563eb' }}
+              />
+              Publish to the global catalog after creation
+            </label>
+            <small style={{ color: '#64748b', display: 'block', marginTop: '0.25rem' }}>
+              The dataset will not appear in the global catalog until an
+              administrator approves the submission.
             </small>
           </div>
 


### PR DESCRIPTION
## Summary
- "+ New > Dataset" form gains a "Publish to the global catalog after creation" checkbox. When checked, the form first registers the dataset on the local catalog and then chains a publish call to the existing `POST /dataset/{id}/publish` endpoint.
- A helper line under the checkbox tells the user the dataset will only appear in the global catalog once an administrator approves the submission.
- The success banner reflects what actually happened: it mentions both the registration and the pending approval when publish was requested, and surfaces any non-fatal `warning` returned by publish (for example, the timestamped variant PRE-CKAN assigns when the same name already exists there).
- If registration succeeds but publish fails, the form surfaces a non-fatal yellow warning instead of a destructive error: the local dataset is kept and the user is told they can retry from the Search page.

## Backwards compatibility
- UI-only change. No backend modifications.
- Default behavior (checkbox unchecked) is identical to 0.26.0 — a single registration call against the local catalog.
- The publish endpoint and the dataset registration endpoint are untouched.

## Test plan
- [x] UI build: `react-scripts build` succeeds (+595 B net vs 0.26.0).
- [x] UI smoke test (local container):
  - Create a dataset with the checkbox unchecked → standard "Dataset X registered" success banner.
  - Create a dataset with the checkbox checked → "Dataset X registered and submitted to the global catalog. It will only appear there once an administrator approves the submission." Success banner.
  - When PRE-CKAN already has a dataset with the same name, the success banner appends the warning returned by the API (the timestamped variant name PRE-CKAN used).
  - Datasets created with the checkbox immediately show `extras.status = "submitted"` on the Search page, so the inline Publish button does not appear (already-published state).

Closes #161.