### PR TITLE
Roles documentation + surface it in UI, Swagger and README (closes #173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.1] - 2026-05-19
+
+### Added
+- `docs/roles-and-permissions.md`: operator/support reference for the role model. Covers the three tiers and what each can do, the `ndp_{tier}` and `group:{AFFINITIES_EP_UUID}:{tier}` naming convention (and the legacy `{uuid}_admin` form), how `effective_role` is derived and where that code lives, how realm roles reach the JWT through the client's protocol mapper (with the empirically-verified note that newly created realm roles need no per-role client change), the AAI API surface for role/group management with exact request shapes, the "editor (AAI) vs writer (EP)" gotcha, and step-by-step guidance for the two "I need more roles" scenarios (reuse an existing tier in another group = config only, vs. a new permission level = Endpoint code change) plus when to escalate to NDP support.
+
 ## [0.28.0] - 2026-05-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.28.1] - 2026-05-19
+## [0.29.0] - 2026-05-19
 
 ### Added
 - `docs/roles-and-permissions.md`: operator/support reference for the role model. Covers the three tiers and what each can do, the `ndp_{tier}` and `group:{AFFINITIES_EP_UUID}:{tier}` naming convention (and the legacy `{uuid}_admin` form), how `effective_role` is derived and where that code lives, how realm roles reach the JWT through the client's protocol mapper (with the empirically-verified note that newly created realm roles need no per-role client change), the AAI API surface for role/group management with exact request shapes, the "editor (AAI) vs writer (EP)" gotcha, and step-by-step guidance for the two "I need more roles" scenarios (reuse an existing tier in another group = config only, vs. a new permission level = Endpoint code change) plus when to escalate to NDP support.
+- The same role reference is now reachable three ways:
+  - **UI**: a new `/roles-help` page renders the guide in-app. The Access Requests page gained an **"Add more roles"** button next to Refresh that opens it, and the page links out to the full markdown reference on GitHub.
+  - **Swagger**: the `POST /user/access-requests/{id}/approve` endpoint description now explains all three tiers (plus the deprecated `member` alias), the role naming convention, and points to `docs/roles-and-permissions.md`.
+  - **README**: a "Role tiers" subsection under Group-Based Access Control links the doc and mentions the in-UI button.
+
+### Backwards compatibility
+- Additive only: one new UI route, one new button, an expanded Swagger description, a README link. No API behavior, request/response shapes or existing routes change.
 
 ## [0.28.0] - 2026-05-18
 

--- a/README.md
+++ b/README.md
@@ -393,6 +393,16 @@ The user **will be authorized** because `data-managers` is in both the user's gr
 - GET endpoints remain public regardless of this setting
 - If `ENABLE_GROUP_BASED_ACCESS=True` but `GROUP_NAMES` is empty, all write operations will be denied
 
+### Role tiers (viewer / writer / admin)
+
+On top of group membership, the Endpoint enforces three role tiers —
+**viewer** (read-only), **writer** (modify catalog content) and **admin**
+(everything). See **[Roles and permissions](docs/roles-and-permissions.md)**
+for the full model: how roles are named, how they reach the JWT, the AAI
+role-management API, and how to grant a tier or introduce a brand-new
+permission level. The same reference is available inside the UI from the
+**Access Requests → Add more roles** button.
+
 ## 📖 Usage Examples
 
 For detailed usage examples and tutorials, please check the documentation in the `/docs` folder.

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.28.1"
+    swagger_version: str = "0.29.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.28.0"
+    swagger_version: str = "0.28.1"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/routes/user_routes/access_requests.py
+++ b/api/routes/user_routes/access_requests.py
@@ -84,9 +84,21 @@ async def list_requests(
     response_model=AccessRequest,
     summary="Approve an access request (admin only)",
     description=(
-        "Approve a pending access request. The administrator chooses what to "
-        "grant via `grant_type`: `member` adds the user to the endpoint "
-        "group, `admin` also assigns the endpoint admin role.\n\n"
+        "Approve a pending access request. The administrator chooses the "
+        "role tier to grant via `grant_type`:\n\n"
+        "- **viewer** — adds the user to the endpoint group; read-only "
+        "access. (The AAI assigns the viewer role automatically on join.)\n"
+        "- **writer** — group membership plus the per-endpoint writer "
+        "role; can create, edit, delete and publish catalog content.\n"
+        "- **admin** — group membership plus the per-endpoint admin "
+        "role; full access including managing access requests.\n"
+        "- **member** — deprecated alias for `viewer`, kept so existing "
+        "clients keep working.\n\n"
+        "Roles are Keycloak realm roles named `ndp_{tier}` (platform-wide) "
+        "or `group:{AFFINITIES_EP_UUID}:{tier}` (per-endpoint). For the "
+        "full role model, how roles reach the JWT, the AAI role-management "
+        "API, and how to introduce a brand-new permission level, see "
+        "`docs/roles-and-permissions.md` in the repository.\n\n"
         "The IDP write is performed using the administrator's own bearer "
         "token, so no service account is involved."
     ),

--- a/docs/roles-and-permissions.md
+++ b/docs/roles-and-permissions.md
@@ -1,0 +1,227 @@
+# Roles and permissions
+
+This document explains the role model the Endpoint (EP) enforces, how a
+user's roles travel from Keycloak into the JWT, and the exact steps to
+grant access or introduce a new role. It is aimed at deployment
+operators and at NDP support.
+
+> TL;DR
+> - The EP understands three tiers: **viewer** (read), **writer**
+>   (modify catalog content) and **admin** (everything).
+> - Roles are Keycloak **realm roles** named either `ndp_{tier}`
+>   (platform-wide) or `group:{AFFINITIES_EP_UUID}:{tier}` (per-EP).
+> - Assigning an existing tier to a user is **configuration only** (AAI
+>   API or the Access Requests screen). A genuinely new permission level
+>   requires an **Endpoint code change** (see
+>   [Scenario B](#scenario-b-a-brand-new-permission-level)).
+
+---
+
+## 1. The three tiers
+
+| Tier   | Can do | Implied lower tiers |
+| ------ | ------ | ------------------- |
+| viewer | Read / browse only (Search, view details). | — |
+| writer | Everything a viewer can, plus create / edit / delete / publish catalog content. | viewer |
+| admin  | Everything a writer can, plus manage access requests and admin-only pages. | writer, viewer |
+
+The tiers are hierarchical: an **admin** does not also need the writer
+and viewer roles, and a **writer** does not also need viewer. The
+Endpoint resolves the highest tier the user holds.
+
+**Strict default:** a user who is a member of the EP group but holds
+**no** recognised role is treated as `none` and cannot perform any write
+operation. They can still authenticate and read.
+
+---
+
+## 2. Role naming convention
+
+Every recognised role is a Keycloak **realm role**. Two forms are
+accepted for each tier:
+
+| Tier   | Platform-wide (any EP) | Per-endpoint                                |
+| ------ | ---------------------- | ------------------------------------------- |
+| admin  | `ndp_admin`            | `group:{AFFINITIES_EP_UUID}:admin`          |
+| writer | `ndp_writer`           | `group:{AFFINITIES_EP_UUID}:writer`         |
+| viewer | `ndp_viewer`           | `group:{AFFINITIES_EP_UUID}:viewer`         |
+
+`{AFFINITIES_EP_UUID}` is the value of the `AFFINITIES_EP_UUID`
+environment variable for this deployment (it is also the name of the
+endpoint's Keycloak group). Example for the dev EP whose UUID is
+`96207a63-ee21-40c8-a492-31d680002330`:
+
+```
+group:96207a63-ee21-40c8-a492-31d680002330:writer
+```
+
+The legacy per-EP admin form `{AFFINITIES_EP_UUID}_admin` (no `group:`
+prefix, underscore before `admin`) is **also** still accepted for admin,
+for backwards compatibility. New deployments should prefer the
+`group:{uuid}:admin` form.
+
+> **Gotcha — "editor" vs "writer".** The AAI's own group model uses the
+> default role names `admin` / `editor` / `viewer`. The Endpoint, by
+> contrast, recognises `admin` / `writer` / `viewer`. Assigning the
+> AAI's `editor` role does **not** grant write access on the EP — you
+> must assign `writer`. Only `admin`, `writer` and `viewer` are mapped
+> to EP permissions.
+
+---
+
+## 3. How the Endpoint sees roles
+
+When a user authenticates, the AAI returns their realm roles in the
+`roles` claim. `GET /user/info` exposes them, plus a derived
+`effective_role` field that is the single value the UI and API gating
+rely on:
+
+```jsonc
+GET /user/info
+{
+  "username": "raul",
+  "sub": "6bfaa6c3-…",
+  "roles": ["ndp_admin", "group:96207a63-…:admin", "default-roles-ndp"],
+  "effective_role": "admin"      // admin | writer | viewer | none
+}
+```
+
+The matching logic lives in
+[`api/services/auth_services/authorization_service.py`](../api/services/auth_services/authorization_service.py):
+
+- `is_admin`, `is_writer`, `is_viewer` — tier checks (each implies the
+  lower tiers).
+- `effective_role` — returns the highest tier as a string.
+- `get_user_for_write_operation` — the FastAPI dependency guarding every
+  `POST`/`PUT`/`PATCH`/`DELETE`; rejects callers below writer with `403`.
+- `get_user_for_read_operation` — viewer-or-above dependency, available
+  for future read endpoints.
+
+Any realm role that does not match one of the six names in the table
+above is carried in the token but **ignored** by the EP for permission
+purposes (it will not raise `effective_role` above what the recognised
+roles grant).
+
+---
+
+## 4. How roles reach the JWT (the "Keycloak client" question)
+
+Roles are emitted into the token by a **protocol mapper** on the
+Keycloak client (`oidc-usermodel-realm-role-mapper`, claim name
+`roles`). This mapper is configured once, when the client is created by
+the AAI (see `create_client` in the AAI's
+`services/direct_keycloak/client_service.py`).
+
+**You do not need to touch the Keycloak client when you add a new realm
+role.** Because the mapper emits the user's realm roles wholesale, a
+newly created `group:{uuid}:…` role appears in the token as soon as it
+is assigned — no per-role client change, no client-scope edit.
+
+This was verified empirically: creating a brand-new realm role
+`group:{uuid}:probe-doc`, assigning it to a user, and re-reading
+`GET /user/info` showed the role present in `roles` immediately, with no
+client modification. (`effective_role` stayed `viewer` because
+`probe-doc` is not a recognised tier — see
+[Scenario B](#scenario-b-a-brand-new-permission-level).)
+
+The only situation where the client *would* matter is a deployment whose
+client was created **without** the realm-roles mapper, or one relying on
+client-specific roles (`resource_access.{client}.roles`) instead of
+realm roles. The standard AAI-provisioned client already includes the
+mapper, so this is not a concern for normal deployments.
+
+---
+
+## 5. AAI API for role and group management
+
+The AAI API (base URL = `AUTH_API_URL` host) is authoritative for group
+and role writes; it wraps the Keycloak Admin API and enforces that the
+caller is a group admin/editor. All calls take the caller's own Bearer
+token.
+
+| Action | Endpoint | Body | Notes |
+| ------ | -------- | ---- | ----- |
+| Create a custom role in a group | `POST /role/create` | `{groupName, roleName, users?:[]}` | `roleName` is the bare tier (e.g. `writer`); the AAI builds `group:{groupName}:{roleName}`. The names `admin`/`editor`/`viewer` are reserved and cannot be created. Caller must be group editor. |
+| Assign a role to user(s) | `POST /role/assign` | `{groupName, roleName, username \| users:[]}` | `roleName` is the **bare** tier — do **not** pass the fully-qualified `group:…:writer` string (it double-prefixes). Assigning `admin` requires the caller to be a group admin. |
+| Remove a role from user(s) | `DELETE /role/remove` | `{groupName, roleName, username \| users:[]}` | |
+| Delete a custom role | `DELETE /role/delete` | `{groupName, roleName}` | Cannot delete `admin`/`editor`/`viewer`. Caller must be group admin. |
+| Add user to a group | `POST /group/add-user` | `{group_name, username}` | The AAI assigns the `viewer` role automatically on join. |
+| List group members | `GET /group/members?group_name=…` | — | |
+
+The Endpoint's own thin wrapper around these lives in
+[`api/services/auth_services/aai_client.py`](../api/services/auth_services/aai_client.py)
+(`assign_role`, `add_user_to_group`, `list_group_members`).
+
+---
+
+## 6. Common tasks
+
+### Grant an existing tier to a user
+
+**Via the UI (preferred).** When a user requests access, an admin
+approves the request on the **Access Requests** page and picks the tier
+(Viewer / Writer / Admin). This adds the user to the EP group and
+assigns the chosen per-EP role.
+
+**Via the AAI API.** Add the user to the group (this gives them
+`viewer`), then assign a higher tier if needed:
+
+```bash
+TOKEN=$(curl -s -X POST "$AAI/user/login" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"<admin>","password":"<pass>"}' | jq -r .access_token)
+
+# join the group (auto-assigns viewer)
+curl -s -X POST "$AAI/group/add-user" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"group_name":"<EP_UUID>","username":"<user>"}'
+
+# upgrade to writer (bare tier name + groupName)
+curl -s -X POST "$AAI/role/assign" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"groupName":"<EP_UUID>","roleName":"writer","username":"<user>"}'
+```
+
+The user must **re-login** afterwards: their old JWT was issued before
+the grant and will not contain the new role until a fresh token is
+minted.
+
+### Scenario A: reuse an existing tier in another group
+
+Nothing in the Endpoint changes. Create/assign the
+`group:{OTHER_UUID}:viewer|writer|admin` roles for that group. The
+Endpoint only ever evaluates roles for **its own** `AFFINITIES_EP_UUID`,
+so per-group roles for other endpoints are naturally isolated.
+
+### Scenario B: a brand-new permission level
+
+If you need a tier that is **not** viewer/writer/admin (say, a
+`publisher` that can publish but not delete), two things are required:
+
+1. **Create the role** in Keycloak / via the AAI as usual
+   (`group:{uuid}:publisher`). It will appear in the token automatically
+   (Section 4).
+2. **Teach the Endpoint about it** — a code change in
+   [`authorization_service.py`](../api/services/auth_services/authorization_service.py):
+   add a matcher (e.g. `is_publisher`), fold it into `effective_role`,
+   and gate the relevant routes/dependencies. Without this step the role
+   rides in the token but grants nothing (`effective_role` ignores it).
+
+Step 2 is the part that "request to NDP support" covers when an operator
+cannot change the Endpoint code themselves.
+
+---
+
+## 7. When to request NDP support
+
+Open a request with NDP support when you need something that is not a
+plain assignment of an existing tier:
+
+- A new permission level that the Endpoint must enforce (Scenario B).
+- Changes to the Keycloak client itself (new protocol mappers, switching
+  to client roles) — only relevant for non-standard clients (Section 4).
+- Realm-level changes you do not have admin rights for.
+
+For everything else — granting viewer/writer/admin to a user, creating a
+per-group custom role, listing members — use the Access Requests screen
+or the AAI API directly.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,8 +26,11 @@ server {
     }
 
     # Redirect ${ROOT_PATH}/ui to ${ROOT_PATH}/ui/
+    # Use a relative redirect so the non-standard port (e.g. :8002) is
+    # preserved — \$host drops it, sending the browser to port 80.
     location = ${ROOT_PATH}/ui {
-        return 301 \$scheme://\$host\$request_uri/;
+        absolute_redirect off;
+        return 301 ${ROOT_PATH}/ui/;
     }
 
     # Alternative API path (also works via ${ROOT_PATH}/api/)

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -12,6 +12,7 @@ import Services from './pages/Services';
 import Search from './pages/Search';
 import DatasetManagement from './pages/DatasetManagement';
 import AccessRequests from './pages/AccessRequests';
+import RolesHelp from './pages/RolesHelp';
 import './styles/global.css';
 
 /**
@@ -49,6 +50,9 @@ function App() {
 
               {/* Access request management route (admin-gated on backend) */}
               <Route path="/access-requests" element={<AccessRequests />} />
+
+              {/* Roles & permissions documentation */}
+              <Route path="/roles-help" element={<RolesHelp />} />
             </Routes>
           </Layout>
         </Router>

--- a/ui/src/pages/AccessRequests.js
+++ b/ui/src/pages/AccessRequests.js
@@ -6,7 +6,9 @@ import {
   RefreshCw,
   ShieldAlert,
   XCircle,
+  BookOpen,
 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { accessRequestsAPI } from '../services/api';
 
 const STATUS_TABS = [
@@ -34,6 +36,7 @@ const formatDate = (value) => {
  * Admin-only page to review and act on access requests.
  */
 const AccessRequests = () => {
+  const navigate = useNavigate();
   const [requests, setRequests] = useState([]);
   const [statusFilter, setStatusFilter] = useState('pending');
   const [loading, setLoading] = useState(false);
@@ -180,27 +183,49 @@ const AccessRequests = () => {
           <ShieldAlert size={24} style={{ verticalAlign: 'middle', marginRight: '0.5rem' }} />
           Access Requests
         </h1>
-        <button
-          type="button"
-          onClick={fetchRequests}
-          disabled={loading}
-          style={{
-            padding: '0.55rem 0.9rem',
-            backgroundColor: 'white',
-            border: '1px solid #cbd5e1',
-            borderRadius: '6px',
-            cursor: loading ? 'not-allowed' : 'pointer',
-            color: '#374151',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.4rem',
-            fontSize: '0.85rem',
-            fontWeight: 500,
-          }}
-        >
-          <RefreshCw size={14} />
-          Refresh
-        </button>
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            onClick={() => navigate('/roles-help')}
+            style={{
+              padding: '0.55rem 0.9rem',
+              backgroundColor: 'white',
+              border: '1px solid #cbd5e1',
+              borderRadius: '6px',
+              cursor: 'pointer',
+              color: '#374151',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.4rem',
+              fontSize: '0.85rem',
+              fontWeight: 500,
+            }}
+          >
+            <BookOpen size={14} />
+            Add more roles
+          </button>
+          <button
+            type="button"
+            onClick={fetchRequests}
+            disabled={loading}
+            style={{
+              padding: '0.55rem 0.9rem',
+              backgroundColor: 'white',
+              border: '1px solid #cbd5e1',
+              borderRadius: '6px',
+              cursor: loading ? 'not-allowed' : 'pointer',
+              color: '#374151',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.4rem',
+              fontSize: '0.85rem',
+              fontWeight: 500,
+            }}
+          >
+            <RefreshCw size={14} />
+            Refresh
+          </button>
+        </div>
       </div>
 
       {/* Tabs */}

--- a/ui/src/pages/RolesHelp.js
+++ b/ui/src/pages/RolesHelp.js
@@ -1,0 +1,191 @@
+import React from 'react';
+import { ShieldAlert, ArrowLeft, ExternalLink } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+
+/**
+ * In-app runbook for adding a new role. Deliberately terse and
+ * procedural — no conceptual intro. Reached from the "Add more roles"
+ * button on the Access Requests page.
+ */
+const Pre = ({ children }) => (
+  <pre
+    style={{
+      background: '#0f172a',
+      color: '#e2e8f0',
+      borderRadius: '8px',
+      padding: '0.9rem 1rem',
+      overflowX: 'auto',
+      fontSize: '0.82rem',
+      lineHeight: 1.5,
+      margin: '0.5rem 0 1rem'
+    }}
+  >
+    <code>{children}</code>
+  </pre>
+);
+
+const C = ({ children }) => (
+  <code
+    style={{
+      background: '#f1f5f9',
+      borderRadius: '4px',
+      padding: '0.1rem 0.35rem',
+      fontSize: '0.85em',
+      fontFamily: 'monospace',
+      color: '#0f172a',
+      wordBreak: 'break-word'
+    }}
+  >
+    {children}
+  </code>
+);
+
+const StepTitle = ({ n, children }) => (
+  <h2
+    style={{
+      fontSize: '1.05rem',
+      fontWeight: 700,
+      color: '#1e293b',
+      marginTop: '1.75rem',
+      marginBottom: '0.5rem'
+    }}
+  >
+    {n}. {children}
+  </h2>
+);
+
+const RolesHelp = () => {
+  const navigate = useNavigate();
+  const aai = 'https://idp.nationaldataplatform.org'; // AAI base (AUTH_API_URL host)
+  const docUrl =
+    'https://github.com/national-data-platform/ep-api/blob/main/docs/roles-and-permissions.md';
+
+  return (
+    <div style={{ maxWidth: '820px', margin: '0 auto', padding: '0 1rem' }}>
+      <div className="page-header">
+        <h1 className="page-title">
+          <ShieldAlert size={32} style={{ marginRight: '0.5rem' }} />
+          Add a new role
+        </h1>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => navigate('/access-requests')}
+        className="btn btn-secondary"
+        style={{ marginBottom: '1rem' }}
+      >
+        <ArrowLeft size={16} />
+        Back to Access Requests
+      </button>
+
+      <div className="card">
+        <p style={{ margin: 0, color: '#475569', lineHeight: 1.55 }}>
+          A role is a Keycloak realm role named{' '}
+          <C>group:&#123;EP_UUID&#125;:&#123;name&#125;</C>, where{' '}
+          <C>EP_UUID</C> is this deployment&apos;s <C>AFFINITIES_EP_UUID</C>.
+          Replace <C>$EP_UUID</C>, <C>$ADMIN_TOKEN</C> (a group-admin&apos;s
+          bearer token) and <C>$USER</C> below.
+        </p>
+
+        <StepTitle n={1}>Create the role (AAI API)</StepTitle>
+        <p style={{ color: '#475569', lineHeight: 1.55, margin: 0 }}>
+          <C>roleName</C> is the <strong>bare</strong> name — the AAI prefixes{' '}
+          <C>group:$EP_UUID:</C> itself. The names <C>admin</C>, <C>editor</C>{' '}
+          and <C>viewer</C> are reserved and rejected.
+        </p>
+        <Pre>{`curl -X POST "${aai}/role/create" \\
+  -H "Authorization: Bearer $ADMIN_TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d '{"groupName":"'$EP_UUID'","roleName":"publisher"}'
+# -> 201 {"role":"group:$EP_UUID:publisher"}`}</Pre>
+        <p style={{ color: '#64748b', fontSize: '0.85rem', margin: 0 }}>
+          (Step 2 auto-creates the role too if you skip this, but creating it
+          explicitly lets you assign to many users at once with{' '}
+          <C>&quot;users&quot;:[…]</C>.)
+        </p>
+
+        <StepTitle n={2}>Assign it to a user (AAI API)</StepTitle>
+        <p style={{ color: '#475569', lineHeight: 1.55, margin: 0 }}>
+          Again the <strong>bare</strong> name plus <C>groupName</C>. Do not
+          pass the full <C>group:…:publisher</C> string — it double-prefixes
+          and fails.
+        </p>
+        <Pre>{`curl -X POST "${aai}/role/assign" \\
+  -H "Authorization: Bearer $ADMIN_TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d '{"groupName":"'$EP_UUID'","roleName":"publisher","username":"'$USER'"}'`}</Pre>
+        <p style={{ color: '#475569', lineHeight: 1.55, margin: 0 }}>
+          The user must <strong>log out and back in</strong> — the new role
+          only appears in a freshly minted JWT. No Keycloak client change is
+          needed; the realm-roles mapper puts it in the token automatically.
+          Verify with <C>GET /user/info</C> (look at the <C>roles</C> array).
+        </p>
+
+        <StepTitle n={3}>Make the Endpoint enforce it (code change)</StepTitle>
+        <p style={{ color: '#475569', lineHeight: 1.55, margin: 0 }}>
+          Steps 1–2 put the role in the token, but the Endpoint only grants
+          permissions for <C>admin</C> / <C>writer</C> / <C>viewer</C>. Any
+          other role rides in the token and grants nothing. To make{' '}
+          <C>publisher</C> actually do something, edit{' '}
+          <C>api/services/auth_services/authorization_service.py</C>:
+        </p>
+        <ul style={{ color: '#475569', lineHeight: 1.7, paddingLeft: '1.4rem' }}>
+          <li>
+            Add a matcher, e.g. <C>is_publisher()</C>, reusing{' '}
+            <C>_has_any_role(user_info, [endpoint_group_role_name(&quot;publisher&quot;), &quot;ndp_publisher&quot;])</C>.
+          </li>
+          <li>
+            Fold it into <C>effective_role()</C> at the right precedence.
+          </li>
+          <li>
+            Create/extend a dependency (like{' '}
+            <C>get_user_for_write_operation</C>) and apply it to the routes the
+            role should guard.
+          </li>
+          <li>Add tests, bump the version, redeploy.</li>
+        </ul>
+        <p
+          style={{
+            background: '#fffbeb',
+            border: '1px solid #fde68a',
+            borderRadius: '8px',
+            padding: '0.75rem 1rem',
+            color: '#78350f',
+            fontSize: '0.9rem',
+            lineHeight: 1.5,
+            marginTop: '0.5rem'
+          }}
+        >
+          If you only need <strong>viewer / writer / admin</strong> (in this or
+          another group), skip steps 1 and 3 entirely — just assign the
+          existing tier via the Access Requests screen. Step 3 is only for a
+          genuinely new permission level, and is the part to{' '}
+          <strong>request from NDP support</strong> if you can&apos;t change
+          the Endpoint code.
+        </p>
+
+        <p style={{ marginTop: '1.25rem', marginBottom: 0 }}>
+          <a
+            href={docUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              color: '#2563eb',
+              fontWeight: 600,
+              textDecoration: 'none',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '0.4rem'
+            }}
+          >
+            Full reference (naming, JWT flow, AAI surface)
+            <ExternalLink size={16} />
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default RolesHelp;


### PR DESCRIPTION
## Summary
Documents the role model and makes that documentation reachable from the three places operators look.

**Reference doc**
- `docs/roles-and-permissions.md`: the full operator/support reference — tiers, the `ndp_{tier}` / `group:{AFFINITIES_EP_UUID}:{tier}` naming convention (and the legacy `{uuid}_admin` form), how `effective_role` is derived, how realm roles reach the JWT through the client's protocol mapper (verified empirically: a new realm role needs no per-role client change), the AAI role/group API with exact request shapes, the "editor (AAI) vs writer (EP)" gotcha, and the two "I need more roles" scenarios.

**Surfaced in the product**
- **UI**: new `/roles-help` page — a terse, procedural "Add a new role" runbook with the exact `curl` calls (create the realm role via the AAI, assign it, and the `authorization_service.py` change needed for a genuinely new permission level). Reached from an **"Add more roles"** button on the Access Requests page; links out to the full markdown reference.
- **Swagger**: `POST /user/access-requests/{id}/approve` description now explains viewer/writer/admin (plus the deprecated `member` alias), the naming convention, and points to the doc.
- **README**: "Role tiers" subsection under Group-Based Access Control links the doc and mentions the in-UI button.

**Incidental fix**
- nginx `${ROOT_PATH}/ui` -> `${ROOT_PATH}/ui/` redirect used `$host`, dropping a non-standard port (e.g. `:8002`) and sending the browser to port 80. Now a relative redirect (`absolute_redirect off`) preserves the port.

## Backwards compatibility
- Additive: one new UI route + button, an expanded Swagger description, a README link, a new docs file, and a redirect bugfix. No API behavior, request/response shapes, or existing routes change. `docs/` is not shipped in the Docker image; the UI page and Swagger text are.

Closes #173.