### PR TITLE
Fix README docker run port so the API is reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.2] - 2026-06-05
+
+### Fixed
+- **The README `docker run` command no longer leaves the API unreachable.** It mapped the host port to container port `8000`, but the published `rbardaji/ndp-ep-api` all-in-one image serves the app through nginx on container port **80**, so nothing answered and every verification URL failed even though the container was healthy. The command now maps to `:80`, with a note explaining the all-in-one image and its port.
+
+### Changed
+- **The "Verify Installation" section is clearer and more complete.** It now lists the Web UI (`/ui/`) and the liveness endpoint (`/health`) alongside the docs and status URLs, and notes that the `docker compose` default host port is `8002` (vs `8001` for the `docker run` example).
+
+### Backwards compatibility
+- Documentation only. No API behavior, request/response shapes, or routes change.
+
 ## [0.32.1] - 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -247,8 +247,11 @@ S3_REGION=us-east-1
 
 2. **Run the container**:
 ```bash
-docker run -p 8001:8000 --env-file .env rbardaji/ndp-ep-api
+docker run -p 8001:80 --env-file .env rbardaji/ndp-ep-api
 ```
+The `rbardaji/ndp-ep-api` image is the all-in-one build (API + web UI behind
+nginx) and listens on container port **80**. The command above maps it to host
+port `8001`, so the API is reachable at `http://localhost:8001`.
 
 ### 3. Run with Docker Compose (Optional Services)
 
@@ -302,10 +305,14 @@ docker compose --profile mongodb --profile s3 --profile kafka --profile jupyter 
 
 ### 4. Verify Installation
 
-Once the container is running, verify everything is working:
+Once the container is running, verify everything is working (replace `8001`
+with `8002` if you started the stack with `docker compose`, whose default
+host port is `8002`):
 
 - **API Documentation**: http://localhost:8001/docs
-- **Health Check**: http://localhost:8001/status/
+- **Web UI**: http://localhost:8001/ui/
+- **Health Check (liveness)**: http://localhost:8001/health
+- **Status**: http://localhost:8001/status/
 - **Interactive API Explorer**: Available at the docs URL
 
 ### 5. Common Configuration Scenarios

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.32.1"
+    swagger_version: str = "0.32.2"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"


### PR DESCRIPTION
Closes #187

## Problem

The "Run with Docker" section documented:

```bash
docker run -p 8001:8000 --env-file .env rbardaji/ndp-ep-api
```

The published `rbardaji/ndp-ep-api` image is the all-in-one build, which serves the app through nginx on container port **80** (nothing listens on 8000 in that image). So mapping the host port to container `8000` connects to nothing, and every verification URL fails even though the container is up and healthy — exactly the failure a user hits when following the README as written.

## Changes

- `docker run` now maps to `:80` (`docker run -p 8001:80 ...`), with a short note explaining the all-in-one image and its port.
- "Verify Installation" now also lists the **Web UI** (`/ui/`) and the **liveness** endpoint (`/health`), and notes that `docker compose` uses host port `8002` by default (vs `8001` for the `docker run` example).
- Version bumped to `0.32.2` (`swagger_settings.py` + `CHANGELOG.md`).

## Testing

Documentation-only change; the only code change is the version string (existing tests mock the version, so none are affected).