### PR TITLE
Bold the user's group that matches this EP on the Dashboard (closes #169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.4] - 2026-05-14
+
+### Added
+- Dashboard: the group whose identifier matches the deployment's `AFFINITIES_EP_UUID` env value is now rendered in bold in the user's Groups list, so the user can tell at a glance which of their Keycloak groups ties them to this Endpoint. A hover tooltip explains the highlight. Matching covers all the shapes the auth service returns (plain string, or object with id/name/path, with any leading "/" stripped). Other groups render exactly as before.
+
+### Changed
+- `entrypoint.sh` now also exposes `AFFINITIES_EP_UUID` to the React UI through the runtime `config.js` (already used to expose `rootPath`). The new field is `window.__EP_CONFIG__.affinitiesEpUuid`. When the env var is not set, the field is an empty string and the Dashboard highlight is a no-op.
+
+### Backwards compatibility
+- UI-only feature plus a small entrypoint addition. The shape of `window.__EP_CONFIG__` only grows (new field, existing field unchanged), so any consumer that ignores unknown keys keeps working.
+- When `AFFINITIES_EP_UUID` is not configured or the user has no matching group, the Dashboard renders exactly as before.
+
 ## [0.27.3] - 2026-05-14
 
 ### Changed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.27.3"
+    swagger_version: str = "0.27.4"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
 
-# Generate runtime config for the React UI
+# Generate runtime config for the React UI. AFFINITIES_EP_UUID lets the
+# UI highlight the user's group that ties them to this endpoint without
+# having to look the value up against the deployment env manually.
 cat > /app/ui/build/config.js <<EOF
-window.__EP_CONFIG__ = { rootPath: "${ROOT_PATH}" };
+window.__EP_CONFIG__ = {
+  rootPath: "${ROOT_PATH}",
+  affinitiesEpUuid: "${AFFINITIES_EP_UUID}"
+};
 EOF
 
 # Rewrite all /ui/ asset references in the built index.html to include ROOT_PATH

--- a/ui/src/pages/Dashboard.js
+++ b/ui/src/pages/Dashboard.js
@@ -147,17 +147,36 @@ const Dashboard = () => {
   };
 
   /**
-   * Get user groups display
-   * Handles both string arrays and object arrays (with id, name, path properties)
+   * Get user groups display.
+   *
+   * Returns an array of `{ label, isThisEp }` objects. `label` is what
+   * gets rendered; `isThisEp` is true when any identifier on the group
+   * (string value, id, name, path) matches the configured
+   * AFFINITIES_EP_UUID exposed through window.__EP_CONFIG__, so the
+   * caller can highlight that one entry.
    */
   const getUserGroups = () => {
     if (!userInfo || !userInfo.groups) return [];
-    return userInfo.groups.map(group => {
-      if (typeof group === 'string') return group;
-      if (typeof group === 'object' && group !== null) {
-        return group.name || group.id || JSON.stringify(group);
+    const epUuid = (window.__EP_CONFIG__?.affinitiesEpUuid || '').trim();
+    const matchesEp = (...candidates) => {
+      if (!epUuid) return false;
+      return candidates.some(
+        (c) =>
+          typeof c === 'string' &&
+          c.replace(/^\/+/, '') === epUuid
+      );
+    };
+    return userInfo.groups.map((group) => {
+      if (typeof group === 'string') {
+        return { label: group, isThisEp: matchesEp(group) };
       }
-      return String(group);
+      if (typeof group === 'object' && group !== null) {
+        return {
+          label: group.name || group.id || JSON.stringify(group),
+          isThisEp: matchesEp(group.id, group.name, group.path)
+        };
+      }
+      return { label: String(group), isThisEp: false };
     });
   };
 
@@ -335,13 +354,23 @@ const Dashboard = () => {
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
                 {getUserGroups().length > 0 ? (
                   getUserGroups().map((group, index) => (
-                    <span 
+                    <span
                       key={index}
                       className="status-indicator status-success"
-                      style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}
+                      title={
+                        group.isThisEp
+                          ? "This is the group that ties you to this Endpoint"
+                          : undefined
+                      }
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.25rem',
+                        fontWeight: group.isThisEp ? 700 : undefined
+                      }}
                     >
                       <Users size={12} />
-                      {group}
+                      {group.label}
                     </span>
                   ))
                 ) : (


### PR DESCRIPTION
## Summary
- The Dashboard's Groups section now renders the group whose identifier matches the deployment's `AFFINITIES_EP_UUID` env value in **bold**, so the user can tell at a glance which of their Keycloak groups ties them to this Endpoint. A hover tooltip explains the highlight. Other groups render exactly as before.
- Matching covers all the shapes the auth service returns: plain string, or object with `id`/`name`/`path`. Any leading "/" in `path` is stripped before comparing.
- `entrypoint.sh` now also exposes `AFFINITIES_EP_UUID` to the React UI through the runtime `config.js` (already used for `rootPath`). The new field is `window.__EP_CONFIG__.affinitiesEpUuid`. When the env var is not set, the field is an empty string and the Dashboard highlight is a no-op.

## Backwards compatibility
- UI-only feature plus a small entrypoint addition. The shape of `window.__EP_CONFIG__` only grows (new field, existing field unchanged), so any consumer that ignores unknown keys keeps working.
- When `AFFINITIES_EP_UUID` is not configured or the user has no matching group, the Dashboard renders exactly as before.

## Test plan
- [x] UI build: `react-scripts build` succeeds (-87 B vs 0.27.3).
- [x] `curl /ep-api/ui/config.js` shows `affinitiesEpUuid: "96207a63-ee21-40c8-a492-31d680002330"` on the running local container.
- [x] Logged in as `raul`/`raul`: the matching group on the Dashboard appears in bold, others unchanged.

Closes #169.