### PR TITLE
Introduce viewer and writer roles with strict default (closes #171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-05-18
+
+### Added
+- Three explicit role tiers — Viewer (read-only), Writer (modify catalog content) and Admin (everything) — recognised in two flavours each, mirroring how the admin role already worked:
+  - **Admin**: `ndp_admin` (global, already supported), plus per-endpoint `group:{AFFINITIES_EP_UUID}:admin` (the form Keycloak actually emits). The legacy form `{AFFINITIES_EP_UUID}_admin` is also still accepted for compatibility — we added matchers, we did not replace them.
+  - **Writer**: `ndp_writer` (global) and `group:{AFFINITIES_EP_UUID}:writer` (per-EP). New.
+  - **Viewer**: `ndp_viewer` (global) and `group:{AFFINITIES_EP_UUID}:viewer` (per-EP). New.
+  - Implicit ordering: admin can do everything a writer can; writer can do everything a viewer can. A user only needs the highest tier they want — three separate role assignments are not required.
+- New auth helpers exported from `api.services.auth_services`: `is_writer`, `is_viewer`, `effective_role`, `endpoint_group_role_name`, `get_user_for_read_operation`. The existing `is_admin` and `get_user_for_write_operation` are updated; the existing `get_user_for_endpoint_access` is unchanged.
+- `GET /user/info` carries a new `effective_role` field (`admin`, `writer`, `viewer` or `none`). The UI uses it to decide which actions to expose without re-implementing the role-tier logic in the browser.
+- UI gates write actions on the user's effective role:
+  - The "+ New" menu in the navigation bar is hidden for viewers and users without a role.
+  - The Delete action on owned organization, dataset and service cards in Search is hidden for viewers and users without a role.
+  - The Publish action on owned dataset cards is hidden for viewers and users without a role.
+  - Read paths (browsing Search results, expanding details) are unchanged.
+
+### Changed
+- `get_user_for_write_operation` now adds a role gate on top of the existing group-based-access gate. After group membership has been verified, the user must also carry at least the writer tier; otherwise the request is rejected with `403` and a friendly message asking an administrator to grant them the writer or admin role.
+- The "Access Requests" approval flow now exposes three radios (Viewer / Writer / Admin) instead of the previous two (Member / Admin). The `POST /user/access-requests/{id}/approve` request body's `grant_type` accepts `viewer`, `writer` and `admin`; the legacy `member` value keeps working as an alias for `viewer` so existing API clients are unaffected. Approving as `writer` or `admin` adds the user to the EP group and then assigns the per-EP role on top via the AAI; approving as `viewer` only adds the user to the group (the AAI defaults the per-group role to viewer on join).
+- `aai_client.assign_role` now takes a `group_name` argument and a bare tier name (`"admin"` / `"writer"`) — the AAI expects the per-group role to be specified as `(group_name, tier)` and builds the full `group:{group_name}:{tier}` name server-side. The previous signature was passing the already-prefixed string and got `"Missing token or group"` back from the AAI; tests had been mocking around it so the bug only surfaced once the UI actually exercised the approve-as-admin path on real data.
+
+### Backwards compatibility
+- **Strict default**: users that today belong to the EP group but have no role assigned were implicitly writers before this release; they now become "none" and lose write access until an administrator assigns them a role. The flow that adds approved users to the EP group via the AAI already assigns the `viewer` role automatically, so newly approved users land as viewers and have to be upgraded explicitly to writers.
+- The legacy `{AFFINITIES_EP_UUID}_admin` role keeps working — we did not remove the old matcher.
+- No request/response payload shapes change. The only addition on `/user/info` is `effective_role`, which clients that ignore unknown keys can safely ignore.
+- The new realm roles (`ndp_writer`, `ndp_viewer`, the per-EP `group:{uuid}:writer` and `group:{uuid}:viewer` forms) have to be created in Keycloak before they can be assigned. The EP does not expose role creation; that step happens in the realm's admin console.
+
 ## [0.27.4] - 2026-05-14
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.27.4"
+    swagger_version: str = "0.28.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/models/access_request_model.py
+++ b/api/models/access_request_model.py
@@ -34,13 +34,19 @@ class AccessRequestDecision(BaseModel):
 class AccessRequestApproveDecision(AccessRequestDecision):
     """Payload sent by an admin to approve a pending request."""
 
-    grant_type: Literal["member", "admin"] = Field(
+    grant_type: Literal["viewer", "writer", "admin", "member"] = Field(
         ...,
         description=(
-            "What to grant the user. 'member' adds the user to the endpoint "
-            "group; 'admin' assigns the endpoint admin role in addition."
+            "Role tier to grant the user. "
+            "'viewer' adds the user to the endpoint group (the AAI's "
+            "default per-group assignment is viewer, so this is the "
+            "minimal grant). "
+            "'writer' additionally assigns the per-endpoint writer role. "
+            "'admin' additionally assigns the per-endpoint admin role. "
+            "'member' is kept as a deprecated alias for 'viewer' so "
+            "existing clients keep working."
         ),
-        json_schema_extra={"example": "member"},
+        json_schema_extra={"example": "viewer"},
     )
 
 
@@ -67,7 +73,7 @@ class AccessRequest(BaseModel):
     decided_at: Optional[datetime] = None
     decided_by_sub: Optional[str] = None
     decided_by_username: Optional[str] = None
-    grant_type: Optional[Literal["member", "admin"]] = None
+    grant_type: Optional[Literal["viewer", "writer", "admin", "member"]] = None
     decision_notes: Optional[str] = None
 
     @classmethod

--- a/api/routes/user_routes/user_info.py
+++ b/api/routes/user_routes/user_info.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 
 from fastapi import APIRouter, Depends
 
-from api.services.auth_services import get_user_for_endpoint_access
+from api.services.auth_services import effective_role, get_user_for_endpoint_access
 from api.services.metadata_services import hash_user_id
 
 router = APIRouter()
@@ -124,4 +124,8 @@ async def get_user_info(
     # compatible if the auth service ever starts returning it itself.
     enriched = dict(user_info)
     enriched.setdefault("ndp_user_id", hash_user_id(user_info))
+    # effective_role lets the UI decide which actions to expose without
+    # reimplementing the role-tier logic in the browser. Values are
+    # "admin", "writer", "viewer" or "none".
+    enriched.setdefault("effective_role", effective_role(user_info))
     return enriched

--- a/api/services/access_request_services/access_request_service.py
+++ b/api/services/access_request_services/access_request_service.py
@@ -17,7 +17,6 @@ from api.config.catalog_settings import catalog_settings
 from api.config.swagger_settings import swagger_settings
 from api.repositories.access_request_repository import AccessRequestRepository
 from api.services.auth_services import aai_client
-from api.services.auth_services.authorization_service import endpoint_admin_role_name
 
 logger = logging.getLogger(__name__)
 
@@ -124,28 +123,43 @@ def list_access_requests(
 
 def _grant_via_aai(
     admin_token: str,
-    grant_type: Literal["member", "admin"],
+    grant_type: Literal["viewer", "writer", "admin", "member"],
     username: str,
 ) -> None:
-    """Perform the actual IDP write for an approve decision."""
+    """
+    Perform the IDP write for an approve decision.
+
+    The three tiers map to AAI calls as follows:
+
+    - ``viewer`` / ``member`` (alias): only add the user to the endpoint
+      group. The AAI assigns the viewer role automatically on join, so
+      no separate role assignment is needed.
+    - ``writer``: group membership plus the per-endpoint writer role.
+    - ``admin``: group membership plus the per-endpoint admin role.
+
+    For the role-assignment calls we pass the bare tier name
+    (``"writer"`` / ``"admin"``) plus ``group_name=ep_uuid``. The AAI
+    builds the fully-qualified ``group:{ep_uuid}:{tier}`` server-side;
+    passing the qualified form here makes it double-prefix.
+    """
     ep_uuid = _require_endpoint_uuid()
 
-    # "member" always grants group membership. "admin" grants the admin
-    # role on top — the two are complementary, not alternatives, so an
-    # admin user has both.
     aai_client.add_user_to_group(admin_token, ep_uuid, username)
 
-    if grant_type == "admin":
-        admin_role = endpoint_admin_role_name()
-        if admin_role:
-            aai_client.assign_role(admin_token, admin_role, username)
+    if grant_type in ("writer", "admin"):
+        aai_client.assign_role(
+            admin_token,
+            grant_type,
+            username,
+            ep_uuid,
+        )
 
 
 def approve_access_request(
     request_id: str,
     admin_info: Dict[str, Any],
     admin_token: str,
-    grant_type: Literal["member", "admin"],
+    grant_type: Literal["viewer", "writer", "admin", "member"],
     notes: Optional[str],
 ) -> Dict[str, Any]:
     """

--- a/api/services/auth_services/__init__.py
+++ b/api/services/auth_services/__init__.py
@@ -2,11 +2,16 @@
 from .authorization_service import (  # noqa: F401
     check_group_membership,
     check_organization_membership,  # backward compatibility
+    effective_role,
     endpoint_admin_role_name,
+    endpoint_group_role_name,
     get_allowed_groups,
     get_user_for_endpoint_access,
+    get_user_for_read_operation,
     get_user_for_write_operation,
     is_admin,
+    is_viewer,
+    is_writer,
     require_admin,
     require_group_member,
     require_organization_member,  # backward compatibility

--- a/api/services/auth_services/aai_client.py
+++ b/api/services/auth_services/aai_client.py
@@ -134,12 +134,28 @@ def add_user_to_group(
     )
 
 
-def assign_role(admin_token: str, role_name: str, username: str) -> Dict[str, Any]:
-    """Assign the realm role ``role_name`` to ``username``."""
+def assign_role(
+    admin_token: str,
+    role_level: str,
+    username: str,
+    group_name: str,
+) -> Dict[str, Any]:
+    """
+    Assign a per-group role to ``username`` on ``group_name``.
+
+    The AAI expects ``role_level`` to be the bare tier name (``"admin"``,
+    ``"writer"``, ``"viewer"``) — it concatenates ``group:{group_name}:``
+    on its own. Passing the fully-qualified ``group:UUID:writer`` form
+    causes the AAI to double-prefix and the call fails with HTTP 500.
+    """
     return _post(
         "/role/assign",
         admin_token,
-        {"role_name": role_name, "username": username},
+        {
+            "role_name": role_level,
+            "username": username,
+            "group_name": group_name,
+        },
     )
 
 

--- a/api/services/auth_services/authorization_service.py
+++ b/api/services/auth_services/authorization_service.py
@@ -11,20 +11,40 @@ from api.services.auth_services.get_current_user import get_current_user
 
 logger = logging.getLogger(__name__)
 
-# Role that always grants access when group-based access is enabled.
+# Platform-wide role names. A user that carries any of these can act at
+# the corresponding tier on any endpoint of the federation.
 ADMIN_ROLE_NAME = "ndp_admin"
+WRITER_ROLE_NAME = "ndp_writer"
+VIEWER_ROLE_NAME = "ndp_viewer"
 
 
 def endpoint_admin_role_name() -> str:
     """
-    Return the endpoint-specific admin role name derived from the configured
-    ``AFFINITIES_EP_UUID``, e.g. ``96207a63-...-002330_admin``. Returns an
-    empty string when the UUID is not configured.
+    Return the *legacy* endpoint-specific admin role name derived from the
+    configured ``AFFINITIES_EP_UUID``, e.g. ``96207a63-...-002330_admin``.
+    Returns an empty string when the UUID is not configured.
+
+    Kept for backwards compatibility; the canonical Keycloak emits
+    ``group:{ep_uuid}:admin`` (see :func:`endpoint_group_role_name`) and
+    both forms are accepted.
     """
     ep_uuid = (affinities_settings.ep_uuid or "").strip()
     if not ep_uuid:
         return ""
     return f"{ep_uuid}_admin"
+
+
+def endpoint_group_role_name(role_level: str) -> str:
+    """
+    Return the per-endpoint role name in the canonical
+    ``group:{AFFINITIES_EP_UUID}:{role_level}`` format that Keycloak
+    actually emits (e.g. ``group:96207a63-...:admin``). Returns an empty
+    string when the UUID is not configured.
+    """
+    ep_uuid = (affinities_settings.ep_uuid or "").strip()
+    if not ep_uuid:
+        return ""
+    return f"group:{ep_uuid}:{role_level}"
 
 
 def normalize_group_path(path: str) -> str:
@@ -237,36 +257,78 @@ def get_user_for_write_operation(
     user_info: Dict[str, Any] = Depends(get_current_user),
 ) -> Dict[str, Any]:
     """
-    Get current user and check group membership for write operations.
+    Dependency that guards POST, PUT, PATCH and DELETE endpoints.
 
-    This is the main dependency to use on POST, PUT, DELETE endpoints.
-    It will:
-    1. Always require authentication
-    2. If group-based access is enabled, check membership in allowed groups
-    3. If group-based access is disabled, allow all authenticated users
+    Two gates apply in order:
+
+    1. *Endpoint access*: if ``ENABLE_GROUP_BASED_ACCESS`` is on, the
+       user must belong to one of the configured groups, the endpoint
+       group, or carry the ``ndp_admin`` role. Disabled installations
+       skip this gate.
+    2. *Role*: the user must carry at least the writer tier
+       (``ndp_writer``, ``group:{ep_uuid}:writer``, ``ndp_admin``,
+       ``group:{ep_uuid}:admin`` or the legacy ``{ep_uuid}_admin``).
+       A user that satisfies the access gate but has no role assigned
+       is rejected — this is the deliberate strict default introduced
+       with the viewer/writer/admin model.
 
     Parameters
     ----------
     user_info : Dict[str, Any]
-        User information from get_current_user dependency
+        User information from :func:`get_current_user`.
 
     Returns
     -------
     Dict[str, Any]
-        User information if authorized
+        User information when both gates allow the call.
 
     Raises
     ------
     HTTPException
-        401 Unauthorized if not authenticated
-        403 Forbidden if group-based access is enabled and user
-        is not a member of any allowed group
+        401 if not authenticated; 403 if either gate denies.
     """
     if swagger_settings.enable_group_based_access:
-        return require_group_member(user_info)
-    else:
-        # Feature disabled, just return authenticated user
-        return user_info
+        require_group_member(user_info)
+
+    if not is_writer(user_info):
+        logger.warning(
+            "Write denied for user '%s' (sub=%s): no writer or admin role.",
+            user_info.get("username"),
+            user_info.get("sub"),
+        )
+        _raise_forbidden(
+            "You do not have permission to modify resources on this Endpoint. "
+            "Ask an administrator to grant you the writer or admin role."
+        )
+    return user_info
+
+
+def get_user_for_read_operation(
+    user_info: Dict[str, Any] = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """
+    Dependency for GET endpoints that should be limited to authenticated
+    readers. Mirrors :func:`get_user_for_write_operation` but accepts
+    viewer-tier users (in addition to writers and admins).
+
+    Not retrofitted onto the existing GET endpoints in the same release
+    that introduced the role tiers; available for future use on any new
+    read endpoint that wants role-gated access.
+    """
+    if swagger_settings.enable_group_based_access:
+        require_group_member(user_info)
+
+    if not is_viewer(user_info):
+        logger.warning(
+            "Read denied for user '%s' (sub=%s): no viewer, writer or admin role.",
+            user_info.get("username"),
+            user_info.get("sub"),
+        )
+        _raise_forbidden(
+            "You do not have permission to read resources on this Endpoint. "
+            "Ask an administrator to grant you a role."
+        )
+    return user_info
 
 
 def get_user_for_endpoint_access(
@@ -310,26 +372,85 @@ def get_user_for_endpoint_access(
     return user_info
 
 
-def is_admin(user_info: Dict[str, Any]) -> bool:
+def _has_any_role(user_info: Dict[str, Any], candidates) -> bool:
     """
-    Return True if the user has either the ``ndp_admin`` role or the
-    endpoint-specific admin role (``{AFFINITIES_EP_UUID}_admin``).
-    """
-    if _has_admin_role(user_info):
-        return True
+    Return True if the user carries any of the role names in ``candidates``.
 
-    ep_admin_role = endpoint_admin_role_name()
-    if not ep_admin_role:
+    Comparison is case-insensitive and ignores surrounding whitespace, so
+    a freshly assigned role like " group:UUID:admin " still matches.
+    Empty strings in ``candidates`` are skipped (callers may pass them
+    when AFFINITIES_EP_UUID is not configured).
+    """
+    targets = {c.strip().lower() for c in candidates if c}
+    if not targets:
         return False
-
     roles = user_info.get("roles", [])
     if not isinstance(roles, list):
         return False
-
-    target = ep_admin_role.strip().lower()
     return any(
-        isinstance(role, str) and role.strip().lower() == target for role in roles
+        isinstance(role, str) and role.strip().lower() in targets for role in roles
     )
+
+
+def is_admin(user_info: Dict[str, Any]) -> bool:
+    """
+    Return True if the user has admin tier on this endpoint.
+
+    Accepts any of:
+    - ``ndp_admin``                         (platform-wide)
+    - ``group:{AFFINITIES_EP_UUID}:admin``  (per-EP, canonical)
+    - ``{AFFINITIES_EP_UUID}_admin``        (per-EP, legacy form kept
+                                             for backwards compatibility)
+    """
+    return _has_any_role(
+        user_info,
+        [
+            ADMIN_ROLE_NAME,
+            endpoint_group_role_name("admin"),
+            endpoint_admin_role_name(),
+        ],
+    )
+
+
+def is_writer(user_info: Dict[str, Any]) -> bool:
+    """
+    Return True if the user has writer tier or above on this endpoint.
+    Admins are implicitly writers — they don't need both roles assigned.
+    """
+    if is_admin(user_info):
+        return True
+    return _has_any_role(
+        user_info,
+        [WRITER_ROLE_NAME, endpoint_group_role_name("writer")],
+    )
+
+
+def is_viewer(user_info: Dict[str, Any]) -> bool:
+    """
+    Return True if the user has viewer tier or above on this endpoint.
+    Writers (and therefore admins) are implicitly viewers.
+    """
+    if is_writer(user_info):
+        return True
+    return _has_any_role(
+        user_info,
+        [VIEWER_ROLE_NAME, endpoint_group_role_name("viewer")],
+    )
+
+
+def effective_role(user_info: Dict[str, Any]) -> str:
+    """
+    Return the highest role tier the user holds on this endpoint as one
+    of ``admin``, ``writer``, ``viewer`` or ``none``. The UI uses this
+    value to gate write-only actions client-side.
+    """
+    if is_admin(user_info):
+        return "admin"
+    if is_writer(user_info):
+        return "writer"
+    if is_viewer(user_info):
+        return "viewer"
+    return "none"
 
 
 def require_admin(

--- a/tests/test_aai_client.py
+++ b/tests/test_aai_client.py
@@ -132,12 +132,16 @@ class TestAssignRole:
         resp.json.return_value = {}
         mock_post.return_value = resp
 
-        aai_client.assign_role("tok", "my-role", "yutian")
+        aai_client.assign_role("tok", "writer", "yutian", "ep-group")
 
         mock_post.assert_called_once_with(
             "http://idp.example.com:5055/role/assign",
             headers={"Authorization": "Bearer tok"},
-            json={"role_name": "my-role", "username": "yutian"},
+            json={
+                "role_name": "writer",
+                "username": "yutian",
+                "group_name": "ep-group",
+            },
             timeout=15,
         )
 

--- a/tests/test_access_request_service.py
+++ b/tests/test_access_request_service.py
@@ -218,24 +218,20 @@ class TestApproveAccessRequest:
     )
     @patch("api.services.access_request_services.access_request_service.aai_client")
     @patch(
-        "api.services.access_request_services"
-        ".access_request_service.endpoint_admin_role_name"
-    )
-    @patch(
         "api.services.access_request_services" ".access_request_service.get_repository"
     )
-    def test_admin_grant_calls_add_user_and_assign_role(
+    def test_admin_grant_assigns_bare_admin_role_with_group_name(
         self,
         mock_get_repo,
-        mock_admin_role,
         mock_aai,
         mock_affinities,
         mock_settings,
         mock_repo,
     ):
+        """admin grant passes the bare tier name plus group_name; the AAI
+        builds the fully-qualified group:{uuid}:admin server-side."""
         mock_settings.enable_access_requests = True
         mock_affinities.ep_uuid = "ep-uuid"
-        mock_admin_role.return_value = "ep-uuid_admin"
         mock_repo.find_by_id.return_value = {
             "_id": "req1",
             "status": "pending",
@@ -253,7 +249,97 @@ class TestApproveAccessRequest:
         )
 
         mock_aai.add_user_to_group.assert_called_once_with("tok", "ep-uuid", "yutian")
-        mock_aai.assign_role.assert_called_once_with("tok", "ep-uuid_admin", "yutian")
+        mock_aai.assign_role.assert_called_once_with(
+            "tok", "admin", "yutian", "ep-uuid"
+        )
+
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.affinities_settings"
+    )
+    @patch("api.services.access_request_services.access_request_service.aai_client")
+    @patch(
+        "api.services.access_request_services" ".access_request_service.get_repository"
+    )
+    def test_viewer_grant_only_adds_to_group(
+        self,
+        mock_get_repo,
+        mock_aai,
+        mock_affinities,
+        mock_settings,
+        mock_repo,
+    ):
+        """viewer grant is the same as the AAI default join-the-group:
+        no role assignment is needed, since the AAI auto-assigns
+        viewer when a user joins a group."""
+        mock_settings.enable_access_requests = True
+        mock_affinities.ep_uuid = "ep-uuid"
+        mock_repo.find_by_id.return_value = {
+            "_id": "req1",
+            "status": "pending",
+            "username": "yutian",
+        }
+        mock_repo.mark_decided.return_value = {"_id": "req1", "status": "approved"}
+        mock_get_repo.return_value = mock_repo
+
+        access_request_service.approve_access_request(
+            request_id="req1",
+            admin_info={"sub": "as", "username": "raul"},
+            admin_token="tok",
+            grant_type="viewer",
+            notes=None,
+        )
+
+        mock_aai.add_user_to_group.assert_called_once_with("tok", "ep-uuid", "yutian")
+        mock_aai.assign_role.assert_not_called()
+
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.swagger_settings"
+    )
+    @patch(
+        "api.services.access_request_services"
+        ".access_request_service.affinities_settings"
+    )
+    @patch("api.services.access_request_services.access_request_service.aai_client")
+    @patch(
+        "api.services.access_request_services" ".access_request_service.get_repository"
+    )
+    def test_writer_grant_adds_to_group_and_assigns_writer_role(
+        self,
+        mock_get_repo,
+        mock_aai,
+        mock_affinities,
+        mock_settings,
+        mock_repo,
+    ):
+        """writer grant joins the group and assigns the per-EP writer role."""
+        mock_settings.enable_access_requests = True
+        mock_affinities.ep_uuid = "ep-uuid"
+        mock_repo.find_by_id.return_value = {
+            "_id": "req1",
+            "status": "pending",
+            "username": "yutian",
+        }
+        mock_repo.mark_decided.return_value = {"_id": "req1"}
+        mock_get_repo.return_value = mock_repo
+
+        access_request_service.approve_access_request(
+            request_id="req1",
+            admin_info={"sub": "as", "username": "raul"},
+            admin_token="tok",
+            grant_type="writer",
+            notes=None,
+        )
+
+        mock_aai.add_user_to_group.assert_called_once_with("tok", "ep-uuid", "yutian")
+        mock_aai.assign_role.assert_called_once_with(
+            "tok", "writer", "yutian", "ep-uuid"
+        )
 
     @patch(
         "api.services.access_request_services"

--- a/tests/test_authorization_service.py
+++ b/tests/test_authorization_service.py
@@ -9,9 +9,17 @@ from fastapi import HTTPException
 
 from api.services.auth_services.authorization_service import (
     ADMIN_ROLE_NAME,
+    VIEWER_ROLE_NAME,
+    WRITER_ROLE_NAME,
     check_group_membership,
+    effective_role,
+    endpoint_group_role_name,
     get_allowed_groups,
     get_user_for_endpoint_access,
+    get_user_for_read_operation,
+    is_admin,
+    is_viewer,
+    is_writer,
     normalize_group_path,
     require_group_member,
     get_user_for_write_operation,
@@ -293,8 +301,9 @@ class TestRequireGroupMember:
 class TestGetUserForWriteOperation:
     """Test cases for get_user_for_write_operation function."""
 
-    def test_feature_enabled_calls_require_group_member(self):
-        """Test that when feature is enabled, it calls require_group_member."""
+    def test_feature_enabled_with_writer_role_passes(self):
+        """When feature is enabled, the user still needs a writer/admin role
+        after passing the group membership check."""
         with patch(
             "api.services.auth_services.authorization_service.swagger_settings"
         ) as mock_settings:
@@ -304,23 +313,32 @@ class TestGetUserForWriteOperation:
                 mock_settings.enable_group_based_access = True
                 mock_require.return_value = {"user_id": "123"}
 
-                user_info = {"user_id": "123", "groups": ["admins"]}
+                # The user has writer-tier so the new role gate passes.
+                user_info = {
+                    "user_id": "123",
+                    "groups": ["admins"],
+                    "roles": [WRITER_ROLE_NAME],
+                }
                 result = get_user_for_write_operation(user_info)
 
-                assert result == {"user_id": "123"}
+                assert result == user_info
                 mock_require.assert_called_once_with(user_info)
 
-    def test_feature_disabled_returns_user_directly(self):
-        """Test that when feature is disabled, returns user info directly."""
+    def test_feature_disabled_still_requires_writer_role(self):
+        """Strict-default: even with group-based-access off, a user without
+        a writer/admin role cannot perform write operations."""
         with patch(
             "api.services.auth_services.authorization_service.swagger_settings"
         ) as mock_settings:
             mock_settings.enable_group_based_access = False
 
-            user_info = {"user_id": "123", "groups": []}
-            result = get_user_for_write_operation(user_info)
+            no_role_user = {"user_id": "123", "groups": [], "roles": []}
+            with pytest.raises(HTTPException) as exc:
+                get_user_for_write_operation(no_role_user)
+            assert exc.value.status_code == 403
 
-            assert result == user_info
+            writer_user = {"user_id": "123", "groups": [], "roles": [WRITER_ROLE_NAME]}
+            assert get_user_for_write_operation(writer_user) == writer_user
 
     def test_feature_enabled_unauthorized_user_raises_403(self):
         """Test that unauthorized user raises 403 when feature is enabled."""
@@ -655,3 +673,117 @@ class TestGetUserForEndpointAccess:
             )
             assert ADMIN_ROLE_NAME not in exc_info.value.detail
             assert "some-uuid" not in exc_info.value.detail
+
+
+class TestRoleTiers:
+    """Tests for the viewer/writer/admin role helpers."""
+
+    def _patch_uuid(self, uuid):
+        return patch(
+            "api.services.auth_services.authorization_service.affinities_settings",
+            ep_uuid=uuid,
+        )
+
+    EP = "11111111-2222-3333-4444-555555555555"
+
+    def test_is_admin_via_global_role(self):
+        assert is_admin({"roles": [ADMIN_ROLE_NAME]}) is True
+
+    def test_is_admin_via_canonical_per_ep_role(self):
+        with self._patch_uuid(self.EP):
+            user = {"roles": [f"group:{self.EP}:admin"]}
+            assert is_admin(user) is True
+
+    def test_is_admin_via_legacy_per_ep_role_is_still_supported(self):
+        with self._patch_uuid(self.EP):
+            user = {"roles": [f"{self.EP}_admin"]}
+            assert is_admin(user) is True
+
+    def test_is_admin_rejects_unrelated_roles(self):
+        with self._patch_uuid(self.EP):
+            assert is_admin({"roles": ["unrelated"]}) is False
+            assert is_admin({"roles": []}) is False
+            assert is_admin({}) is False
+
+    def test_is_writer_includes_writer_and_admin_but_not_viewer(self):
+        with self._patch_uuid(self.EP):
+            assert is_writer({"roles": [WRITER_ROLE_NAME]}) is True
+            assert is_writer({"roles": [f"group:{self.EP}:writer"]}) is True
+            assert is_writer({"roles": [ADMIN_ROLE_NAME]}) is True
+            assert is_writer({"roles": [VIEWER_ROLE_NAME]}) is False
+            assert is_writer({"roles": [f"group:{self.EP}:viewer"]}) is False
+            assert is_writer({"roles": []}) is False
+
+    def test_is_viewer_includes_every_tier_above_none(self):
+        with self._patch_uuid(self.EP):
+            assert is_viewer({"roles": [VIEWER_ROLE_NAME]}) is True
+            assert is_viewer({"roles": [f"group:{self.EP}:viewer"]}) is True
+            assert is_viewer({"roles": [WRITER_ROLE_NAME]}) is True
+            assert is_viewer({"roles": [ADMIN_ROLE_NAME]}) is True
+            assert is_viewer({"roles": []}) is False
+
+    def test_effective_role_returns_highest_tier(self):
+        with self._patch_uuid(self.EP):
+            assert effective_role({"roles": []}) == "none"
+            assert effective_role({"roles": [VIEWER_ROLE_NAME]}) == "viewer"
+            assert effective_role({"roles": [WRITER_ROLE_NAME]}) == "writer"
+            # Admin wins even when paired with writer/viewer.
+            assert (
+                effective_role(
+                    {"roles": [VIEWER_ROLE_NAME, WRITER_ROLE_NAME, ADMIN_ROLE_NAME]}
+                )
+                == "admin"
+            )
+
+    def test_endpoint_group_role_name_emits_canonical_format(self):
+        with self._patch_uuid(self.EP):
+            assert endpoint_group_role_name("admin") == f"group:{self.EP}:admin"
+            assert endpoint_group_role_name("writer") == f"group:{self.EP}:writer"
+            assert endpoint_group_role_name("viewer") == f"group:{self.EP}:viewer"
+
+    def test_endpoint_group_role_name_returns_empty_when_uuid_missing(self):
+        with self._patch_uuid(""):
+            assert endpoint_group_role_name("writer") == ""
+
+    def test_role_comparison_is_case_and_whitespace_insensitive(self):
+        with self._patch_uuid(self.EP):
+            assert is_admin({"roles": ["  NDP_ADMIN  "]}) is True
+            assert is_writer({"roles": ["NDP_WRITER"]}) is True
+
+
+class TestGetUserForReadOperation:
+    """Tests for the new viewer-tier dependency."""
+
+    def test_viewer_passes(self):
+        with patch(
+            "api.services.auth_services.authorization_service.swagger_settings"
+        ) as mock_settings:
+            mock_settings.enable_group_based_access = False
+            user = {"roles": [VIEWER_ROLE_NAME]}
+            assert get_user_for_read_operation(user) == user
+
+    def test_writer_passes(self):
+        with patch(
+            "api.services.auth_services.authorization_service.swagger_settings"
+        ) as mock_settings:
+            mock_settings.enable_group_based_access = False
+            user = {"roles": [WRITER_ROLE_NAME]}
+            assert get_user_for_read_operation(user) == user
+
+    def test_admin_passes(self):
+        with patch(
+            "api.services.auth_services.authorization_service.swagger_settings"
+        ) as mock_settings:
+            mock_settings.enable_group_based_access = False
+            user = {"roles": [ADMIN_ROLE_NAME]}
+            assert get_user_for_read_operation(user) == user
+
+    def test_no_role_is_rejected(self):
+        with patch(
+            "api.services.auth_services.authorization_service.swagger_settings"
+        ) as mock_settings:
+            mock_settings.enable_group_based_access = False
+            with pytest.raises(HTTPException) as exc:
+                get_user_for_read_operation({"roles": []})
+            assert exc.value.status_code == 403
+            assert "read resources" in exc.value.detail

--- a/tests/test_user_info_route.py
+++ b/tests/test_user_info_route.py
@@ -49,3 +49,20 @@ def test_user_info_response_is_a_copy_not_a_mutation():
 
     assert "ndp_user_id" in response
     assert "ndp_user_id" not in upstream
+    assert "effective_role" not in upstream
+
+
+def test_user_info_response_includes_effective_role():
+    """The enriched response carries the highest role tier the user holds."""
+    no_role = _call({"sub": "u1", "roles": []})
+    assert no_role["effective_role"] == "none"
+
+    admin = _call({"sub": "u2", "roles": ["ndp_admin"]})
+    assert admin["effective_role"] == "admin"
+
+
+def test_user_info_response_does_not_overwrite_upstream_effective_role():
+    """If the upstream payload already carries effective_role, don't clobber it."""
+    upstream = {"sub": "u3", "roles": [], "effective_role": "upstream-set"}
+    response = _call(upstream)
+    assert response["effective_role"] == "upstream-set"

--- a/ui/src/components/Navigation.js
+++ b/ui/src/components/Navigation.js
@@ -32,18 +32,28 @@ const Navigation = () => {
   const newButtonRef = useRef(null);
   const newTimeoutRef = useRef(null);
   const [isAdmin, setIsAdmin] = useState(false);
+  // canWrite drives the visibility of the "+ New" menu — viewers and
+  // users with no role can browse but cannot create new resources.
+  const [canWrite, setCanWrite] = useState(false);
 
-  // Determine admin status from the current token's /user/info response so
-  // the "Access Requests" entry is only shown to users that can use it.
+  // Determine admin and write-capability status from the current token's
+  // /user/info response so the admin-only and writer-only entries are
+  // only shown to users that can actually use them.
   useEffect(() => {
     let cancelled = false;
     userAPI
       .getUserInfo()
       .then((response) => {
-        if (!cancelled) setIsAdmin(isAccessRequestAdmin(response.data));
+        if (cancelled) return;
+        setIsAdmin(isAccessRequestAdmin(response.data));
+        const role = response.data?.effective_role || 'none';
+        setCanWrite(role === 'admin' || role === 'writer');
       })
       .catch(() => {
-        if (!cancelled) setIsAdmin(false);
+        if (!cancelled) {
+          setIsAdmin(false);
+          setCanWrite(false);
+        }
       });
     return () => {
       cancelled = true;
@@ -377,7 +387,8 @@ const Navigation = () => {
                 )}
               </div>
 
-              {/* + New menu (compact entry point for create flows) */}
+              {/* + New menu — only visible to users that can write */}
+              {canWrite && (
               <div
                 style={{ position: 'relative' }}
                 onMouseEnter={handleNewMenuEnter}
@@ -525,6 +536,7 @@ const Navigation = () => {
                   </div>
                 )}
               </div>
+              )}
 
               {/* Dashboard (admin only) */}
               {isAdmin && (

--- a/ui/src/pages/AccessRequests.js
+++ b/ui/src/pages/AccessRequests.js
@@ -83,7 +83,7 @@ const AccessRequests = () => {
   const openApproveDraft = (id) => {
     setApproveDraft((prev) => ({
       ...prev,
-      [id]: prev[id] || { grant: 'member', notes: '' },
+      [id]: prev[id] || { grant: 'viewer', notes: '' },
     }));
     setRejectDraft((prev) => {
       if (!(id in prev)) return prev;
@@ -121,7 +121,7 @@ const AccessRequests = () => {
   };
 
   const handleApprove = async (id) => {
-    const draft = approveDraft[id] || { grant: 'member', notes: '' };
+    const draft = approveDraft[id] || { grant: 'viewer', notes: '' };
     try {
       setBusyId(id);
       setActionError(null);
@@ -454,43 +454,34 @@ const AccessRequests = () => {
                         <div style={{ fontSize: '0.85rem', color: '#374151', fontWeight: 600 }}>
                           Approve request — choose grant
                         </div>
-                        <div style={{ display: 'flex', gap: '1rem', fontSize: '0.85rem', color: '#374151' }}>
-                          <label style={{ display: 'flex', alignItems: 'center', gap: '0.3rem' }}>
-                            <input
-                              type="radio"
-                              name={`grant-${req.id}`}
-                              value="member"
-                              checked={approveDraft[req.id]?.grant === 'member'}
-                              onChange={() =>
-                                setApproveDraft((prev) => ({
-                                  ...prev,
-                                  [req.id]: {
-                                    ...(prev[req.id] || { notes: '' }),
-                                    grant: 'member',
-                                  },
-                                }))
-                              }
-                            />
-                            Member (access to the Endpoint)
-                          </label>
-                          <label style={{ display: 'flex', alignItems: 'center', gap: '0.3rem' }}>
-                            <input
-                              type="radio"
-                              name={`grant-${req.id}`}
-                              value="admin"
-                              checked={approveDraft[req.id]?.grant === 'admin'}
-                              onChange={() =>
-                                setApproveDraft((prev) => ({
-                                  ...prev,
-                                  [req.id]: {
-                                    ...(prev[req.id] || { notes: '' }),
-                                    grant: 'admin',
-                                  },
-                                }))
-                              }
-                            />
-                            Admin (access + manage future requests)
-                          </label>
+                        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', fontSize: '0.85rem', color: '#374151' }}>
+                          {[
+                            { value: 'viewer', label: 'Viewer (read-only)' },
+                            { value: 'writer', label: 'Writer (can modify catalog)' },
+                            { value: 'admin', label: 'Admin (full access + manage future requests)' }
+                          ].map((opt) => (
+                            <label
+                              key={opt.value}
+                              style={{ display: 'flex', alignItems: 'center', gap: '0.3rem' }}
+                            >
+                              <input
+                                type="radio"
+                                name={`grant-${req.id}`}
+                                value={opt.value}
+                                checked={approveDraft[req.id]?.grant === opt.value}
+                                onChange={() =>
+                                  setApproveDraft((prev) => ({
+                                    ...prev,
+                                    [req.id]: {
+                                      ...(prev[req.id] || { notes: '' }),
+                                      grant: opt.value
+                                    }
+                                  }))
+                                }
+                              />
+                              {opt.label}
+                            </label>
+                          ))}
                         </div>
                         <textarea
                           value={approveDraft[req.id]?.notes || ''}

--- a/ui/src/pages/Search.js
+++ b/ui/src/pages/Search.js
@@ -51,6 +51,10 @@ const Search = () => {
   // that comes back in /user/info.
   const [onlyMine, setOnlyMine] = useState(false);
   const [myUserHash, setMyUserHash] = useState(null);
+  // canWrite gates the Delete and Publish actions on result cards. We
+  // do not need a separate `isViewer` flag — viewers can browse, and
+  // any tier above viewer is by definition `canWrite`.
+  const [canWrite, setCanWrite] = useState(false);
   // Names of organizations the current user owns on the *local* catalog.
   // The Search page uses this to show a Delete action on org cards that
   // belong to the user. Only local because the delete endpoint targets
@@ -67,18 +71,23 @@ const Search = () => {
     inputRef.current?.focus();
   }, []);
 
-  // Fetch the user's own ndp_user_id once on mount. The backend
-  // enriches /user/info with this hash, so the UI does not have to
-  // decode the JWT or compute SHA-256 in the browser.
+  // Fetch the user's own ndp_user_id and effective role once on mount.
+  // /user/info exposes both, so the UI does not have to decode the JWT,
+  // compute SHA-256, or re-implement the role-tier logic in the browser.
   useEffect(() => {
     let cancelled = false;
     userAPI
       .getUserInfo()
       .then((response) => {
-        if (!cancelled) setMyUserHash(response.data?.ndp_user_id || null);
+        if (cancelled) return;
+        setMyUserHash(response.data?.ndp_user_id || null);
+        const role = response.data?.effective_role || 'none';
+        setCanWrite(role === 'admin' || role === 'writer');
       })
       .catch(() => {
-        if (!cancelled) setMyUserHash(null);
+        if (cancelled) return;
+        setMyUserHash(null);
+        setCanWrite(false);
       });
     return () => {
       cancelled = true;
@@ -528,7 +537,7 @@ const Search = () => {
           emptyMessage="No datasets matched your search."
           isService={false}
           myUserHash={myUserHash}
-          canDelete={server === 'local'}
+          canDelete={server === 'local' && canWrite}
           onDelete={handleDeleteDataset}
           mapDeleteError={friendlyDatasetDeleteError}
           onPublish={handlePublishDataset}
@@ -544,7 +553,7 @@ const Search = () => {
           emptyMessage="No services matched your search."
           isService
           myUserHash={myUserHash}
-          canDelete={server === 'local'}
+          canDelete={server === 'local' && canWrite}
           onDelete={handleDeleteService}
           mapDeleteError={friendlyServiceDeleteError}
         />
@@ -559,7 +568,7 @@ const Search = () => {
             items={organizationResults}
             onViewDatasets={handleViewDatasetsInOrg}
             ownedOrgNames={myLocalOrgNames}
-            canDelete={server === 'local'}
+            canDelete={server === 'local' && canWrite}
             onDelete={handleDeleteOrg}
             mapDeleteError={friendlyDeleteError}
           />


### PR DESCRIPTION
## Summary
- Adds two new role tiers — **viewer** (read-only) and **writer** (modify catalog content) — alongside the existing **admin**, with a strict default: a user in the EP group but with no role assigned can no longer perform write operations.
- Roles are accepted in two flavours each, mirroring how admin already worked: `ndp_{tier}` global plus the per-EP `group:{AFFINITIES_EP_UUID}:{tier}` canonical Keycloak form. The legacy `{AFFINITIES_EP_UUID}_admin` per-EP admin form is still accepted (no matcher removed).
- New auth helpers: `is_writer`, `is_viewer`, `effective_role`, `endpoint_group_role_name`, `get_user_for_read_operation`. `is_admin` and `get_user_for_write_operation` are updated. `get_user_for_endpoint_access` is unchanged.
- `GET /user/info` carries a new `effective_role` field (`admin`/`writer`/`viewer`/`none`) so clients can gate write actions without reimplementing the role logic in the browser.
- The Access Requests approval form replaces the "Member / Admin" radios with **Viewer / Writer / Admin** (default Viewer). The backend `grant_type` accepts `viewer` / `writer` / `admin`, with `member` kept as a deprecated alias for `viewer` so existing API clients keep working.
- `aai_client.assign_role` now takes a bare tier name plus `group_name` — the AAI builds `group:{group_name}:{tier}` server-side. The previous signature double-prefixed and failed with HTTP 401 "Missing token or group" whenever the approve flow tried to assign a non-viewer role, surfacing in the UI as a spurious "your session has expired" reload loop.
- UI gating: the "+ New" menu and the Delete / Publish actions on owned cards in Search are hidden for viewers and users with no role.

## Backwards compatibility
- Strict default: users that today belong to the EP group but have no role assigned were implicitly writers before this release; they now become "none" and lose write access until an administrator assigns them a role. The approval flow's AAI integration assigns the viewer role automatically on group join, so newly approved users land as viewers by default.
- No request/response payload shapes change. The only addition on `/user/info` is `effective_role`, and clients that ignore unknown keys can safely ignore it.
- Existing `member` clients of the approval endpoint keep working: the value is now a deprecated alias for `viewer`.
- The legacy `{AFFINITIES_EP_UUID}_admin` matcher keeps working; we added matchers, we did not remove them.
- The realm roles `ndp_writer`, `ndp_viewer`, and the per-EP `group:{uuid}:writer` and `group:{uuid}:viewer` forms have to exist in the realm before they can be assigned. The EP does not expose role creation; that step happens in Keycloak's admin console.

## Test plan
- [x] Backend tests: 1152 pass (+19 vs 0.27.4). New coverage: per-tier helpers, per-EP role matchers (canonical + legacy), `effective_role`, `get_user_for_read_operation`, the three approval paths (viewer/writer/admin), the new `assign_role` signature, and `/user/info`'s `effective_role` enrichment.
- [x] Lint: `black --check .` clean. `flake8` shows only the preexisting warnings already present on `main`.
- [x] End-to-end smoke tests with `raul` / `raul` (admin) and `writer` / `writer` against the running container:
  - admin writes succeed (`POST /organization` → 201).
  - viewer is rejected (`POST /organization` → 403 with the friendly "ask an administrator to grant you the writer or admin role" message).
  - writer writes succeed (201).
  - Approving `writer` user via `POST /user/access-requests/{id}/approve` with `grant_type="writer"` returns 200, the user's `/user/info` shows `effective_role: writer`, and the user can immediately create resources.
- [x] UI smoke tests:
  - "+ New" hidden for viewer/none, visible for writer/admin.
  - Delete/Publish on owned cards hidden for viewer/none, visible for writer/admin.
  - Access Requests page shows three radios; selecting Writer + Confirm approves without the previous spurious "session expired" reload.

Closes #171.