### PR TITLE
Fix test token being rejected under group-based access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.1] - 2026-07-25
+
+### Fixed
+- **The test token is no longer rejected on endpoints with group-based access enabled.** The user information fabricated for the test token carried the role `admin`, which the endpoint does not recognize (`ndp_admin` is the platform admin role), and no groups. With `ENABLE_GROUP_BASED_ACCESS=True` this failed the entry check, so `/user/info` returned 403 and the UI refused to let the test token in — and even where admitted it resolved to no effective role. The test token now carries `ndp_admin`, so it grants the full access it is meant to, regardless of group-based access.
+
+### Backwards compatibility
+- Only the roles reported for the test token change. No routes or request/response shapes change. The test token remains a development convenience that should be left unset in production.
+
 ## [0.33.0] - 2026-07-20
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.33.0"
+    swagger_version: str = "0.33.1"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/services/auth_services/get_current_user.py
+++ b/api/services/auth_services/get_current_user.py
@@ -42,8 +42,14 @@ def get_current_user(token_data=Depends(security)) -> Dict[str, Any]:
 
     # Handle test token
     if token == swagger_settings.test_token:
+        # The test token is meant to grant full access without contacting the
+        # authentication service. It must therefore carry the platform admin
+        # role the endpoint actually recognizes (``ndp_admin``); the earlier
+        # ``"admin"`` string matched nothing, so with group-based access
+        # enabled the test user was denied entry to its own endpoint and
+        # resolved to no effective role.
         return {
-            "roles": ["admin", "user"],
+            "roles": ["ndp_admin"],
             "groups": [],
             "sub": "test_user",
             "username": "Test User",

--- a/tests/test_test_token_access.py
+++ b/tests/test_test_token_access.py
@@ -1,0 +1,53 @@
+"""
+The test token must grant full access, including on endpoints that enable
+group-based access control.
+
+Regression for the case reported in the field: signing in with the test token
+was refused on an endpoint with ``ENABLE_GROUP_BASED_ACCESS=True`` because the
+fabricated user carried the role ``admin`` (not the recognized ``ndp_admin``)
+and belonged to no groups.
+"""
+
+from unittest.mock import patch
+
+from api.services.auth_services.authorization_service import (
+    check_group_membership,
+    effective_role,
+    is_admin,
+)
+from api.services.auth_services.get_current_user import get_current_user
+
+
+class _Creds:
+    def __init__(self, token):
+        self.credentials = token
+
+
+def _test_user():
+    with patch(
+        "api.services.auth_services.get_current_user.swagger_settings"
+    ) as settings:
+        settings.test_token = "the-test-token"
+        return get_current_user(token_data=_Creds("the-test-token"))
+
+
+def test_test_token_is_recognized_as_platform_admin():
+    assert is_admin(_test_user()) is True
+
+
+def test_test_token_resolves_to_admin_effective_role():
+    assert effective_role(_test_user()) == "admin"
+
+
+def test_test_token_passes_group_based_access():
+    """
+    The core of the reported bug: with group-based access enabled and an
+    allowed group configured, the test user (which is in no groups) must still
+    be admitted, on the strength of its platform admin role.
+    """
+    with patch(
+        "api.services.auth_services.authorization_service.swagger_settings"
+    ) as settings:
+        settings.enable_group_based_access = True
+        settings.group_names = "ndp_ep/ep-6a4bd3018a4f66a6d25cd511"
+        assert check_group_membership(_test_user()) is True


### PR DESCRIPTION
Closes #200

## Problem

The test token is meant to grant full access without contacting the authentication service. On an endpoint with `ENABLE_GROUP_BASED_ACCESS=True` it was refused: signing in through the UI with the test token returned 403.

The fabricated user carried the roles `admin` and `user` and belonged to no groups. The endpoint's platform admin role is `ndp_admin`, not `admin`, so entry — which requires an allowed group, `ndp_admin`, or the endpoint's own group — was denied. Even where the token was admitted, it resolved to no effective role and could exercise no write or management action.

This was reported from the field on the FARSITE endpoint, which has group-based access enabled.

## Fix

The test token now carries `ndp_admin`, the role it is meant to represent. One line, in the fabricated user info.

## Verified

New regression tests in `tests/test_test_token_access.py` cover the reported scenario directly: with group-based access enabled and an allowed group configured, the test user (in no groups) is admitted, is recognized as admin, and resolves to the `admin` effective role.

- Full suite: 1157 passed
- `black --check` and `flake8` clean

No routes or request/response shapes change; only the roles reported for the test token.