### PR TITLE
Move Kafka/URL/S3 resource creation into + New; simplify pages (closes #175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0] - 2026-05-20
+
+### Changed
+- The "+ New" menu now also creates **Kafka topic**, **URL resource** and **S3 resource** (next to Organization, Dataset, Service). Their pages (`/kafka-topics`, `/url-resources`, `/s3-resources`) are simplified to single-purpose creation forms — listing, editing and deletion are dropped, mirroring the earlier organization/service/dataset reorganization. Listing and deletion of these resources now happen on the Search page (they are CKAN packages, appear in the Datasets group, and owned ones expose the existing Delete action).
+- The "Resources" navigation dropdown is removed. Its only remaining entry that is not a catalog-creation flow — **S3 Management** (bucket/object management) — is now a top-level navigation item.
+
+### Backwards compatibility
+- UI-only reorganization. No API behavior, request/response shapes, or routes change. The `/kafka-topics`, `/url-resources`, `/s3-resources` routes remain (now create-only) and `/s3-management` is unchanged.
+- Resources registered before the creator-hash feature do not expose a Delete action on Search; no migration is performed.
+
 ## [0.29.0] - 2026-05-19
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.29.0"
+    swagger_version: str = "0.30.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/ui/src/components/Navigation.js
+++ b/ui/src/components/Navigation.js
@@ -10,7 +10,6 @@ import {
   Search,
   FileText,
   LogOut,
-  FolderOpen,
   ChevronDown,
   HardDrive,
   ShieldAlert,
@@ -23,10 +22,6 @@ import { isAccessRequestAdmin, userAPI } from '../services/api';
  * Gray background with improved dropdown logic that always closes properly
  */
 const Navigation = () => {
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const dropdownRef = useRef(null);
-  const buttonRef = useRef(null);
-  const timeoutRef = useRef(null);
   const [isNewMenuOpen, setIsNewMenuOpen] = useState(false);
   const newMenuRef = useRef(null);
   const newButtonRef = useRef(null);
@@ -60,25 +55,16 @@ const Navigation = () => {
     };
   }, []);
 
-  // Clear timeouts on unmount
+  // Clear timeout on unmount
   useEffect(() => {
     return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
       if (newTimeoutRef.current) clearTimeout(newTimeoutRef.current);
     };
   }, []);
 
-  // Close dropdowns when clicking outside
+  // Close the "+ New" menu when clicking outside
   useEffect(() => {
     const handleClickOutside = (event) => {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target) &&
-        buttonRef.current &&
-        !buttonRef.current.contains(event.target)
-      ) {
-        setIsDropdownOpen(false);
-      }
       if (
         newMenuRef.current &&
         !newMenuRef.current.contains(event.target) &&
@@ -95,26 +81,9 @@ const Navigation = () => {
     };
   }, []);
 
-  // Improved dropdown handlers with timeout for better UX
-  const handleDropdownEnter = () => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
-    setIsDropdownOpen(true);
-    setIsNewMenuOpen(false);
-  };
-
-  const handleDropdownLeave = () => {
-    // Add small delay to prevent accidental closes
-    timeoutRef.current = setTimeout(() => {
-      setIsDropdownOpen(false);
-    }, 150);
-  };
-
   const handleNewMenuEnter = () => {
     if (newTimeoutRef.current) clearTimeout(newTimeoutRef.current);
     setIsNewMenuOpen(true);
-    setIsDropdownOpen(false);
   };
 
   const handleNewMenuLeave = () => {
@@ -123,11 +92,9 @@ const Navigation = () => {
     }, 150);
   };
 
-  // Handle mouse entering other nav items - close dropdowns immediately
+  // Handle mouse entering other nav items - close the menu immediately
   const handleOtherNavEnter = () => {
-    if (timeoutRef.current) clearTimeout(timeoutRef.current);
     if (newTimeoutRef.current) clearTimeout(newTimeoutRef.current);
-    setIsDropdownOpen(false);
     setIsNewMenuOpen(false);
   };
 
@@ -210,182 +177,37 @@ const Navigation = () => {
                 <span>Search</span>
               </Link>
 
-              {/* Resources Dropdown */}
-              <div 
-                style={{ position: 'relative' }}
-                onMouseEnter={handleDropdownEnter}
-                onMouseLeave={handleDropdownLeave}
+              {/* S3 Management (bucket/object storage tool) */}
+              <Link
+                to="/s3-management"
+                onMouseEnter={handleOtherNavEnter}
+                style={{
+                  color: '#6b7280',
+                  textDecoration: 'none',
+                  padding: '0.5rem 0.75rem',
+                  borderRadius: '8px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.5rem',
+                  fontSize: '0.95rem',
+                  whiteSpace: 'nowrap',
+                  fontWeight: '500',
+                  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+                  backgroundColor: 'transparent',
+                  transition: 'all 0.2s ease'
+                }}
+                onMouseOver={(e) => {
+                  e.target.style.color = '#374151';
+                  e.target.style.fontWeight = '600';
+                }}
+                onMouseOut={(e) => {
+                  e.target.style.color = '#6b7280';
+                  e.target.style.fontWeight = '500';
+                }}
               >
-                <button
-                  ref={buttonRef}
-                  style={{
-                    color: isDropdownOpen ? '#374151' : '#6b7280', // Only changes when dropdown is open
-                    background: 'none',
-                    border: 'none',
-                    padding: '0.75rem 1rem',
-                    borderRadius: '8px',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '0.5rem',
-                    fontSize: '0.95rem',
-                    fontWeight: isDropdownOpen ? '600' : '500', // Only changes when dropdown is open
-                    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-                    cursor: 'pointer',
-                    backgroundColor: 'transparent',
-                    transition: 'all 0.2s ease'
-                  }}
-                  onMouseOver={(e) => {
-                    if (!isDropdownOpen) {
-                      e.target.style.color = '#374151';
-                      e.target.style.fontWeight = '600';
-                    }
-                  }}
-                  onMouseOut={(e) => {
-                    if (!isDropdownOpen) {
-                      e.target.style.color = '#6b7280';
-                      e.target.style.fontWeight = '500';
-                    }
-                  }}
-                >
-                  <FolderOpen size={18} />
-                  <span>Resources</span>
-                  <ChevronDown size={16} />
-                </button>
-
-                {/* Dropdown */}
-                {isDropdownOpen && (
-                  <div
-                    ref={dropdownRef}
-                    style={{
-                      position: 'absolute',
-                      top: '100%',
-                      left: '0',
-                      backgroundColor: 'white',
-                      borderRadius: '10px',
-                      boxShadow: '0 10px 25px rgba(0, 0, 0, 0.15)',
-                      border: '1px solid #e5e7eb',
-                      minWidth: '220px',
-                      zIndex: 1000,
-                      marginTop: '0.5rem'
-                    }}
-                  >
-                    <Link
-                      to="/kafka-topics"
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '0.75rem',
-                        padding: '1rem 1.25rem',
-                        color: '#374151', // Always same color
-                        textDecoration: 'none',
-                        fontSize: '0.9rem',
-                        fontWeight: '500', // Always same weight
-                        backgroundColor: 'white',
-                        borderBottom: '1px solid #f3f4f6'
-                      }}
-                      onMouseOver={(e) => {
-                        e.target.style.backgroundColor = '#f9fafb';
-                        e.target.style.color = '#2563eb';
-                        e.target.style.fontWeight = '600';
-                      }}
-                      onMouseOut={(e) => {
-                        e.target.style.backgroundColor = 'white';
-                        e.target.style.color = '#374151';
-                        e.target.style.fontWeight = '500';
-                      }}
-                    >
-                      <Radio size={18} />
-                      <span>Kafka Topics</span>
-                    </Link>
-
-                    <Link
-                      to="/url-resources"
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '0.75rem',
-                        padding: '1rem 1.25rem',
-                        color: '#374151', // Always same color
-                        textDecoration: 'none',
-                        fontSize: '0.9rem',
-                        fontWeight: '500', // Always same weight
-                        backgroundColor: 'white',
-                        borderBottom: '1px solid #f3f4f6'
-                      }}
-                      onMouseOver={(e) => {
-                        e.target.style.backgroundColor = '#f9fafb';
-                        e.target.style.color = '#2563eb';
-                        e.target.style.fontWeight = '600';
-                      }}
-                      onMouseOut={(e) => {
-                        e.target.style.backgroundColor = 'white';
-                        e.target.style.color = '#374151';
-                        e.target.style.fontWeight = '500';
-                      }}
-                    >
-                      <LinkIcon size={18} />
-                      <span>URL Resources</span>
-                    </Link>
-
-                    <Link
-                      to="/s3-resources"
-                      style={{
-                        display: 'flex',
-                        alignItems:'center',
-                        gap: '0.75rem',
-                        padding: '1rem 1.25rem',
-                        color: '#374151', // Always same color
-                        textDecoration: 'none',
-                        fontSize: '0.9rem',
-                        fontWeight: '500', // Always same weight
-                        backgroundColor: 'white',
-                        borderBottom: '1px solid #f3f4f6'
-                      }}
-                      onMouseOver={(e) => {
-                        e.target.style.backgroundColor = '#f9fafb';
-                        e.target.style.color = '#2563eb';
-                        e.target.style.fontWeight = '600';
-                      }}
-                      onMouseOut={(e) => {
-                        e.target.style.backgroundColor = 'white';
-                        e.target.style.color = '#374151';
-                        e.target.style.fontWeight = '500';
-                      }}
-                    >
-                      <Database size={18} />
-                      <span>S3 Resources</span>
-                    </Link>
-
-                    <Link
-                      to="/s3-management"
-                      style={{
-                        display: 'flex',
-                        alignItems:'center',
-                        gap: '0.75rem',
-                        padding: '1rem 1.25rem',
-                        color: '#374151', // Always same color
-                        textDecoration: 'none',
-                        fontSize: '0.9rem',
-                        fontWeight: '500', // Always same weight
-                        backgroundColor: 'white'
-                      }}
-                      onMouseOver={(e) => {
-                        e.target.style.backgroundColor = '#f9fafb';
-                        e.target.style.color = '#2563eb';
-                        e.target.style.fontWeight = '600';
-                      }}
-                      onMouseOut={(e) => {
-                        e.target.style.backgroundColor = 'white';
-                        e.target.style.color = '#374151';
-                        e.target.style.fontWeight = '500';
-                      }}
-                    >
-                      <HardDrive size={18} />
-                      <span>S3 Management</span>
-                    </Link>
-                  </div>
-                )}
-              </div>
+                <HardDrive size={18} />
+                <span>S3 Management</span>
+              </Link>
 
               {/* + New menu — only visible to users that can write */}
               {canWrite && (
@@ -517,7 +339,8 @@ const Navigation = () => {
                         textDecoration: 'none',
                         fontSize: '0.9rem',
                         fontWeight: '500',
-                        backgroundColor: 'white'
+                        backgroundColor: 'white',
+                        borderBottom: '1px solid #f3f4f6'
                       }}
                       onMouseOver={(e) => {
                         e.target.style.backgroundColor = '#f9fafb';
@@ -532,6 +355,92 @@ const Navigation = () => {
                     >
                       <Settings size={18} />
                       <span>Service</span>
+                    </Link>
+
+                    <Link
+                      to="/kafka-topics"
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.75rem',
+                        padding: '1rem 1.25rem',
+                        color: '#374151',
+                        textDecoration: 'none',
+                        fontSize: '0.9rem',
+                        fontWeight: '500',
+                        backgroundColor: 'white',
+                        borderBottom: '1px solid #f3f4f6'
+                      }}
+                      onMouseOver={(e) => {
+                        e.target.style.backgroundColor = '#f9fafb';
+                        e.target.style.color = '#2563eb';
+                        e.target.style.fontWeight = '600';
+                      }}
+                      onMouseOut={(e) => {
+                        e.target.style.backgroundColor = 'white';
+                        e.target.style.color = '#374151';
+                        e.target.style.fontWeight = '500';
+                      }}
+                    >
+                      <Radio size={18} />
+                      <span>Kafka topic</span>
+                    </Link>
+
+                    <Link
+                      to="/url-resources"
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.75rem',
+                        padding: '1rem 1.25rem',
+                        color: '#374151',
+                        textDecoration: 'none',
+                        fontSize: '0.9rem',
+                        fontWeight: '500',
+                        backgroundColor: 'white',
+                        borderBottom: '1px solid #f3f4f6'
+                      }}
+                      onMouseOver={(e) => {
+                        e.target.style.backgroundColor = '#f9fafb';
+                        e.target.style.color = '#2563eb';
+                        e.target.style.fontWeight = '600';
+                      }}
+                      onMouseOut={(e) => {
+                        e.target.style.backgroundColor = 'white';
+                        e.target.style.color = '#374151';
+                        e.target.style.fontWeight = '500';
+                      }}
+                    >
+                      <LinkIcon size={18} />
+                      <span>URL resource</span>
+                    </Link>
+
+                    <Link
+                      to="/s3-resources"
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.75rem',
+                        padding: '1rem 1.25rem',
+                        color: '#374151',
+                        textDecoration: 'none',
+                        fontSize: '0.9rem',
+                        fontWeight: '500',
+                        backgroundColor: 'white'
+                      }}
+                      onMouseOver={(e) => {
+                        e.target.style.backgroundColor = '#f9fafb';
+                        e.target.style.color = '#2563eb';
+                        e.target.style.fontWeight = '600';
+                      }}
+                      onMouseOut={(e) => {
+                        e.target.style.backgroundColor = 'white';
+                        e.target.style.color = '#374151';
+                        e.target.style.fontWeight = '500';
+                      }}
+                    >
+                      <Database size={18} />
+                      <span>S3 resource</span>
                     </Link>
                   </div>
                 )}

--- a/ui/src/pages/KafkaTopics.js
+++ b/ui/src/pages/KafkaTopics.js
@@ -1,471 +1,196 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { 
-  Radio, 
-  Plus, 
-  AlertCircle, 
-  Edit3,
-  Save,
-  X,
-  Trash2,
-  RefreshCw,
-  Database
-} from 'lucide-react';
-import { kafkaAPI, organizationsAPI, searchAPI, resourcesAPI } from '../services/api';
+import React, { useEffect, useState } from 'react';
+import { Radio, AlertCircle, CheckCircle, Plus, Trash2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { kafkaAPI, organizationsAPI } from '../services/api';
 
 /**
- * Kafka Topics page component for managing Kafka data sources
- * Allows creating, listing, editing, and deleting Kafka topic datasets
+ * Single-purpose page reached from "+ New > Kafka topic". Registers a
+ * Kafka topic as a catalog dataset. Listing and deletion live on the
+ * Search page (Kafka topics are CKAN packages and show up there).
  */
 const KafkaTopics = () => {
-  const [kafkaTopics, setKafkaTopics] = useState([]);
-  const [organizations, setOrganizations] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [success, setSuccess] = useState(null);
-  const [showCreateForm, setShowCreateForm] = useState(false);
-  const [editingTopic, setEditingTopic] = useState(null);
-  const [selectedServer] = useState('local'); // Fixed to local for consistency
-
-  // Form state for creating/editing Kafka topic
+  const navigate = useNavigate();
   const [formData, setFormData] = useState({
     dataset_name: '',
     dataset_title: '',
     owner_org: '',
+    dataset_description: '',
     kafka_topic: '',
     kafka_host: '',
-    kafka_port: '',
-    dataset_description: '',
-    extras: {},
-    mapping: {},
-    processing: {}
+    kafka_port: ''
   });
+  const [extrasPairs, setExtrasPairs] = useState([]);
+  const [organizations, setOrganizations] = useState([]);
+  const [orgsLoading, setOrgsLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(null);
 
-  // JSON editor states for complex fields
-  const [extrasJson, setExtrasJson] = useState('{}');
-  const [mappingJson, setMappingJson] = useState('{}');
-  const [processingJson, setProcessingJson] = useState('{}');
-
-  /**
-   * Fetch organizations for dropdown
-   */
-  const fetchOrganizations = useCallback(async () => {
-    try {
-      const response = await organizationsAPI.list({ server: selectedServer });
-      setOrganizations(response.data || []);
-    } catch (err) {
-      console.error('Error fetching organizations:', err);
-    }
-  }, [selectedServer]);
-
-  /**
-   * Fetch all Kafka topics (filtered from all datasets)
-   */
-  const fetchKafkaTopics = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      
-      // Use search to get all datasets, then filter for Kafka topics
-      const response = await searchAPI.searchByTerms([''], null, selectedServer);
-      
-      // Filter to show only Kafka topics
-      const filteredTopics = (response.data || []).filter(dataset => {
-        const extras = dataset.extras || {};
-        
-        // Include if it has Kafka-specific metadata
-        // Check for both old format (kafka_*) and new format (host, port, topic)
-        return (
-          extras.kafka_topic || extras.kafka_host || extras.kafka_port || // Old format
-          extras.topic || extras.host || extras.port || // New format
-          // Also check if any resource has format "kafka"
-          (dataset.resources && dataset.resources.some(resource => 
-            resource.format === 'kafka'
-          ))
-        );
-      });
-      
-      console.log('All datasets:', response.data); // Debug
-      console.log('Filtered Kafka topics:', filteredTopics); // Debug
-      
-      setKafkaTopics(filteredTopics);
-      
-    } catch (err) {
-      console.error('Error fetching Kafka topics:', err);
-      setError('Failed to load Kafka topics: ' + 
-        (err.response?.data?.detail || err.message));
-    } finally {
-      setLoading(false);
-    }
-  }, [selectedServer]);
-
-  /**
-   * Fetch organizations and Kafka topics on component mount
-   */
   useEffect(() => {
-    fetchOrganizations();
-    fetchKafkaTopics();
-  }, [fetchOrganizations, fetchKafkaTopics]);
+    let cancelled = false;
+    organizationsAPI
+      .list({ server: 'local' })
+      .then((response) => {
+        if (cancelled) return;
+        const orgs = Array.isArray(response.data) ? response.data : [];
+        setOrganizations(orgs);
+        setFormData((prev) =>
+          prev.owner_org ? prev : { ...prev, owner_org: orgs[0] || '' }
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setOrganizations([]);
+      })
+      .finally(() => {
+        if (!cancelled) setOrgsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
-  /**
-   * Handle form input changes
-   */
   const handleInputChange = (e) => {
     const { name, value } = e.target;
-    setFormData(prev => ({
-      ...prev,
-      [name]: value
-    }));
+    setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  /**
-   * Parse JSON string safely
-   */
-  const parseJsonSafely = (jsonString, fallback = {}) => {
-    try {
-      return jsonString.trim() === '' ? fallback : JSON.parse(jsonString);
-    } catch {
-      return fallback;
+  const addExtraPair = () =>
+    setExtrasPairs((prev) => [...prev, { key: '', value: '' }]);
+  const removeExtraPair = (idx) =>
+    setExtrasPairs((prev) => prev.filter((_, i) => i !== idx));
+  const updateExtraPair = (idx, field, value) =>
+    setExtrasPairs((prev) =>
+      prev.map((p, i) => (i === idx ? { ...p, [field]: value } : p))
+    );
+
+  const buildExtras = () => {
+    const out = {};
+    for (const { key, value } of extrasPairs) {
+      const trimmed = (key || '').trim();
+      if (trimmed) out[trimmed] = value;
     }
+    return out;
   };
 
-  /**
-   * Reset form to initial state
-   */
-  const resetForm = () => {
-    setFormData({
-      dataset_name: '',
-      dataset_title: '',
-      owner_org: '',
-      kafka_topic: '',
-      kafka_host: '',
-      kafka_port: '',
-      dataset_description: '',
-      extras: {},
-      mapping: {},
-      processing: {}
-    });
-    setExtrasJson('{}');
-    setMappingJson('{}');
-    setProcessingJson('{}');
-    setEditingTopic(null);
-    setShowCreateForm(false);
-  };
-
-  /**
-   * Prepare form data for submission
-   */
-  const prepareFormData = () => {
-    // Parse JSON fields
-    const extras = parseJsonSafely(extrasJson, {});
-    const mapping = parseJsonSafely(mappingJson, {});
-    const processing = parseJsonSafely(processingJson, {});
-
-    // Prepare data
-    const requestData = {
-      ...formData,
-      extras: Object.keys(extras).length > 0 ? extras : undefined,
-      mapping: Object.keys(mapping).length > 0 ? mapping : undefined,
-      processing: Object.keys(processing).length > 0 ? processing : undefined
-    };
-
-    // Remove empty fields
-    Object.keys(requestData).forEach(key => {
-      if (requestData[key] === '' || requestData[key] === undefined) {
-        delete requestData[key];
-      }
-    });
-
-    return requestData;
-  };
-
-  /**
-   * Handle form submission for creating Kafka topic
-   */
-  const handleCreate = async (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    
-    try {
-      setError(null);
-      setSuccess(null);
-      setLoading(true);
+    setError(null);
+    setSuccess(null);
+    setSubmitting(true);
 
-      const requestData = prepareFormData();
-      await kafkaAPI.create(requestData, selectedServer);
-      
-      setSuccess('Kafka topic dataset created successfully!');
-      resetForm();
-      fetchKafkaTopics();
-      
-    } catch (err) {
-      console.error('Error creating Kafka topic:', err);
-      setError('Failed to create Kafka topic: ' + 
-        (err.response?.data?.detail || err.message));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  /**
-   * Handle form submission for updating Kafka topic
-   */
-  const handleUpdate = async (e) => {
-    e.preventDefault();
-    
-    try {
-      setError(null);
-      setSuccess(null);
-      setLoading(true);
-
-      const requestData = prepareFormData();
-      await kafkaAPI.update(editingTopic.id, requestData, selectedServer);
-      
-      setSuccess('Kafka topic updated successfully!');
-      resetForm();
-      fetchKafkaTopics();
-      
-    } catch (err) {
-      console.error('Error updating Kafka topic:', err);
-      setError('Failed to update Kafka topic: ' + 
-        (err.response?.data?.detail || err.message));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  /**
-   * Start editing a Kafka topic
-   * FIXED: Properly separate Kafka-specific fields from general extras
-   */
-  const startEditing = (topic) => {
-    setEditingTopic(topic);
-    const extras = topic.extras || {};
-    
-    // Extract Kafka-specific fields from extras
-    const kafkaFields = {
-      kafka_topic: extras.kafka_topic || extras.topic || '',
-      kafka_host: extras.kafka_host || extras.host || '',
-      kafka_port: extras.kafka_port || extras.port || ''
+    const payload = {
+      dataset_name: formData.dataset_name,
+      dataset_title: formData.dataset_title,
+      owner_org: formData.owner_org,
+      kafka_topic: formData.kafka_topic,
+      kafka_host: formData.kafka_host,
+      kafka_port: Number(formData.kafka_port)
     };
-    
-    // Create a clean extras object without the reserved Kafka fields
-    const cleanExtras = { ...extras };
-    
-    // Remove reserved Kafka fields from extras
-    const reservedKafkaFields = [
-      'kafka_topic', 'topic',
-      'kafka_host', 'host', 
-      'kafka_port', 'port'
-    ];
-    
-    reservedKafkaFields.forEach(field => {
-      delete cleanExtras[field];
-    });
-    
-    // Also extract mapping and processing from extras if they exist
-    const mapping = cleanExtras.mapping || {};
-    const processing = cleanExtras.processing || {};
-    
-    // Remove mapping and processing from cleanExtras since they have their own fields
-    delete cleanExtras.mapping;
-    delete cleanExtras.processing;
-    
-    setFormData({
-      dataset_name: topic.name || '',
-      dataset_title: topic.title || '',
-      owner_org: topic.owner_org || '',
-      kafka_topic: kafkaFields.kafka_topic,
-      kafka_host: kafkaFields.kafka_host,
-      kafka_port: kafkaFields.kafka_port,
-      dataset_description: topic.notes || '',
-      extras: cleanExtras,
-      mapping: mapping,
-      processing: processing
-    });
-    
-    // Set JSON fields with clean data
-    setExtrasJson(JSON.stringify(cleanExtras, null, 2));
-    setMappingJson(JSON.stringify(mapping, null, 2));
-    setProcessingJson(JSON.stringify(processing, null, 2));
-    setShowCreateForm(true);
-  };
-
-  /**
-   * Handle Kafka topic deletion
-   */
-  const handleDeleteTopic = async (topic) => {
-    const displayName = topic.title || topic.name || 'Unnamed Topic';
-    
-    if (!window.confirm(
-      `Are you sure you want to delete Kafka topic "${displayName}"? This will also delete all associated resources. This action cannot be undone.`
-    )) {
-      return;
-    }
+    if (formData.dataset_description)
+      payload.dataset_description = formData.dataset_description;
+    const extras = buildExtras();
+    if (Object.keys(extras).length > 0) payload.extras = extras;
 
     try {
-      setError(null);
-      setSuccess(null);
-      
-      // Debug: Log the topic being deleted
-      console.log('Attempting to delete Kafka topic with ID:', topic.id);
-      console.log('Using endpoint: DELETE /resource?resource_id=' + topic.id + '&server=local');
-      
-      // Use the resource deletion endpoint since datasets are resources in CKAN
-      await resourcesAPI.deleteById(topic.id, 'local');
-      
-      setSuccess(`Kafka topic "${displayName}" deleted successfully!`);
-      
-      // Refresh the topics list
-      fetchKafkaTopics();
-      
+      await kafkaAPI.create(payload, 'local');
+      setSuccess(
+        `Kafka topic "${formData.dataset_name}" registered. You can keep registering more or go back to Search.`
+      );
+      setFormData((prev) => ({
+        ...prev,
+        dataset_name: '',
+        dataset_title: '',
+        dataset_description: '',
+        kafka_topic: '',
+        kafka_host: '',
+        kafka_port: ''
+      }));
+      setExtrasPairs([]);
     } catch (err) {
-      console.error('Error deleting Kafka topic:', err);
-      console.error('Full error object:', err);
-      console.error('Error response:', err.response);
-      
-      let errorMessage = 'Failed to delete Kafka topic: ';
-      
-      if (err.response?.status === 404) {
-        errorMessage += `Topic "${displayName}" not found. It may have been already deleted.`;
-      } else if (err.response?.status === 405) {
-        errorMessage += 'Topic deletion method not allowed.';
-      } else if (err.response?.status === 401) {
-        errorMessage += 'Authentication required. Please login again.';
-      } else if (err.response?.status === 403) {
-        errorMessage += 'You do not have permission to delete this topic.';
-      } else {
-        errorMessage += (err.response?.data?.detail || err.message);
-      }
-      
-      setError(errorMessage);
+      const detail = err.response?.data?.detail;
+      const raw = typeof detail === 'string' ? detail : err.message;
+      const msg = raw || 'unknown error';
+      setError(
+        /already exists/i.test(msg)
+          ? `A dataset called "${formData.dataset_name}" already exists. Pick a different name.`
+          : `Could not register the Kafka topic: ${msg}.`
+      );
+    } finally {
+      setSubmitting(false);
     }
-  };
-
-  /**
-   * Get connection status badge
-   */
-  const getConnectionStatus = (topic) => {
-    const extras = topic.extras || {};
-    // Check both old format (kafka_*) and new format (host, port, topic)
-    const hasHost = extras.kafka_host || extras.host;
-    const hasPort = extras.kafka_port || extras.port;
-    const hasTopic = extras.kafka_topic || extras.topic;
-    
-    if (hasHost && hasPort && hasTopic) {
-      return { status: 'Connected', color: 'status-success' };
-    }
-    return { status: 'Incomplete', color: 'status-warning' };
   };
 
   return (
-    <div className="kafka-topics-page">
-      {/* Page Header */}
+    <div style={{ maxWidth: '720px', margin: '0 auto', padding: '0 1rem' }}>
       <div className="page-header">
         <h1 className="page-title">
           <Radio size={32} style={{ marginRight: '0.5rem' }} />
-          Kafka Topics
+          New Kafka topic
         </h1>
         <p className="page-subtitle">
-          Register and manage Kafka topics as datasets in your CKAN instance
+          Register a Kafka topic as a catalog dataset so others can
+          discover the stream and how to connect to it. Find it (and
+          remove it) from the Search page once created.
         </p>
       </div>
 
-      {/* Alert Messages */}
       {error && (
         <div className="alert alert-error">
           <AlertCircle size={20} />
           {error}
         </div>
       )}
-
       {success && (
         <div className="alert alert-success">
+          <CheckCircle size={20} />
           {success}
         </div>
       )}
 
-      {/* Page actions */}
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
-        <button
-          onClick={fetchKafkaTopics}
-          className="btn btn-secondary"
-          disabled={loading}
-        >
-          <RefreshCw size={16} />
-          Refresh
-        </button>
-        {!showCreateForm && (
-          <button
-            onClick={() => setShowCreateForm(true)}
-            className="btn btn-primary"
-          >
-            <Plus size={16} />
-            Create Kafka Topic
-          </button>
-        )}
-      </div>
-
-      {/* Create/Edit Kafka Topic Form */}
-      {showCreateForm && (
-        <div className="card">
-          <div className="card-header">
-            <h3 className="card-title">
-              {editingTopic ? (
-                <>
-                  <Edit3 size={20} />
-                  Edit Kafka Topic: {editingTopic.title}
-                </>
-              ) : (
-                <>
-                  <Plus size={20} />
-                  Create New Kafka Topic Dataset
-                </>
-              )}
-            </h3>
-            <button
-              onClick={resetForm}
-              className="btn btn-secondary"
-            >
-              <X size={16} />
-              Cancel
-            </button>
+      <div className="card">
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label className="form-label">Dataset name *</label>
+            <input
+              type="text"
+              name="dataset_name"
+              value={formData.dataset_name}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="my-kafka-topic"
+              required
+            />
+            <small style={{ color: '#64748b' }}>
+              Unique identifier — lowercase letters, numbers, underscores
+              and hyphens only.
+            </small>
           </div>
 
-          <form onSubmit={editingTopic ? handleUpdate : handleCreate}>
-            {/* Basic Information */}
-            <div className="grid grid-2">
-              <div className="form-group">
-                <label className="form-label">Dataset Name *</label>
-                <input
-                  type="text"
-                  name="dataset_name"
-                  value={formData.dataset_name}
-                  onChange={handleInputChange}
-                  className="form-input"
-                  placeholder="kafka_topic_example"
-                  required
-                  disabled={editingTopic} // Cannot change name when editing
-                />
-                <small style={{ color: '#64748b' }}>
-                  Unique identifier for the dataset
-                </small>
-              </div>
+          <div className="form-group">
+            <label className="form-label">Title *</label>
+            <input
+              type="text"
+              name="dataset_title"
+              value={formData.dataset_title}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="My Kafka Topic"
+              required
+            />
+          </div>
 
-              <div className="form-group">
-                <label className="form-label">Dataset Title *</label>
-                <input
-                  type="text"
-                  name="dataset_title"
-                  value={formData.dataset_title}
-                  onChange={handleInputChange}
-                  className="form-input"
-                  placeholder="Kafka Topic Example"
-                  required
-                />
+          <div className="form-group">
+            <label className="form-label">Organization *</label>
+            {orgsLoading ? (
+              <div style={{ color: '#64748b', fontSize: '0.9rem' }}>
+                Loading organizations…
               </div>
-            </div>
-
-            <div className="form-group">
-              <label className="form-label">Organization *</label>
+            ) : organizations.length === 0 ? (
+              <div style={{ color: '#7f1d1d', fontSize: '0.9rem' }}>
+                No organizations available. Create one from &quot;+ New →
+                Organization&quot; first.
+              </div>
+            ) : (
               <select
                 name="owner_org"
                 value={formData.owner_org}
@@ -473,264 +198,141 @@ const KafkaTopics = () => {
                 className="form-select"
                 required
               >
-                <option value="">Select an organization</option>
-                {organizations.map(org => (
-                  <option key={org} value={org}>{org}</option>
+                <option value="" disabled>
+                  Choose an organization…
+                </option>
+                {organizations.map((org) => (
+                  <option key={org} value={org}>
+                    {org}
+                  </option>
                 ))}
               </select>
-            </div>
+            )}
+          </div>
 
-            {/* Kafka Configuration */}
-            <div className="grid grid-3">
-              <div className="form-group">
-                <label className="form-label">Kafka Topic *</label>
-                <input
-                  type="text"
-                  name="kafka_topic"
-                  value={formData.kafka_topic}
-                  onChange={handleInputChange}
-                  className="form-input"
-                  placeholder="example_topic"
-                  required
-                />
-              </div>
+          <div className="form-group">
+            <label className="form-label">Description</label>
+            <textarea
+              name="dataset_description"
+              value={formData.dataset_description}
+              onChange={handleInputChange}
+              className="form-input form-textarea"
+              placeholder="What does this stream contain?"
+            />
+          </div>
 
-              <div className="form-group">
-                <label className="form-label">Kafka Host *</label>
-                <input
-                  type="text"
-                  name="kafka_host"
-                  value={formData.kafka_host}
-                  onChange={handleInputChange}
-                  className="form-input"
-                  placeholder="localhost"
-                  required
-                />
-              </div>
-
-              <div className="form-group">
-                <label className="form-label">Kafka Port *</label>
-                <input
-                  type="text"
-                  name="kafka_port"
-                  value={formData.kafka_port}
-                  onChange={handleInputChange}
-                  className="form-input"
-                  placeholder="9092"
-                  required
-                />
-              </div>
-            </div>
-
+          <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: '0.75rem' }}>
             <div className="form-group">
-              <label className="form-label">Dataset Description</label>
-              <textarea
-                name="dataset_description"
-                value={formData.dataset_description}
+              <label className="form-label">Kafka host *</label>
+              <input
+                type="text"
+                name="kafka_host"
+                value={formData.kafka_host}
                 onChange={handleInputChange}
-                className="form-input form-textarea"
-                placeholder="Description of the Kafka topic dataset..."
+                className="form-input"
+                placeholder="kafka.example.com"
+                required
               />
             </div>
-
-            {/* Advanced Configuration */}
-            <div className="grid grid-3">
-              <div className="form-group">
-                <label className="form-label">Extras (JSON)</label>
-                <textarea
-                  value={extrasJson}
-                  onChange={(e) => setExtrasJson(e.target.value)}
-                  className="form-input form-textarea"
-                  placeholder='{"key1": "value1", "key2": "value2"}'
-                  style={{ fontFamily: 'monospace', fontSize: '0.875rem' }}
-                />
-                <small style={{ color: '#64748b' }}>
-                  Additional metadata as JSON (excluding Kafka fields)
-                </small>
-              </div>
-
-              <div className="form-group">
-                <label className="form-label">Mapping (JSON)</label>
-                <textarea
-                  value={mappingJson}
-                  onChange={(e) => setMappingJson(e.target.value)}
-                  className="form-input form-textarea"
-                  placeholder='{"field1": "mapping1", "field2": "mapping2"}'
-                  style={{ fontFamily: 'monospace', fontSize: '0.875rem' }}
-                />
-                <small style={{ color: '#64748b' }}>
-                  Field mapping configuration
-                </small>
-              </div>
-
-              <div className="form-group">
-                <label className="form-label">Processing (JSON)</label>
-                <textarea
-                  value={processingJson}
-                  onChange={(e) => setProcessingJson(e.target.value)}
-                  className="form-input form-textarea"
-                  placeholder='{"data_key": "data", "info_key": "info"}'
-                  style={{ fontFamily: 'monospace', fontSize: '0.875rem' }}
-                />
-                <small style={{ color: '#64748b' }}>
-                  Processing configuration
-                </small>
-              </div>
+            <div className="form-group">
+              <label className="form-label">Kafka port *</label>
+              <input
+                type="number"
+                name="kafka_port"
+                value={formData.kafka_port}
+                onChange={handleInputChange}
+                className="form-input"
+                placeholder="9092"
+                min={1}
+                max={65535}
+                required
+              />
             </div>
+          </div>
 
-            {/* Submit Button */}
-            <button 
-              type="submit" 
-              className="btn btn-primary"
-              disabled={loading}
+          <div className="form-group">
+            <label className="form-label">Kafka topic *</label>
+            <input
+              type="text"
+              name="kafka_topic"
+              value={formData.kafka_topic}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="example_topic"
+              required
+            />
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">Additional metadata</label>
+            <small style={{ color: '#64748b', display: 'block', marginBottom: '0.5rem' }}>
+              Optional key/value pairs stored on the dataset.
+            </small>
+            {extrasPairs.map((pair, idx) => (
+              <div key={idx} style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
+                <input
+                  type="text"
+                  value={pair.key}
+                  onChange={(e) => updateExtraPair(idx, 'key', e.target.value)}
+                  className="form-input"
+                  placeholder="key"
+                  style={{ flex: 1 }}
+                />
+                <input
+                  type="text"
+                  value={pair.value}
+                  onChange={(e) => updateExtraPair(idx, 'value', e.target.value)}
+                  className="form-input"
+                  placeholder="value"
+                  style={{ flex: 1 }}
+                />
+                <button
+                  type="button"
+                  onClick={() => removeExtraPair(idx)}
+                  className="btn btn-secondary"
+                  style={{ padding: '0.5rem 0.75rem' }}
+                  aria-label="Remove this pair"
+                >
+                  <Trash2 size={16} />
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={addExtraPair}
+              className="btn btn-secondary"
+              style={{ marginTop: '0.25rem' }}
             >
-              {loading ? (
+              <Plus size={16} />
+              Add field
+            </button>
+          </div>
+
+          <div style={{ display: 'flex', gap: '1rem' }}>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={submitting || orgsLoading || organizations.length === 0}
+            >
+              {submitting ? (
                 <>
                   <div className="loading-spinner" />
-                  {editingTopic ? 'Updating...' : 'Creating...'}
+                  Registering
                 </>
               ) : (
-                <>
-                  <Save size={16} />
-                  {editingTopic ? 'Update Kafka Topic' : 'Create Kafka Topic Dataset'}
-                </>
+                'Register Kafka topic'
               )}
             </button>
-          </form>
-        </div>
-      )}
-
-      {/* Kafka Topics List */}
-      <div className="card">
-        <div className="card-header">
-          <h3 className="card-title">
-            Kafka Topics ({kafkaTopics.length})
-          </h3>
-        </div>
-
-        {loading && !showCreateForm ? (
-          <div style={{ textAlign: 'center', padding: '2rem' }}>
-            <div className="loading-spinner" style={{ margin: '0 auto' }}></div>
-            <p style={{ marginTop: '1rem' }}>Loading Kafka topics...</p>
+            <button
+              type="button"
+              onClick={() => navigate('/')}
+              className="btn btn-secondary"
+              disabled={submitting}
+            >
+              Back to Search
+            </button>
           </div>
-        ) : kafkaTopics.length === 0 ? (
-          <div style={{ textAlign: 'center', padding: '2rem', color: '#64748b' }}>
-            <Radio size={48} style={{ marginBottom: '1rem', opacity: 0.5 }} />
-            <p>No Kafka topics found</p>
-            <p>Create your first Kafka topic using the form above</p>
-          </div>
-        ) : (
-          <div className="table-container">
-            <table className="table">
-              <thead>
-                <tr>
-                  <th>Topic</th>
-                  <th>Kafka Details</th>
-                  <th>Organization</th>
-                  <th>Status</th>
-                  <th>Resources</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {kafkaTopics.map((topic, index) => {
-                  const extras = topic.extras || {};
-                  const connectionStatus = getConnectionStatus(topic);
-                  
-                  return (
-                    <tr key={`${topic.id}-${index}`}>
-                      <td>
-                        <div>
-                          <div style={{ fontWeight: '500', marginBottom: '0.25rem' }}>
-                            {topic.title || topic.name}
-                          </div>
-                          {topic.title && topic.name && topic.title !== topic.name && (
-                            <div style={{ fontSize: '0.875rem', color: '#64748b' }}>
-                              {topic.name}
-                            </div>
-                          )}
-                          {topic.notes && (
-                            <div style={{ 
-                              fontSize: '0.875rem', 
-                              color: '#64748b',
-                              marginTop: '0.25rem',
-                              maxWidth: '200px',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              whiteSpace: 'nowrap'
-                            }}>
-                              {topic.notes}
-                            </div>
-                          )}
-                          <div style={{ 
-                            fontSize: '0.75rem', 
-                            color: '#94a3b8',
-                            marginTop: '0.25rem',
-                            fontFamily: 'monospace'
-                          }}>
-                            ID: {topic.id}
-                          </div>
-                        </div>
-                      </td>
-                      <td>
-                        <div>
-                          <div style={{ fontSize: '0.875rem', fontWeight: '500' }}>
-                            Topic: {extras.topic || extras.kafka_topic || 'N/A'}
-                          </div>
-                          <div style={{ fontSize: '0.875rem', color: '#64748b' }}>
-                            Host: {extras.host || extras.kafka_host || 'N/A'}
-                          </div>
-                          <div style={{ fontSize: '0.875rem', color: '#64748b' }}>
-                            Port: {extras.port || extras.kafka_port || 'N/A'}
-                          </div>
-                        </div>
-                      </td>
-                      <td>
-                        <span className="status-indicator status-success">
-                          {topic.owner_org || 'No organization'}
-                        </span>
-                      </td>
-                      <td>
-                        <span className={`status-indicator ${connectionStatus.color}`}>
-                          {connectionStatus.status}
-                        </span>
-                      </td>
-                      <td>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-                          <Database size={14} />
-                          <span>{topic.resources?.length || 0}</span>
-                        </div>
-                      </td>
-                      <td>
-                        <div style={{ display: 'flex', gap: '0.5rem' }}>
-                          <button
-                            onClick={() => startEditing(topic)}
-                            className="btn btn-secondary"
-                            style={{ padding: '0.375rem 0.75rem' }}
-                            title="Edit Kafka topic"
-                          >
-                            <Edit3 size={14} />
-                            <span style={{ fontSize: '0.75rem' }}>Edit</span>
-                          </button>
-                          
-                          <button
-                            onClick={() => handleDeleteTopic(topic)}
-                            className="btn btn-danger"
-                            style={{ padding: '0.375rem 0.75rem' }}
-                            title="Delete Kafka topic"
-                          >
-                            <Trash2 size={14} />
-                            <span style={{ fontSize: '0.75rem' }}>Delete</span>
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
+        </form>
       </div>
     </div>
   );

--- a/ui/src/pages/S3Resources.js
+++ b/ui/src/pages/S3Resources.js
@@ -1,474 +1,188 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { 
-  Database, 
-  Plus, 
-  AlertCircle, 
-  Edit3,
-  Save,
-  X,
-  Trash2,
-  RefreshCw,
-  ExternalLink,
-  FileText,
-  Cloud
-} from 'lucide-react';
-import { s3API, organizationsAPI, searchAPI, resourcesAPI } from '../services/api';
+import React, { useEffect, useState } from 'react';
+import { Database, AlertCircle, CheckCircle, Plus, Trash2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { s3API, organizationsAPI } from '../services/api';
 
 /**
- * S3 Resources page component for managing S3 bucket resources
- * Allows creating, listing, editing, and deleting S3 resources in CKAN
+ * Single-purpose page reached from "+ New > S3 resource". Registers an
+ * S3 object/path as a catalog dataset. Listing and deletion live on the
+ * Search page (S3 resources are CKAN packages and show up there).
  */
 const S3Resources = () => {
-  const [s3Resources, setS3Resources] = useState([]);
-  const [organizations, setOrganizations] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [success, setSuccess] = useState(null);
-  const [showCreateForm, setShowCreateForm] = useState(false);
-  const [editingResource, setEditingResource] = useState(null);
-  const [selectedServer] = useState('local'); // Fixed to local for consistency
-
-  // Form state for creating/editing S3 resource
+  const navigate = useNavigate();
   const [formData, setFormData] = useState({
     resource_name: '',
     resource_title: '',
     owner_org: '',
     resource_s3: '',
-    notes: '',
-    extras: {}
+    notes: ''
   });
+  const [extrasPairs, setExtrasPairs] = useState([]);
+  const [organizations, setOrganizations] = useState([]);
+  const [orgsLoading, setOrgsLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(null);
 
-  // JSON editor state for extras
-  const [extrasJson, setExtrasJson] = useState('{}');
-
-  /**
-   * Fetch organizations for dropdown
-   */
-  const fetchOrganizations = useCallback(async () => {
-    try {
-      const response = await organizationsAPI.list({ server: selectedServer });
-      setOrganizations(response.data || []);
-    } catch (err) {
-      console.error('Error fetching organizations:', err);
-    }
-  }, [selectedServer]);
-
-  /**
-   * Fetch all S3 resources (filtered from all datasets)
-   */
-  const fetchS3Resources = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      
-      // Use search to get all datasets, then filter for S3 resources
-      const response = await searchAPI.searchByTerms([''], null, selectedServer);
-      
-      // Filter to show only S3 resources
-      const filteredResources = (response.data || []).filter(dataset => {
-        const resources = dataset.resources || [];
-        
-        // Include if it has S3 resources
-        return resources.some(resource => 
-          resource.url && (
-            resource.url.startsWith('s3://') ||
-            resource.url.includes('s3.amazonaws.com') ||
-            resource.url.includes('.s3.')
-          )
-        ) && 
-        // Exclude Kafka topics (no Kafka extras)
-        !(dataset.extras && (
-          dataset.extras.kafka_topic || dataset.extras.kafka_host || 
-          dataset.extras.topic || dataset.extras.host
-        )) &&
-        // Exclude services organization
-        dataset.owner_org !== 'services';
-      });
-      
-      console.log('All datasets:', response.data); // Debug
-      console.log('Filtered S3 resources:', filteredResources); // Debug
-      
-      setS3Resources(filteredResources);
-      
-    } catch (err) {
-      console.error('Error fetching S3 resources:', err);
-      setError('Failed to load S3 resources: ' + 
-        (err.response?.data?.detail || err.message));
-    } finally {
-      setLoading(false);
-    }
-  }, [selectedServer]);
-
-  /**
-   * Fetch organizations and S3 resources on component mount
-   */
   useEffect(() => {
-    fetchOrganizations();
-    fetchS3Resources();
-  }, [fetchOrganizations, fetchS3Resources]);
+    let cancelled = false;
+    organizationsAPI
+      .list({ server: 'local' })
+      .then((response) => {
+        if (cancelled) return;
+        const orgs = Array.isArray(response.data) ? response.data : [];
+        setOrganizations(orgs);
+        setFormData((prev) =>
+          prev.owner_org ? prev : { ...prev, owner_org: orgs[0] || '' }
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setOrganizations([]);
+      })
+      .finally(() => {
+        if (!cancelled) setOrgsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
-  /**
-   * Handle form input changes
-   */
   const handleInputChange = (e) => {
     const { name, value } = e.target;
-    setFormData(prev => ({
-      ...prev,
-      [name]: value
-    }));
+    setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  /**
-   * Parse JSON string safely
-   */
-  const parseJsonSafely = (jsonString, fallback = {}) => {
-    try {
-      return jsonString.trim() === '' ? fallback : JSON.parse(jsonString);
-    } catch {
-      return fallback;
+  const addExtraPair = () =>
+    setExtrasPairs((prev) => [...prev, { key: '', value: '' }]);
+  const removeExtraPair = (idx) =>
+    setExtrasPairs((prev) => prev.filter((_, i) => i !== idx));
+  const updateExtraPair = (idx, field, value) =>
+    setExtrasPairs((prev) =>
+      prev.map((p, i) => (i === idx ? { ...p, [field]: value } : p))
+    );
+
+  const buildExtras = () => {
+    const out = {};
+    for (const { key, value } of extrasPairs) {
+      const trimmed = (key || '').trim();
+      if (trimmed) out[trimmed] = value;
     }
+    return out;
   };
 
-  /**
-   * Reset form to initial state
-   */
-  const resetForm = () => {
-    setFormData({
-      resource_name: '',
-      resource_title: '',
-      owner_org: '',
-      resource_s3: '',
-      notes: '',
-      extras: {}
-    });
-    setExtrasJson('{}');
-    setEditingResource(null);
-    setShowCreateForm(false);
-  };
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+    setSubmitting(true);
 
-  /**
-   * Prepare form data for submission
-   */
-  const prepareFormData = () => {
-    // Parse JSON fields
-    const extras = parseJsonSafely(extrasJson, {});
-
-    // Prepare data
-    const requestData = {
-      ...formData,
-      extras: Object.keys(extras).length > 0 ? extras : undefined
+    const payload = {
+      resource_name: formData.resource_name,
+      resource_title: formData.resource_title,
+      owner_org: formData.owner_org,
+      resource_s3: formData.resource_s3
     };
+    if (formData.notes) payload.notes = formData.notes;
+    const extras = buildExtras();
+    if (Object.keys(extras).length > 0) payload.extras = extras;
 
-    // Remove empty fields
-    Object.keys(requestData).forEach(key => {
-      if (requestData[key] === '' || requestData[key] === undefined) {
-        delete requestData[key];
-      }
-    });
-
-    return requestData;
-  };
-
-  /**
-   * Handle form submission for creating S3 resource
-   */
-  const handleCreate = async (e) => {
-    e.preventDefault();
-    
     try {
-      setError(null);
-      setSuccess(null);
-      setLoading(true);
-
-      const requestData = prepareFormData();
-      await s3API.create(requestData, selectedServer);
-      
-      setSuccess('S3 resource created successfully!');
-      resetForm();
-      fetchS3Resources();
-      
+      await s3API.create(payload, 'local');
+      setSuccess(
+        `S3 resource "${formData.resource_name}" registered. You can keep registering more or go back to Search.`
+      );
+      setFormData((prev) => ({
+        ...prev,
+        resource_name: '',
+        resource_title: '',
+        resource_s3: '',
+        notes: ''
+      }));
+      setExtrasPairs([]);
     } catch (err) {
-      console.error('Error creating S3 resource:', err);
-      setError('Failed to create S3 resource: ' + 
-        (err.response?.data?.detail || err.message));
+      const detail = err.response?.data?.detail;
+      const raw = typeof detail === 'string' ? detail : err.message;
+      const msg = raw || 'unknown error';
+      setError(
+        /already exists/i.test(msg)
+          ? `A resource called "${formData.resource_name}" already exists. Pick a different name.`
+          : `Could not register the S3 resource: ${msg}.`
+      );
     } finally {
-      setLoading(false);
+      setSubmitting(false);
     }
-  };
-
-  /**
-   * Handle form submission for updating S3 resource
-   */
-  const handleUpdate = async (e) => {
-    e.preventDefault();
-    
-    try {
-      setError(null);
-      setSuccess(null);
-      setLoading(true);
-
-      const requestData = prepareFormData();
-      await s3API.update(editingResource.id, requestData, selectedServer);
-      
-      setSuccess('S3 resource updated successfully!');
-      resetForm();
-      fetchS3Resources();
-      
-    } catch (err) {
-      console.error('Error updating S3 resource:', err);
-      setError('Failed to update S3 resource: ' + 
-        (err.response?.data?.detail || err.message));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  /**
-   * Start editing an S3 resource
-   */
-  const startEditing = (resource) => {
-    setEditingResource(resource);
-    const extras = resource.extras || {};
-    const firstResource = resource.resources && resource.resources[0];
-    
-    setFormData({
-      resource_name: resource.name || '',
-      resource_title: resource.title || '',
-      owner_org: resource.owner_org || '',
-      resource_s3: firstResource?.url || '',
-      notes: resource.notes || '',
-      extras: extras
-    });
-    
-    // Set JSON fields
-    setExtrasJson(JSON.stringify(extras, null, 2));
-    setShowCreateForm(true);
-  };
-
-  /**
-   * Handle S3 resource deletion
-   */
-  const handleDeleteResource = async (resource) => {
-    const displayName = resource.title || resource.name || 'Unnamed Resource';
-    
-    if (!window.confirm(
-      `Are you sure you want to delete S3 resource "${displayName}"? This will also delete all associated resources. This action cannot be undone.`
-    )) {
-      return;
-    }
-
-    try {
-      setError(null);
-      setSuccess(null);
-      
-      // Debug: Log the resource being deleted
-      console.log('Attempting to delete S3 resource with ID:', resource.id);
-      console.log('Using endpoint: DELETE /resource?resource_id=' + resource.id + '&server=local');
-      
-      // Use the resource deletion endpoint since datasets are resources in CKAN
-      await resourcesAPI.deleteById(resource.id, 'local');
-      
-      setSuccess(`S3 resource "${displayName}" deleted successfully!`);
-      
-      // Refresh the resources list
-      fetchS3Resources();
-      
-    } catch (err) {
-      console.error('Error deleting S3 resource:', err);
-      console.error('Full error object:', err);
-      console.error('Error response:', err.response);
-      
-      let errorMessage = 'Failed to delete S3 resource: ';
-      
-      if (err.response?.status === 404) {
-        errorMessage += `Resource "${displayName}" not found. It may have been already deleted.`;
-      } else if (err.response?.status === 405) {
-        errorMessage += 'Resource deletion method not allowed.';
-      } else if (err.response?.status === 401) {
-        errorMessage += 'Authentication required. Please login again.';
-      } else if (err.response?.status === 403) {
-        errorMessage += 'You do not have permission to delete this resource.';
-      } else {
-        errorMessage += (err.response?.data?.detail || err.message);
-      }
-      
-      setError(errorMessage);
-    }
-  };
-
-  /**
-   * Validate S3 URL format
-   */
-  const isValidS3Url = (url) => {
-    const s3Patterns = [
-      /^s3:\/\/[a-z0-9.-]+\/.*$/,
-      /^https:\/\/[a-z0-9.-]+\.s3[.-][a-z0-9.-]+\.amazonaws\.com\/.*$/,
-      /^https:\/\/s3[.-][a-z0-9.-]+\.amazonaws\.com\/[a-z0-9.-]+\/.*$/
-    ];
-    return s3Patterns.some(pattern => pattern.test(url));
-  };
-
-  /**
-   * Get the main S3 URL from resources
-   */
-  const getMainS3Url = (resource) => {
-    const firstResource = resource.resources && resource.resources[0];
-    return firstResource?.url || 'No URL';
-  };
-
-  /**
-   * Extract bucket name from S3 URL
-   */
-  const getBucketName = (url) => {
-    if (!url || url === 'No URL') return 'Unknown';
-    
-    try {
-      if (url.startsWith('s3://')) {
-        return url.split('/')[2];
-      } else if (url.includes('s3')) {
-        const match = url.match(/https:\/\/([^.]+)\.s3/);
-        if (match) return match[1];
-        
-        const bucketMatch = url.match(/amazonaws\.com\/([^/]+)/);
-        if (bucketMatch) return bucketMatch[1];
-      }
-    } catch (e) {
-      console.error('Error parsing bucket name:', e);
-    }
-    
-    return 'Unknown';
-  };
-
-  /**
-   * Get S3 region from URL or extras
-   */
-  const getS3Region = (resource) => {
-    const extras = resource.extras || {};
-    if (extras.region) return extras.region;
-    
-    const firstResource = resource.resources && resource.resources[0];
-    if (!firstResource?.url) return 'Unknown';
-    
-    try {
-      const regionMatch = firstResource.url.match(/s3[.-]([a-z0-9-]+)\.amazonaws\.com/);
-      if (regionMatch) return regionMatch[1];
-    } catch (e) {
-      console.error('Error parsing region:', e);
-    }
-    
-    return 'us-east-1'; // Default region
   };
 
   return (
-    <div className="s3-resources-page">
-      {/* Page Header */}
+    <div style={{ maxWidth: '720px', margin: '0 auto', padding: '0 1rem' }}>
       <div className="page-header">
         <h1 className="page-title">
           <Database size={32} style={{ marginRight: '0.5rem' }} />
-          S3 Resources
+          New S3 resource
         </h1>
         <p className="page-subtitle">
-          Register and manage Amazon S3 bucket resources in your CKAN instance
+          Register an S3 object or path as a catalog dataset. Find it (and
+          remove it) from the Search page once created.
         </p>
       </div>
 
-      {/* Alert Messages */}
       {error && (
         <div className="alert alert-error">
           <AlertCircle size={20} />
           {error}
         </div>
       )}
-
       {success && (
         <div className="alert alert-success">
+          <CheckCircle size={20} />
           {success}
         </div>
       )}
 
-      {/* Page actions */}
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
-        <button
-          onClick={fetchS3Resources}
-          className="btn btn-secondary"
-          disabled={loading}
-        >
-          <RefreshCw size={16} />
-          Refresh
-        </button>
-        {!showCreateForm && (
-          <button
-            onClick={() => setShowCreateForm(true)}
-            className="btn btn-primary"
-          >
-            <Plus size={16} />
-            Create S3 Resource
-          </button>
-        )}
-      </div>
-
-      {/* Create/Edit S3 Resource Form */}
-      {showCreateForm && (
-        <div className="card">
-          <div className="card-header">
-            <h3 className="card-title">
-              {editingResource ? (
-                <>
-                  <Edit3 size={20} />
-                  Edit S3 Resource: {editingResource.title}
-                </>
-              ) : (
-                <>
-                  <Plus size={20} />
-                  Create New S3 Resource
-                </>
-              )}
-            </h3>
-            <button
-              onClick={resetForm}
-              className="btn btn-secondary"
-            >
-              <X size={16} />
-              Cancel
-            </button>
+      <div className="card">
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label className="form-label">Resource name *</label>
+            <input
+              type="text"
+              name="resource_name"
+              value={formData.resource_name}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="my-s3-resource"
+              required
+            />
+            <small style={{ color: '#64748b' }}>
+              Unique identifier — lowercase letters, numbers, underscores
+              and hyphens only.
+            </small>
           </div>
 
-          <form onSubmit={editingResource ? handleUpdate : handleCreate}>
-            {/* Basic Information */}
-            <div className="grid grid-2">
-              <div className="form-group">
-                <label className="form-label">Resource Name *</label>
-                <input
-                  type="text"
-                  name="resource_name"
-                  value={formData.resource_name}
-                  onChange={handleInputChange}
-                  className="form-input"
-                  placeholder="my_s3_dataset"
-                  required
-                  disabled={editingResource} // Cannot change name when editing
-                />
-                <small style={{ color: '#64748b' }}>
-                  Unique identifier for the S3 resource
-                </small>
-              </div>
+          <div className="form-group">
+            <label className="form-label">Title *</label>
+            <input
+              type="text"
+              name="resource_title"
+              value={formData.resource_title}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="My S3 Resource"
+              required
+            />
+          </div>
 
-              <div className="form-group">
-                <label className="form-label">Resource Title *</label>
-                <input
-                  type="text"
-                  name="resource_title"
-                  value={formData.resource_title}
-                  onChange={handleInputChange}
-                  className="form-input"
-                  placeholder="My S3 Dataset"
-                  required
-                />
+          <div className="form-group">
+            <label className="form-label">Organization *</label>
+            {orgsLoading ? (
+              <div style={{ color: '#64748b', fontSize: '0.9rem' }}>
+                Loading organizations…
               </div>
-            </div>
-
-            <div className="form-group">
-              <label className="form-label">Organization *</label>
+            ) : organizations.length === 0 ? (
+              <div style={{ color: '#7f1d1d', fontSize: '0.9rem' }}>
+                No organizations available. Create one from &quot;+ New →
+                Organization&quot; first.
+              </div>
+            ) : (
               <select
                 name="owner_org"
                 value={formData.owner_org}
@@ -476,239 +190,112 @@ const S3Resources = () => {
                 className="form-select"
                 required
               >
-                <option value="">Select an organization</option>
-                {organizations.map(org => (
-                  <option key={org} value={org}>{org}</option>
+                <option value="" disabled>
+                  Choose an organization…
+                </option>
+                {organizations.map((org) => (
+                  <option key={org} value={org}>
+                    {org}
+                  </option>
                 ))}
               </select>
-            </div>
+            )}
+          </div>
 
-            {/* S3 URL */}
-            <div className="form-group">
-              <label className="form-label">S3 URL *</label>
-              <input
-                type="text"
-                name="resource_s3"
-                value={formData.resource_s3}
-                onChange={handleInputChange}
-                className="form-input"
-                placeholder="s3://my-bucket/path/to/file.csv"
-                required
-              />
-              <small style={{ color: '#64748b' }}>
-                S3 URL in format: s3://bucket-name/path/to/file or HTTPS URL
-              </small>
-              {formData.resource_s3 && !isValidS3Url(formData.resource_s3) && (
-                <div style={{ color: '#ef4444', fontSize: '0.875rem', marginTop: '0.25rem' }}>
-                  ⚠️ URL format may not be valid. Expected formats:
-                  <br />• s3://bucket-name/path/to/file
-                  <br />• https://bucket-name.s3.region.amazonaws.com/path/to/file
-                </div>
-              )}
-            </div>
+          <div className="form-group">
+            <label className="form-label">S3 path / URL *</label>
+            <input
+              type="text"
+              name="resource_s3"
+              value={formData.resource_s3}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="s3://bucket/path/to/object"
+              required
+            />
+          </div>
 
-            <div className="form-group">
-              <label className="form-label">Notes</label>
-              <textarea
-                name="notes"
-                value={formData.notes}
-                onChange={handleInputChange}
-                className="form-input form-textarea"
-                placeholder="Additional notes about the S3 resource..."
-              />
-            </div>
+          <div className="form-group">
+            <label className="form-label">Description</label>
+            <textarea
+              name="notes"
+              value={formData.notes}
+              onChange={handleInputChange}
+              className="form-input form-textarea"
+              placeholder="What does this resource contain?"
+            />
+          </div>
 
-            {/* Extras Configuration */}
-            <div className="form-group">
-              <label className="form-label">Extras (JSON)</label>
-              <textarea
-                value={extrasJson}
-                onChange={(e) => setExtrasJson(e.target.value)}
-                className="form-input form-textarea"
-                placeholder='{"region": "us-east-1", "access_key": "AKIA...", "secret_key": "..."}'
-                style={{ fontFamily: 'monospace', fontSize: '0.875rem' }}
-              />
-              <small style={{ color: '#64748b' }}>
-                Additional metadata including AWS credentials and configuration
-              </small>
-            </div>
-
-            {/* Submit Button */}
-            <button 
-              type="submit" 
-              className="btn btn-primary"
-              disabled={loading}
+          <div className="form-group">
+            <label className="form-label">Additional metadata</label>
+            <small style={{ color: '#64748b', display: 'block', marginBottom: '0.5rem' }}>
+              Optional key/value pairs stored on the dataset.
+            </small>
+            {extrasPairs.map((pair, idx) => (
+              <div key={idx} style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
+                <input
+                  type="text"
+                  value={pair.key}
+                  onChange={(e) => updateExtraPair(idx, 'key', e.target.value)}
+                  className="form-input"
+                  placeholder="key"
+                  style={{ flex: 1 }}
+                />
+                <input
+                  type="text"
+                  value={pair.value}
+                  onChange={(e) => updateExtraPair(idx, 'value', e.target.value)}
+                  className="form-input"
+                  placeholder="value"
+                  style={{ flex: 1 }}
+                />
+                <button
+                  type="button"
+                  onClick={() => removeExtraPair(idx)}
+                  className="btn btn-secondary"
+                  style={{ padding: '0.5rem 0.75rem' }}
+                  aria-label="Remove this pair"
+                >
+                  <Trash2 size={16} />
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={addExtraPair}
+              className="btn btn-secondary"
+              style={{ marginTop: '0.25rem' }}
             >
-              {loading ? (
+              <Plus size={16} />
+              Add field
+            </button>
+          </div>
+
+          <div style={{ display: 'flex', gap: '1rem' }}>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={submitting || orgsLoading || organizations.length === 0}
+            >
+              {submitting ? (
                 <>
                   <div className="loading-spinner" />
-                  {editingResource ? 'Updating...' : 'Creating...'}
+                  Registering
                 </>
               ) : (
-                <>
-                  <Save size={16} />
-                  {editingResource ? 'Update S3 Resource' : 'Create S3 Resource'}
-                </>
+                'Register S3 resource'
               )}
             </button>
-          </form>
-        </div>
-      )}
-
-      {/* S3 Resources List */}
-      <div className="card">
-        <div className="card-header">
-          <h3 className="card-title">
-            S3 Resources ({s3Resources.length})
-          </h3>
-        </div>
-
-        {loading && !showCreateForm ? (
-          <div style={{ textAlign: 'center', padding: '2rem' }}>
-            <div className="loading-spinner" style={{ margin: '0 auto' }}></div>
-            <p style={{ marginTop: '1rem' }}>Loading S3 resources...</p>
+            <button
+              type="button"
+              onClick={() => navigate('/')}
+              className="btn btn-secondary"
+              disabled={submitting}
+            >
+              Back to Search
+            </button>
           </div>
-        ) : s3Resources.length === 0 ? (
-          <div style={{ textAlign: 'center', padding: '2rem', color: '#64748b' }}>
-            <Cloud size={48} style={{ marginBottom: '1rem', opacity: 0.5 }} />
-            <p>No S3 resources found</p>
-            <p>Create your first S3 resource using the form above</p>
-          </div>
-        ) : (
-          <div className="table-container">
-            <table className="table">
-              <thead>
-                <tr>
-                  <th>Resource</th>
-                  <th>S3 Details</th>
-                  <th>Organization</th>
-                  <th>URL</th>
-                  <th>Resources</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {s3Resources.map((resource, index) => {
-                  const s3Url = getMainS3Url(resource);
-                  const bucketName = getBucketName(s3Url);
-                  const region = getS3Region(resource);
-                  
-                  return (
-                    <tr key={`${resource.id}-${index}`}>
-                      <td>
-                        <div>
-                          <div style={{ fontWeight: '500', marginBottom: '0.25rem' }}>
-                            {resource.title || resource.name}
-                          </div>
-                          {resource.title && resource.name && resource.title !== resource.name && (
-                            <div style={{ fontSize: '0.875rem', color: '#64748b' }}>
-                              {resource.name}
-                            </div>
-                          )}
-                          {resource.notes && (
-                            <div style={{ 
-                              fontSize: '0.875rem', 
-                              color: '#64748b',
-                              marginTop: '0.25rem',
-                              maxWidth: '200px',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              whiteSpace: 'nowrap'
-                            }}>
-                              {resource.notes}
-                            </div>
-                          )}
-                          <div style={{ 
-                            fontSize: '0.75rem', 
-                            color: '#94a3b8',
-                            marginTop: '0.25rem',
-                            fontFamily: 'monospace'
-                          }}>
-                            ID: {resource.id}
-                          </div>
-                        </div>
-                      </td>
-                      <td>
-                        <div>
-                          <div style={{ fontSize: '0.875rem', fontWeight: '500' }}>
-                            <Cloud size={14} style={{ display: 'inline', marginRight: '0.25rem' }} />
-                            {bucketName}
-                          </div>
-                          <div style={{ fontSize: '0.875rem', color: '#64748b' }}>
-                            Region: {region}
-                          </div>
-                        </div>
-                      </td>
-                      <td>
-                        <span className="status-indicator status-success">
-                          {resource.owner_org || 'No organization'}
-                        </span>
-                      </td>
-                      <td>
-                        {s3Url !== 'No URL' ? (
-                          <a 
-                            href={s3Url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            style={{
-                              color: '#2563eb',
-                              textDecoration: 'none',
-                              fontSize: '0.875rem',
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: '0.25rem',
-                              maxWidth: '150px',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              whiteSpace: 'nowrap'
-                            }}
-                            title={s3Url}
-                          >
-                            <ExternalLink size={12} />
-                            S3 Link
-                          </a>
-                        ) : (
-                          <span style={{ color: '#94a3b8', fontSize: '0.875rem' }}>
-                            No URL
-                          </span>
-                        )}
-                      </td>
-                      <td>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-                          <FileText size={14} />
-                          <span>{resource.resources?.length || 0}</span>
-                        </div>
-                      </td>
-                      <td>
-                        <div style={{ display: 'flex', gap: '0.5rem' }}>
-                          <button
-                            onClick={() => startEditing(resource)}
-                            className="btn btn-secondary"
-                            style={{ padding: '0.375rem 0.75rem' }}
-                            title="Edit S3 resource"
-                          >
-                            <Edit3 size={14} />
-                            <span style={{ fontSize: '0.75rem' }}>Edit</span>
-                          </button>
-                          
-                          <button
-                            onClick={() => handleDeleteResource(resource)}
-                            className="btn btn-danger"
-                            style={{ padding: '0.375rem 0.75rem' }}
-                            title="Delete S3 resource"
-                          >
-                            <Trash2 size={14} />
-                            <span style={{ fontSize: '0.75rem' }}>Delete</span>
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
+        </form>
       </div>
     </div>
   );

--- a/ui/src/pages/UrlResources.js
+++ b/ui/src/pages/UrlResources.js
@@ -1,626 +1,191 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { 
-  Link as LinkIcon, 
-  Plus, 
-  AlertCircle, 
-  Edit3,
-  Save,
-  X,
-  Trash2,
-  RefreshCw,
-  ExternalLink,
-  FileText
-} from 'lucide-react';
-import { urlAPI, organizationsAPI, searchAPI, resourcesAPI } from '../services/api';
+import React, { useEffect, useState } from 'react';
+import { Link as LinkIcon, AlertCircle, CheckCircle, Plus, Trash2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { urlAPI, organizationsAPI } from '../services/api';
 
 /**
- * URL Resources page component for managing URL-based resources
- * Allows creating, listing, editing, and deleting URL resources in CKAN
- * FIXED: Resolved URL resource update serialization error
+ * Single-purpose page reached from "+ New > URL resource". Registers a
+ * URL-backed resource as a catalog dataset. Listing and deletion live
+ * on the Search page (URL resources are CKAN packages and show there).
  */
-const UrlResources = () => {
-  const [urlResources, setUrlResources] = useState([]);
-  const [organizations, setOrganizations] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [success, setSuccess] = useState(null);
-  const [showCreateForm, setShowCreateForm] = useState(false);
-  const [editingResource, setEditingResource] = useState(null);
-  const [selectedServer] = useState('local'); // Fixed to local for consistency
+const FILE_TYPES = ['', 'CSV', 'TXT', 'JSON', 'NetCDF', 'stream'];
 
-  // Form state for creating/editing URL resource
+const UrlResources = () => {
+  const navigate = useNavigate();
   const [formData, setFormData] = useState({
     resource_name: '',
     resource_title: '',
     owner_org: '',
     resource_url: '',
-    file_type: '',
-    notes: '',
-    extras: {},
-    mapping: {},
-    processing: {}
+    file_type: ''
   });
+  const [extrasPairs, setExtrasPairs] = useState([]);
+  const [organizations, setOrganizations] = useState([]);
+  const [orgsLoading, setOrgsLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(null);
 
-  // JSON editor states for complex fields
-  const [extrasJson, setExtrasJson] = useState('{}');
-  const [mappingJson, setMappingJson] = useState('{}');
-  const [processingJson, setProcessingJson] = useState('{}');
-
-  // Available file types
-  const fileTypes = [
-    'stream',
-    'CSV',
-    'TXT',
-    'JSON',
-    'NetCDF'
-  ];
-
-  /**
-   * Fetch organizations for dropdown
-   */
-  const fetchOrganizations = useCallback(async () => {
-    try {
-      const response = await organizationsAPI.list({ server: selectedServer });
-      setOrganizations(response.data || []);
-    } catch (err) {
-      console.error('Error fetching organizations:', err);
-    }
-  }, [selectedServer]);
-
-  /**
-   * Fetch all URL resources (filtered from all datasets)
-   */
-  const fetchUrlResources = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      
-      // Use search to get all datasets, then filter for URL resources
-      const response = await searchAPI.searchByTerms([''], null, selectedServer);
-      
-      // Filter to show only URL resources
-      const filteredResources = (response.data || []).filter(dataset => {
-        const resources = dataset.resources || [];
-        
-        // Include if it has URL resources but exclude S3 URLs and Kafka topics
-        return resources.some(resource => 
-          resource.url && 
-          !resource.url.startsWith('s3://') &&
-          !resource.url.includes('s3.amazonaws.com') &&
-          !resource.url.includes('.s3.') &&
-          resource.format !== 'kafka'
-        ) && 
-        // Exclude Kafka topics (no Kafka extras)
-        !(dataset.extras && (
-          dataset.extras.kafka_topic || dataset.extras.kafka_host || 
-          dataset.extras.topic || dataset.extras.host
-        )) &&
-        // Exclude services organization
-        dataset.owner_org !== 'services';
-      });
-      
-      console.log('All datasets:', response.data); // Debug
-      console.log('Filtered URL resources:', filteredResources); // Debug
-      
-      setUrlResources(filteredResources);
-      
-    } catch (err) {
-      console.error('Error fetching URL resources:', err);
-      setError('Failed to load URL resources: ' + 
-        (err.response?.data?.detail || err.message));
-    } finally {
-      setLoading(false);
-    }
-  }, [selectedServer]);
-
-  /**
-   * Fetch organizations and URL resources on component mount
-   */
   useEffect(() => {
-    fetchOrganizations();
-    fetchUrlResources();
-  }, [fetchOrganizations, fetchUrlResources]);
+    let cancelled = false;
+    organizationsAPI
+      .list({ server: 'local' })
+      .then((response) => {
+        if (cancelled) return;
+        const orgs = Array.isArray(response.data) ? response.data : [];
+        setOrganizations(orgs);
+        setFormData((prev) =>
+          prev.owner_org ? prev : { ...prev, owner_org: orgs[0] || '' }
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setOrganizations([]);
+      })
+      .finally(() => {
+        if (!cancelled) setOrgsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
-  /**
-   * Handle form input changes
-   */
   const handleInputChange = (e) => {
     const { name, value } = e.target;
-    setFormData(prev => ({
-      ...prev,
-      [name]: value
-    }));
+    setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  /**
-   * Parse JSON string safely with better error handling
-   * FIXED: Improved JSON parsing with detailed error logging
-   */
-  const parseJsonSafely = (jsonString, fallback = {}, fieldName = 'JSON') => {
-    try {
-      if (!jsonString || jsonString.trim() === '') {
-        return fallback;
-      }
-      
-      const parsed = JSON.parse(jsonString);
-      console.log(`Successfully parsed ${fieldName}:`, parsed); // Debug log
-      return parsed;
-    } catch (parseError) {
-      console.error(`Error parsing ${fieldName}:`, parseError);
-      console.error(`Invalid ${fieldName} string:`, jsonString);
-      
-      // Return fallback but also set a user-friendly error
-      setError(`Invalid ${fieldName} format. Please check your JSON syntax.`);
-      return fallback;
+  const addExtraPair = () =>
+    setExtrasPairs((prev) => [...prev, { key: '', value: '' }]);
+  const removeExtraPair = (idx) =>
+    setExtrasPairs((prev) => prev.filter((_, i) => i !== idx));
+  const updateExtraPair = (idx, field, value) =>
+    setExtrasPairs((prev) =>
+      prev.map((p, i) => (i === idx ? { ...p, [field]: value } : p))
+    );
+
+  const buildExtras = () => {
+    const out = {};
+    for (const { key, value } of extrasPairs) {
+      const trimmed = (key || '').trim();
+      if (trimmed) out[trimmed] = value;
     }
+    return out;
   };
 
-  /**
-   * Reset form to initial state
-   */
-  const resetForm = () => {
-    setFormData({
-      resource_name: '',
-      resource_title: '',
-      owner_org: '',
-      resource_url: '',
-      file_type: '',
-      notes: '',
-      extras: {},
-      mapping: {},
-      processing: {}
-    });
-    setExtrasJson('{}');
-    setMappingJson('{}');
-    setProcessingJson('{}');
-    setEditingResource(null);
-    setShowCreateForm(false);
-  };
-
-  /**
-   * Prepare form data for submission
-   * FIXED: Improved data preparation with better validation and error handling
-   */
-  const prepareFormData = () => {
-    console.log('Preparing form data for submission...'); // Debug log
-    console.log('Current form data:', formData); // Debug log
-    console.log('JSON fields:', { extrasJson, mappingJson, processingJson }); // Debug log
-
-    // Parse JSON fields with better error handling
-    const extras = parseJsonSafely(extrasJson, {}, 'Extras');
-    const mapping = parseJsonSafely(mappingJson, {}, 'Mapping');
-    const processing = parseJsonSafely(processingJson, {}, 'Processing');
-
-    // If there was a JSON parsing error, return early
-    if (error && error.includes('Invalid') && error.includes('format')) {
-      return null;
-    }
-
-    // Prepare the request data according to the API specification
-    const requestData = {
-      // Always include required fields even if empty (let API validate)
-      resource_name: formData.resource_name || undefined,
-      resource_title: formData.resource_title || undefined,
-      owner_org: formData.owner_org || undefined,
-      resource_url: formData.resource_url || undefined,
-      notes: formData.notes || undefined,
-      // Only include complex objects if they have content (not empty objects)
-      extras: (extras && Object.keys(extras).length > 0) ? extras : undefined,
-      mapping: (mapping && Object.keys(mapping).length > 0) ? mapping : undefined,
-      processing: (processing && Object.keys(processing).length > 0) ? processing : undefined
-    };
-
-    // FIXED: Handle file_type validation - only include if it's a valid enum value
-    const validFileTypes = ['stream', 'CSV', 'TXT', 'JSON', 'NetCDF'];
-    if (formData.file_type && validFileTypes.includes(formData.file_type)) {
-      requestData.file_type = formData.file_type;
-    }
-    // If file_type is empty or "Auto-detect", don't include it in the request
-
-    // Remove undefined fields completely (API might not like them)
-    const cleanedData = {};
-    Object.keys(requestData).forEach(key => {
-      if (requestData[key] !== undefined && requestData[key] !== '') {
-        cleanedData[key] = requestData[key];
-      }
-    });
-
-    console.log('Final prepared data:', cleanedData); // Debug log
-    return cleanedData;
-  };
-
-  /**
-   * Handle form submission for creating URL resource
-   */
-  const handleCreate = async (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    
-    try {
-      setError(null);
-      setSuccess(null);
-      setLoading(true);
+    setError(null);
+    setSuccess(null);
+    setSubmitting(true);
 
-      const requestData = prepareFormData();
-      
-      // If data preparation failed due to JSON parsing error, stop here
-      if (!requestData) {
-        setLoading(false);
-        return;
-      }
-
-      console.log('Creating URL resource with data:', requestData); // Debug log
-      await urlAPI.create(requestData, selectedServer);
-      
-      setSuccess('URL resource created successfully!');
-      resetForm();
-      fetchUrlResources();
-      
-    } catch (err) {
-      console.error('Error creating URL resource:', err);
-      console.error('Full error object:', err.response); // Additional debug
-      
-      let errorMessage = 'Failed to create URL resource: ';
-      
-      // Better error message handling
-      if (err.response?.data?.detail) {
-        if (typeof err.response.data.detail === 'object') {
-          errorMessage += JSON.stringify(err.response.data.detail);
-        } else {
-          errorMessage += err.response.data.detail;
-        }
-      } else if (err.message) {
-        errorMessage += err.message;
-      } else {
-        errorMessage += 'Unknown error occurred';
-      }
-      
-      setError(errorMessage);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  /**
-   * Handle form submission for updating URL resource
-   * FIXED: Improved validation and data preparation for updates
-   */
-  const handleUpdate = async (e) => {
-    e.preventDefault();
-    
-    try {
-      setError(null);
-      setSuccess(null);
-      setLoading(true);
-
-      // FIXED: Ensure we're using the correct resource ID from the editing resource
-      if (!editingResource || !editingResource.id) {
-        throw new Error('Invalid resource ID for update operation');
-      }
-
-      const requestData = prepareFormData();
-      
-      // If data preparation failed due to JSON parsing error, stop here
-      if (!requestData) {
-        setLoading(false);
-        return;
-      }
-
-      // FIXED: Ensure all critical fields are present for update
-      // Even though API says they're optional, practice shows some are required
-      const updateData = {
-        // Always include these fields even if they haven't changed
-        resource_name: formData.resource_name || editingResource.name,
-        resource_title: formData.resource_title || editingResource.title,
-        owner_org: formData.owner_org || editingResource.owner_org,
-        resource_url: formData.resource_url || (editingResource.resources?.[0]?.url),
-        // Optional fields - only include if they have valid values
-        ...(formData.notes && { notes: formData.notes }),
-        ...(requestData.extras && { extras: requestData.extras }),
-        ...(requestData.mapping && { mapping: requestData.mapping }),
-        ...(requestData.processing && { processing: requestData.processing })
-      };
-
-      // FIXED: Handle file_type validation - only include if it's a valid enum value
-      const validFileTypes = ['stream', 'CSV', 'TXT', 'JSON', 'NetCDF'];
-      if (formData.file_type && validFileTypes.includes(formData.file_type)) {
-        updateData.file_type = formData.file_type;
-      }
-      // If file_type is empty or "Auto-detect", don't include it in the request
-      // The API will handle it appropriately
-
-      // Validate required fields before sending
-      const requiredFields = ['resource_name', 'resource_title', 'owner_org', 'resource_url'];
-      const missingFields = requiredFields.filter(field => !updateData[field]);
-      
-      if (missingFields.length > 0) {
-        throw new Error(`Missing required fields: ${missingFields.join(', ')}`);
-      }
-
-      console.log('Updating URL resource with ID:', editingResource.id); // Debug log
-      console.log('Final update data:', updateData); // Debug log
-      console.log('API endpoint will be:', `PUT /url/${editingResource.id}?server=${selectedServer}`); // Debug log
-
-      await urlAPI.update(editingResource.id, updateData, selectedServer);
-      
-      setSuccess('URL resource updated successfully!');
-      resetForm();
-      fetchUrlResources();
-      
-    } catch (err) {
-      console.error('Error updating URL resource:', err);
-      console.error('Full error object:', err.response); // Additional debug
-      console.error('Error config:', err.config); // Request configuration debug
-      
-      let errorMessage = 'Failed to update URL resource: ';
-      
-      // Better error message handling for updates
-      if (err.response?.status === 404) {
-        errorMessage += 'Resource not found. It may have been deleted.';
-      } else if (err.response?.status === 400) {
-        errorMessage += 'Invalid data provided. Please check your inputs.';
-      } else if (err.response?.status === 422) {
-        const detail = err.response?.data?.detail;
-        if (detail) {
-          if (typeof detail === 'object') {
-            // Handle validation error details
-            if (detail.error && detail.detail) {
-              errorMessage += `${detail.error}: ${detail.detail}`;
-            } else if (Array.isArray(detail)) {
-              // Handle array of validation errors
-              const validationErrors = detail.map(error => 
-                `Field '${error.loc?.join('.')}': ${error.msg || error.type}`
-              ).join(', ');
-              errorMessage += `Validation errors: ${validationErrors}`;
-            } else {
-              errorMessage += JSON.stringify(detail, null, 2);
-            }
-          } else {
-            errorMessage += detail;
-          }
-        } else {
-          errorMessage += 'Validation error. Please check required fields (resource_name, resource_title, owner_org, resource_url).';
-        }
-      } else if (err.message) {
-        errorMessage += err.message;
-      } else {
-        errorMessage += 'Unknown error occurred';
-      }
-      
-      setError(errorMessage);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  /**
-   * Start editing a URL resource
-   * FIXED: Improved data extraction and JSON field preparation
-   */
-  const startEditing = (resource) => {
-    console.log('Starting to edit resource:', resource); // Debug log
-    
-    setEditingResource(resource);
-    const extras = resource.extras || {};
-    const firstResource = resource.resources && resource.resources[0];
-    
-    // Extract mapping and processing from extras if they exist
-    const mapping = extras.mapping || {};
-    const processing = extras.processing || {};
-    
-    // Create clean extras without mapping and processing (since they have separate fields)
-    const cleanExtras = { ...extras };
-    delete cleanExtras.mapping;
-    delete cleanExtras.processing;
-    
-    const editFormData = {
-      resource_name: resource.name || '',
-      resource_title: resource.title || '',
-      owner_org: resource.owner_org || '',
-      resource_url: firstResource?.url || '',
-      file_type: firstResource?.format || '',
-      notes: resource.notes || '',
-      extras: cleanExtras,
-      mapping: mapping,
-      processing: processing
+    const payload = {
+      resource_name: formData.resource_name,
+      resource_title: formData.resource_title,
+      owner_org: formData.owner_org,
+      resource_url: formData.resource_url
     };
-    
-    console.log('Setting edit form data:', editFormData); // Debug log
-    
-    setFormData(editFormData);
-    
-    // Set JSON fields with proper formatting
-    try {
-      setExtrasJson(JSON.stringify(cleanExtras, null, 2));
-      setMappingJson(JSON.stringify(mapping, null, 2));
-      setProcessingJson(JSON.stringify(processing, null, 2));
-    } catch (jsonError) {
-      console.error('Error stringifying JSON for edit form:', jsonError);
-      // Fallback to empty objects
-      setExtrasJson('{}');
-      setMappingJson('{}');
-      setProcessingJson('{}');
-    }
-    
-    setShowCreateForm(true);
-  };
-
-  /**
-   * Handle URL resource deletion
-   */
-  const handleDeleteResource = async (resource) => {
-    const displayName = resource.title || resource.name || 'Unnamed Resource';
-    
-    if (!window.confirm(
-      `Are you sure you want to delete URL resource "${displayName}"? This will also delete all associated resources. This action cannot be undone.`
-    )) {
-      return;
-    }
+    if (formData.file_type) payload.file_type = formData.file_type;
+    const extras = buildExtras();
+    if (Object.keys(extras).length > 0) payload.extras = extras;
 
     try {
-      setError(null);
-      setSuccess(null);
-      
-      // Debug: Log the resource being deleted
-      console.log('Attempting to delete URL resource with ID:', resource.id);
-      console.log('Using endpoint: DELETE /resource?resource_id=' + resource.id + '&server=local');
-      
-      // Use the resource deletion endpoint since datasets are resources in CKAN
-      await resourcesAPI.deleteById(resource.id, 'local');
-      
-      setSuccess(`URL resource "${displayName}" deleted successfully!`);
-      
-      // Refresh the resources list
-      fetchUrlResources();
-      
+      await urlAPI.create(payload, 'local');
+      setSuccess(
+        `URL resource "${formData.resource_name}" registered. You can keep registering more or go back to Search.`
+      );
+      setFormData((prev) => ({
+        ...prev,
+        resource_name: '',
+        resource_title: '',
+        resource_url: '',
+        file_type: ''
+      }));
+      setExtrasPairs([]);
     } catch (err) {
-      console.error('Error deleting URL resource:', err);
-      console.error('Full error object:', err);
-      console.error('Error response:', err.response);
-      
-      let errorMessage = 'Failed to delete URL resource: ';
-      
-      if (err.response?.status === 404) {
-        errorMessage += `Resource "${displayName}" not found. It may have been already deleted.`;
-      } else if (err.response?.status === 405) {
-        errorMessage += 'Resource deletion method not allowed.';
-      } else if (err.response?.status === 401) {
-        errorMessage += 'Authentication required. Please login again.';
-      } else if (err.response?.status === 403) {
-        errorMessage += 'You do not have permission to delete this resource.';
-      } else {
-        errorMessage += (err.response?.data?.detail || err.message);
-      }
-      
-      setError(errorMessage);
+      const detail = err.response?.data?.detail;
+      const raw = typeof detail === 'string' ? detail : err.message;
+      const msg = raw || 'unknown error';
+      setError(
+        /already exists/i.test(msg)
+          ? `A resource called "${formData.resource_name}" already exists. Pick a different name.`
+          : `Could not register the URL resource: ${msg}.`
+      );
+    } finally {
+      setSubmitting(false);
     }
-  };
-
-  /**
-   * Get the main URL from resources
-   */
-  const getMainUrl = (resource) => {
-    const firstResource = resource.resources && resource.resources[0];
-    return firstResource?.url || 'No URL';
-  };
-
-  /**
-   * Get file type badge
-   */
-  const getFileType = (resource) => {
-    const firstResource = resource.resources && resource.resources[0];
-    return firstResource?.format || 'Unknown';
   };
 
   return (
-    <div className="url-resources-page">
-      {/* Page Header */}
+    <div style={{ maxWidth: '720px', margin: '0 auto', padding: '0 1rem' }}>
       <div className="page-header">
         <h1 className="page-title">
           <LinkIcon size={32} style={{ marginRight: '0.5rem' }} />
-          URL Resources
+          New URL resource
         </h1>
         <p className="page-subtitle">
-          Register and manage URL-based resources in your CKAN instance
+          Register a file or endpoint reachable over HTTP(S) as a catalog
+          dataset. Find it (and remove it) from the Search page once
+          created.
         </p>
       </div>
 
-      {/* Alert Messages */}
       {error && (
         <div className="alert alert-error">
           <AlertCircle size={20} />
           {error}
         </div>
       )}
-
       {success && (
         <div className="alert alert-success">
+          <CheckCircle size={20} />
           {success}
         </div>
       )}
 
-      {/* Page actions */}
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
-        <button
-          onClick={fetchUrlResources}
-          className="btn btn-secondary"
-          disabled={loading}
-        >
-          <RefreshCw size={16} />
-          Refresh
-        </button>
-        {!showCreateForm && (
-          <button
-            onClick={() => setShowCreateForm(true)}
-            className="btn btn-primary"
-          >
-            <Plus size={16} />
-            Create URL Resource
-          </button>
-        )}
-      </div>
-
-      {/* Create/Edit URL Resource Form */}
-      {showCreateForm && (
-        <div className="card">
-          <div className="card-header">
-            <h3 className="card-title">
-              {editingResource ? (
-                <>
-                  <Edit3 size={20} />
-                  Edit URL Resource: {editingResource.title}
-                </>
-              ) : (
-                <>
-                  <Plus size={20} />
-                  Create New URL Resource
-                </>
-              )}
-            </h3>
-            <button
-              onClick={resetForm}
-              className="btn btn-secondary"
-            >
-              <X size={16} />
-              Cancel
-            </button>
+      <div className="card">
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label className="form-label">Resource name *</label>
+            <input
+              type="text"
+              name="resource_name"
+              value={formData.resource_name}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="my-url-resource"
+              required
+            />
+            <small style={{ color: '#64748b' }}>
+              Unique identifier — lowercase letters, numbers, underscores
+              and hyphens only.
+            </small>
           </div>
 
-          <form onSubmit={editingResource ? handleUpdate : handleCreate}>
-            {/* Basic Information */}
-            <div className="grid grid-2">
-              <div className="form-group">
-                <label className="form-label">Resource Name *</label>
-                <input
-                  type="text"
-                  name="resource_name"
-                  value={formData.resource_name}
-                  onChange={handleInputChange}
-                  className="form-input"
-                  placeholder="example_resource_name"
-                  required
-                  disabled={editingResource} // Cannot change name when editing
-                />
-                <small style={{ color: '#64748b' }}>
-                  Unique identifier for the resource
-                </small>
-              </div>
+          <div className="form-group">
+            <label className="form-label">Title *</label>
+            <input
+              type="text"
+              name="resource_title"
+              value={formData.resource_title}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="My URL Resource"
+              required
+            />
+          </div>
 
-              <div className="form-group">
-                <label className="form-label">Resource Title *</label>
-                <input
-                  type="text"
-                  name="resource_title"
-                  value={formData.resource_title}
-                  onChange={handleInputChange}
-                  className="form-input"
-                  placeholder="Example Resource Title"
-                  required
-                />
+          <div className="form-group">
+            <label className="form-label">Organization *</label>
+            {orgsLoading ? (
+              <div style={{ color: '#64748b', fontSize: '0.9rem' }}>
+                Loading organizations…
               </div>
-            </div>
-
-            <div className="form-group">
-              <label className="form-label">Organization *</label>
+            ) : organizations.length === 0 ? (
+              <div style={{ color: '#7f1d1d', fontSize: '0.9rem' }}>
+                No organizations available. Create one from &quot;+ New →
+                Organization&quot; first.
+              </div>
+            ) : (
               <select
                 name="owner_org"
                 value={formData.owner_org}
@@ -628,272 +193,117 @@ const UrlResources = () => {
                 className="form-select"
                 required
               >
-                <option value="">Select an organization</option>
-                {organizations.map(org => (
-                  <option key={org} value={org}>{org}</option>
+                <option value="" disabled>
+                  Choose an organization…
+                </option>
+                {organizations.map((org) => (
+                  <option key={org} value={org}>
+                    {org}
+                  </option>
                 ))}
               </select>
-            </div>
+            )}
+          </div>
 
-            {/* URL and File Type */}
-            <div className="grid grid-2">
-              <div className="form-group">
-                <label className="form-label">Resource URL *</label>
-                <input
-                  type="url"
-                  name="resource_url"
-                  value={formData.resource_url}
-                  onChange={handleInputChange}
-                  className="form-input"
-                  placeholder="https://example.com/data.csv"
-                  required
-                />
-                <small style={{ color: '#64748b' }}>
-                  Direct URL to the resource file
-                </small>
-              </div>
+          <div className="form-group">
+            <label className="form-label">Resource URL *</label>
+            <input
+              type="url"
+              name="resource_url"
+              value={formData.resource_url}
+              onChange={handleInputChange}
+              className="form-input"
+              placeholder="https://example.com/data.csv"
+              required
+            />
+          </div>
 
-              <div className="form-group">
-                <label className="form-label">File Type</label>
-                <select
-                  name="file_type"
-                  value={formData.file_type}
-                  onChange={handleInputChange}
-                  className="form-select"
-                >
-                  <option value="">Auto-detect</option>
-                  {fileTypes.map(type => (
-                    <option key={type} value={type}>{type}</option>
-                  ))}
-                </select>
-              </div>
-            </div>
-
-            <div className="form-group">
-              <label className="form-label">Description</label>
-              <textarea
-                name="notes"
-                value={formData.notes}
-                onChange={handleInputChange}
-                className="form-input form-textarea"
-                placeholder="Additional notes about the resource..."
-              />
-            </div>
-
-            {/* Advanced Configuration */}
-            <div className="grid grid-3">
-              <div className="form-group">
-                <label className="form-label">Extras (JSON)</label>
-                <textarea
-                  value={extrasJson}
-                  onChange={(e) => setExtrasJson(e.target.value)}
-                  className="form-input form-textarea"
-                  placeholder='{"key1": "value1", "key2": "value2"}'
-                  style={{ fontFamily: 'monospace', fontSize: '0.875rem' }}
-                />
-                <small style={{ color: '#64748b' }}>
-                  Additional metadata as JSON
-                </small>
-              </div>
-
-              <div className="form-group">
-                <label className="form-label">Mapping (JSON)</label>
-                <textarea
-                  value={mappingJson}
-                  onChange={(e) => setMappingJson(e.target.value)}
-                  className="form-input form-textarea"
-                  placeholder='{"field1": "mapping1", "field2": "mapping2"}'
-                  style={{ fontFamily: 'monospace', fontSize: '0.875rem' }}
-                />
-                <small style={{ color: '#64748b' }}>
-                  Field mapping configuration
-                </small>
-              </div>
-
-              <div className="form-group">
-                <label className="form-label">Processing (JSON)</label>
-                <textarea
-                  value={processingJson}
-                  onChange={(e) => setProcessingJson(e.target.value)}
-                  className="form-input form-textarea"
-                  placeholder='{"delimiter": ",", "header_line": 1}'
-                  style={{ fontFamily: 'monospace', fontSize: '0.875rem' }}
-                />
-                <small style={{ color: '#64748b' }}>
-                  Processing configuration for CSV files
-                </small>
-              </div>
-            </div>
-
-            {/* Submit Button */}
-            <button 
-              type="submit" 
-              className="btn btn-primary"
-              disabled={loading}
+          <div className="form-group">
+            <label className="form-label">File type</label>
+            <select
+              name="file_type"
+              value={formData.file_type}
+              onChange={handleInputChange}
+              className="form-select"
             >
-              {loading ? (
+              {FILE_TYPES.map((t) => (
+                <option key={t || 'none'} value={t}>
+                  {t || '(unspecified)'}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">Additional metadata</label>
+            <small style={{ color: '#64748b', display: 'block', marginBottom: '0.5rem' }}>
+              Optional key/value pairs stored on the dataset.
+            </small>
+            {extrasPairs.map((pair, idx) => (
+              <div key={idx} style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
+                <input
+                  type="text"
+                  value={pair.key}
+                  onChange={(e) => updateExtraPair(idx, 'key', e.target.value)}
+                  className="form-input"
+                  placeholder="key"
+                  style={{ flex: 1 }}
+                />
+                <input
+                  type="text"
+                  value={pair.value}
+                  onChange={(e) => updateExtraPair(idx, 'value', e.target.value)}
+                  className="form-input"
+                  placeholder="value"
+                  style={{ flex: 1 }}
+                />
+                <button
+                  type="button"
+                  onClick={() => removeExtraPair(idx)}
+                  className="btn btn-secondary"
+                  style={{ padding: '0.5rem 0.75rem' }}
+                  aria-label="Remove this pair"
+                >
+                  <Trash2 size={16} />
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={addExtraPair}
+              className="btn btn-secondary"
+              style={{ marginTop: '0.25rem' }}
+            >
+              <Plus size={16} />
+              Add field
+            </button>
+          </div>
+
+          <div style={{ display: 'flex', gap: '1rem' }}>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={submitting || orgsLoading || organizations.length === 0}
+            >
+              {submitting ? (
                 <>
                   <div className="loading-spinner" />
-                  {editingResource ? 'Updating...' : 'Creating...'}
+                  Registering
                 </>
               ) : (
-                <>
-                  <Save size={16} />
-                  {editingResource ? 'Update URL Resource' : 'Create URL Resource'}
-                </>
+                'Register URL resource'
               )}
             </button>
-          </form>
-        </div>
-      )}
-
-      {/* URL Resources List */}
-      <div className="card">
-        <div className="card-header">
-          <h3 className="card-title">
-            URL Resources ({urlResources.length})
-          </h3>
-        </div>
-
-        {loading && !showCreateForm ? (
-          <div style={{ textAlign: 'center', padding: '2rem' }}>
-            <div className="loading-spinner" style={{ margin: '0 auto' }}></div>
-            <p style={{ marginTop: '1rem' }}>Loading URL resources...</p>
+            <button
+              type="button"
+              onClick={() => navigate('/')}
+              className="btn btn-secondary"
+              disabled={submitting}
+            >
+              Back to Search
+            </button>
           </div>
-        ) : urlResources.length === 0 ? (
-          <div style={{ textAlign: 'center', padding: '2rem', color: '#64748b' }}>
-            <LinkIcon size={48} style={{ marginBottom: '1rem', opacity: 0.5 }} />
-            <p>No URL resources found</p>
-            <p>Create your first URL resource using the form above</p>
-          </div>
-        ) : (
-          <div className="table-container">
-            <table className="table">
-              <thead>
-                <tr>
-                  <th>Resource</th>
-                  <th>URL</th>
-                  <th>File Type</th>
-                  <th>Organization</th>
-                  <th>Resources</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {urlResources.map((resource, index) => {
-                  const mainUrl = getMainUrl(resource);
-                  const fileType = getFileType(resource);
-                  
-                  return (
-                    <tr key={`${resource.id}-${index}`}>
-                      <td>
-                        <div>
-                          <div style={{ fontWeight: '500', marginBottom: '0.25rem' }}>
-                            {resource.title || resource.name}
-                          </div>
-                          {resource.title && resource.name && resource.title !== resource.name && (
-                            <div style={{ fontSize: '0.875rem', color: '#64748b' }}>
-                              {resource.name}
-                            </div>
-                          )}
-                          {resource.notes && (
-                            <div style={{ 
-                              fontSize: '0.875rem', 
-                              color: '#64748b',
-                              marginTop: '0.25rem',
-                              maxWidth: '200px',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              whiteSpace: 'nowrap'
-                            }}>
-                              {resource.notes}
-                            </div>
-                          )}
-                          <div style={{ 
-                            fontSize: '0.75rem', 
-                            color: '#94a3b8',
-                            marginTop: '0.25rem',
-                            fontFamily: 'monospace'
-                          }}>
-                            ID: {resource.id}
-                          </div>
-                        </div>
-                      </td>
-                      <td>
-                        {mainUrl !== 'No URL' ? (
-                          <a 
-                            href={mainUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            style={{
-                              color: '#2563eb',
-                              textDecoration: 'none',
-                              fontSize: '0.875rem',
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: '0.25rem',
-                              maxWidth: '200px',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              whiteSpace: 'nowrap'
-                            }}
-                            title={mainUrl}
-                          >
-                            <ExternalLink size={12} />
-                            {mainUrl}
-                          </a>
-                        ) : (
-                          <span style={{ color: '#94a3b8', fontSize: '0.875rem' }}>
-                            No URL
-                          </span>
-                        )}
-                      </td>
-                      <td>
-                        <span className="status-indicator status-info">
-                          {fileType}
-                        </span>
-                      </td>
-                      <td>
-                        <span className="status-indicator status-success">
-                          {resource.owner_org || 'No organization'}
-                        </span>
-                      </td>
-                      <td>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-                          <FileText size={14} />
-                          <span>{resource.resources?.length || 0}</span>
-                        </div>
-                      </td>
-                      <td>
-                        <div style={{ display: 'flex', gap: '0.5rem' }}>
-                          <button
-                            onClick={() => startEditing(resource)}
-                            className="btn btn-secondary"
-                            style={{ padding: '0.375rem 0.75rem' }}
-                            title="Edit URL resource"
-                          >
-                            <Edit3 size={14} />
-                            <span style={{ fontSize: '0.75rem' }}>Edit</span>
-                          </button>
-                          
-                          <button
-                            onClick={() => handleDeleteResource(resource)}
-                            className="btn btn-danger"
-                            style={{ padding: '0.375rem 0.75rem' }}
-                            title="Delete URL resource"
-                          >
-                            <Trash2 size={14} />
-                            <span style={{ fontSize: '0.75rem' }}>Delete</span>
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
+        </form>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- The "+ New" menu now creates **Kafka topic**, **URL resource** and **S3 resource** too (alongside Organization, Dataset, Service).
- `/kafka-topics`, `/url-resources`, `/s3-resources` are simplified to single-purpose creation forms (org dropdown + type-specific fields + key/value extras). Listing/edit/delete are dropped — these are CKAN packages, so they appear in the Search Datasets group and owned ones expose the existing Delete action.
- The "Resources" navigation dropdown is removed; **S3 Management** (bucket/object tool, not a catalog-creation flow) becomes a top-level nav item. Dead dropdown state/refs/handlers and the unused `FolderOpen` import were cleaned up.

## Backwards compatibility
- UI-only reorganization. No API behavior, request/response shapes, or routes change. `/kafka-topics`, `/url-resources`, `/s3-resources` remain (now create-only); `/s3-management` is unchanged.
- Resources registered before the creator-hash feature don't expose Delete on Search; no migration.

## Test plan
- [x] `react-scripts build` succeeds (-3.68 kB net thanks to the simplified pages).
- [x] End-to-end with `raul`/`raul`: `POST /kafka`, `POST /url`, `POST /s3` each return 201 with the simplified payloads the new forms send.
- [x] Nav: "+ New" shows the six items; "Resources" dropdown gone; "S3 Management" is a top-level link.

Closes #175.