### PR TITLE
Rename Search filter Only mine to My assets (closes #163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.1] - 2026-05-14
+
+### Changed
+- Search page: the result-scoping toggle is now labelled "My assets" instead of "Only mine". The tooltip on hover ("Show only assets I created") was adjusted to match the new wording. Behaviour is unchanged — the same client-side and server-side filters are still applied.
+
 ## [0.27.0] - 2026-05-14
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.27.0"
+    swagger_version: str = "0.27.1"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/pages/Search.js
+++ b/ui/src/pages/Search.js
@@ -685,7 +685,7 @@ const OnlyMineToggle = ({ checked, onChange, disabled }) => (
     title={
       disabled
         ? 'Unavailable: could not load your user identity'
-        : 'Show only items I created'
+        : 'Show only assets I created'
     }
     style={{
       display: 'inline-flex',
@@ -710,7 +710,7 @@ const OnlyMineToggle = ({ checked, onChange, disabled }) => (
       onChange={(e) => onChange(e.target.checked)}
       style={{ accentColor: '#2563eb', cursor: disabled ? 'not-allowed' : 'pointer' }}
     />
-    Only mine
+    My assets
   </label>
 );
 


### PR DESCRIPTION
## Summary
- Renamed the result-scoping toggle in the Search filter row from "Only mine" to "My assets". Reads as a self-contained noun phrase that matches the terminology a non-technical user would use for their own datasets, services and organizations together.
- Updated the hover tooltip to "Show only assets I created" so the wording is consistent.
- Behavior is unchanged — the same client-side and server-side filters are still applied.

## Backwards compatibility
- UI-only label change. No backend modifications, no API changes, no contract changes.

## Test plan
- [x] UI build: `react-scripts build` succeeds (-2 B vs 0.27.0).
- [x] Local container shows the new label in the Search filter row; tooltip on hover matches.

Closes #163.