### PR TITLE
Offer canonical service types with Other fallback (closes #165)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.2] - 2026-05-14
+
+### Changed
+- "+ New > Service" form: the "Service type" field is now a select with three canonical options (API, UI, Trigger) plus an Other option that reveals a free-text input. Picking a canonical option submits its exact label as `service_type`; choosing Other submits the value typed into the text input. Leaving the field on "(none)" omits `service_type` from the request, preserving the previous "blank type is fine" behavior.
+
+### Backwards compatibility
+- UI-only change. The backend contract for `POST /services` is unchanged — `service_type` is still an optional string up to 50 characters.
+
 ## [0.27.1] - 2026-05-14
 
 ### Changed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.27.1"
+    swagger_version: str = "0.27.2"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/pages/Services.js
+++ b/ui/src/pages/Services.js
@@ -14,7 +14,11 @@ const Services = () => {
     service_name: '',
     service_title: '',
     service_url: '',
-    service_type: '',
+    // The service type is split between a canonical choice (API/UI/
+    // Trigger) and an "Other" escape hatch with its own text input.
+    // The submitted value is derived from these two fields below.
+    service_type_choice: '',
+    service_type_custom: '',
     notes: '',
     health_check_url: '',
     documentation_url: ''
@@ -63,7 +67,14 @@ const Services = () => {
       owner_org: 'services',
       service_url: formData.service_url
     };
-    if (formData.service_type) payload.service_type = formData.service_type;
+    // Resolve service_type from the choice + Other free-text. Sending
+    // no field at all when nothing is selected preserves the previous
+    // "blank type is fine" behavior.
+    const resolvedType =
+      formData.service_type_choice === 'Other'
+        ? (formData.service_type_custom || '').trim()
+        : formData.service_type_choice;
+    if (resolvedType) payload.service_type = resolvedType;
     if (formData.notes) payload.notes = formData.notes;
     if (formData.health_check_url)
       payload.health_check_url = formData.health_check_url;
@@ -81,7 +92,8 @@ const Services = () => {
         service_name: '',
         service_title: '',
         service_url: '',
-        service_type: '',
+        service_type_choice: '',
+        service_type_custom: '',
         notes: '',
         health_check_url: '',
         documentation_url: ''
@@ -177,14 +189,30 @@ const Services = () => {
 
           <div className="form-group">
             <label className="form-label">Service type</label>
-            <input
-              type="text"
-              name="service_type"
-              value={formData.service_type}
+            <select
+              name="service_type_choice"
+              value={formData.service_type_choice}
               onChange={handleInputChange}
-              className="form-input"
-              placeholder="API, Web Service, Microservice…"
-            />
+              className="form-select"
+            >
+              <option value="">(none)</option>
+              <option value="API">API</option>
+              <option value="UI">UI</option>
+              <option value="Trigger">Trigger</option>
+              <option value="Other">Other…</option>
+            </select>
+            {formData.service_type_choice === 'Other' && (
+              <input
+                type="text"
+                name="service_type_custom"
+                value={formData.service_type_custom}
+                onChange={handleInputChange}
+                className="form-input"
+                placeholder="Describe the service type"
+                style={{ marginTop: '0.5rem' }}
+                maxLength={50}
+              />
+            )}
           </div>
 
           <div className="form-group">


### PR DESCRIPTION
## Summary
- Replaced the free-text "Service type" input on the Service registration form with a select offering three canonical options:
  - **API**
  - **UI**
  - **Trigger**
- Added an **Other…** option that reveals a free-text input (capped at 50 chars to match the backend constraint). Whatever is typed there becomes the submitted `service_type`.
- The default option is "(none)"; leaving it selected omits `service_type` from the request, preserving the previous "blank type is fine" behavior.

## Backwards compatibility
- UI-only change. The backend contract for `POST /services` is unchanged — `service_type` is still an optional string up to 50 chars. Existing API callers are unaffected.

## Test plan
- [x] UI build: `react-scripts build` succeeds (+258 B vs 0.27.1).
- [x] End-to-end round trip with `raul`/`raul`: created a service with each of API / UI / Trigger / a custom value; the `extras.service_type` stored in CKAN matched the submitted value in all four cases.

Closes #165.