### PR TITLE
Drop the 401 /status/ URL from Verify Installation steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.3] - 2026-06-05
+
+### Fixed
+- **The "Verify Installation" steps no longer point to an endpoint that returns `401`.** `/status/` requires an authentication token and returns `401` without one, so following the verification list produced a misleading failure on a fresh install. The quick verification now lists only the unauthenticated URLs that return success (`/docs`, `/ui/`, `/health`), with a note that `/status/` exists but requires a token.
+
+### Backwards compatibility
+- Documentation only. No API behavior, request/response shapes, or routes change.
+
 ## [0.32.2] - 2026-06-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -312,8 +312,11 @@ host port is `8002`):
 - **API Documentation**: http://localhost:8001/docs
 - **Web UI**: http://localhost:8001/ui/
 - **Health Check (liveness)**: http://localhost:8001/health
-- **Status**: http://localhost:8001/status/
 - **Interactive API Explorer**: Available at the docs URL
+
+> The `/status/` endpoint also reports detailed service status, but it requires
+> an authentication token and returns `401` without one, so it is not part of
+> the quick unauthenticated verification above.
 
 ### 5. Common Configuration Scenarios
 

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.32.2"
+    swagger_version: str = "0.32.3"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"


### PR DESCRIPTION
Closes #189

## Problem

The "Verify Installation" section listed `/status/` as a URL to open right after starting the API. That endpoint requires an authentication token and returns `401` for an unauthenticated request (verified by running the published image), so following the verification steps produced a failure-looking response on a fresh install.

## Change

- Keep only the unauthenticated URLs that return success: `/docs`, `/ui/`, `/health`.
- Add a note that `/status/` exists for detailed service status but requires an auth token.
- Version bumped to `0.32.3`.

## Testing

Verified against the running published image: `/docs`, `/ui/`, `/health` return `200`; `/status/` returns `401` without a token. Documentation-only change (only code change is the version string, which tests mock).