### PR TITLE
Recognize endpoint admins whose role uses the Keycloak group path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.3] - 2026-07-27
+
 ### Added
 - **An installer that ships with the code it installs** (`install/`). Driven by a Federation registration: `./install/install.sh --config-id <id>`. It renders `.env` from `example.env` rather than keeping its own list of settings, selects optional services through compose profiles, and verifies the authentication service and CKAN before writing anything.
 - `--backend ckan` installs CKAN, waits for it, creates a sysadmin and mints an API token, storing it in `.env.install-state` so re-running reuses it instead of minting another. Point at an existing CKAN with `--ckan-url` and `--ckan-api-key` instead.
@@ -16,8 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `docker-compose.yml` publishes the API on `${EP_API_PORT:-8002}`. The port was previously a literal that the old installer rewrote with `sed`; the pattern had stopped matching, and `sed -i` exits 0 when it matches nothing, so the override silently did nothing.
 
+### Fixed
+- **Endpoint administrators are recognized when their role uses the Keycloak group path.** Per-endpoint role recognition was keyed on `AFFINITIES_EP_UUID` (`group:{uuid}:admin`), but the identity provider emits the full group path (e.g. `group:ndp_ep/ep-{id}:admin`). On endpoints registered through the Federation or created by the installer, `AFFINITIES_EP_UUID` is unset, so every endpoint-scoped admin/writer/viewer role was missed — the API reported an effective role of `none` and the UI hid the management areas. Roles are now derived from the configured `GROUP_NAMES` (which hold the group paths the provider issues) and compared with path normalization, while the `AFFINITIES_EP_UUID` forms keep working for older deployments. Based on a fix from @Yutian-Qin and @salharir.
+
 ### Removed
 - The two stale installers at the repository root (`install.sh`, `setup.sh`). Neither had been updated since January, both had fallen behind `example.env` by eleven variables, and `setup.sh` had diverged from its counterpart in `sci-ndp/NDP-EP` by more than 1700 lines.
+
+### Backwards compatibility
+- No routes or request/response shapes change. Existing `ndp_admin` and `group:{AFFINITIES_EP_UUID}:*` role recognition is preserved.
 
 ## [0.33.2] - 2026-07-25
 

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.33.2"
+    swagger_version: str = "0.33.3"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/services/auth_services/authorization_service.py
+++ b/api/services/auth_services/authorization_service.py
@@ -47,6 +47,40 @@ def endpoint_group_role_name(role_level: str) -> str:
     return f"group:{ep_uuid}:{role_level}"
 
 
+def endpoint_group_role_names(role_level: str) -> List[str]:
+    """
+    Return accepted per-endpoint role names for ``role_level``.
+
+    The deployment's endpoint access boundary is configured through
+    ``GROUP_NAMES``. Keycloak group roles are emitted as
+    ``group:{group_path}:{role}``, so role checks must accept those group
+    paths directly. ``AFFINITIES_EP_UUID`` forms are still accepted for
+    older deployments that configured roles that way, but Affinities is
+    not required for the viewer/writer/admin model.
+    """
+    role_names = [
+        f"group:{group_name}:{role_level}" for group_name in get_allowed_groups()
+    ]
+
+    ep_uuid = (affinities_settings.ep_uuid or "").strip()
+    if not ep_uuid:
+        return list(dict.fromkeys(role_names))
+
+    normalized_ep = normalize_group_path(ep_uuid)
+    role_names.extend(
+        [
+            endpoint_group_role_name(role_level),
+            f"group:{normalized_ep}:{role_level}",
+        ]
+    )
+    if "/" not in normalized_ep:
+        role_names.append(f"group:ndp_ep/{ep_uuid}:{role_level}")
+        if not normalized_ep.startswith("ep-"):
+            role_names.append(f"group:ndp_ep/ep-{ep_uuid}:{role_level}")
+
+    return list(dict.fromkeys(role_names))
+
+
 def normalize_group_path(path: str) -> str:
     """
     Normalize a group path for comparison.
@@ -372,6 +406,21 @@ def get_user_for_endpoint_access(
     return user_info
 
 
+def _normalize_role_name(role: str) -> str:
+    """
+    Normalize a role name for comparison.
+
+    For Keycloak group roles, normalize the group path segment too, so
+    ``group:/ndp_ep/ep-1:admin`` and ``group:ndp_ep/ep-1:admin`` compare
+    as the same role.
+    """
+    value = role.strip().lower()
+    if value.startswith("group:") and ":" in value[len("group:") :]:
+        group_path, role_level = value[len("group:") :].rsplit(":", 1)
+        return f"group:{normalize_group_path(group_path)}:{role_level.strip()}"
+    return value
+
+
 def _has_any_role(user_info: Dict[str, Any], candidates) -> bool:
     """
     Return True if the user carries any of the role names in ``candidates``.
@@ -381,14 +430,15 @@ def _has_any_role(user_info: Dict[str, Any], candidates) -> bool:
     Empty strings in ``candidates`` are skipped (callers may pass them
     when AFFINITIES_EP_UUID is not configured).
     """
-    targets = {c.strip().lower() for c in candidates if c}
+    targets = {_normalize_role_name(c) for c in candidates if c}
     if not targets:
         return False
     roles = user_info.get("roles", [])
     if not isinstance(roles, list):
         return False
     return any(
-        isinstance(role, str) and role.strip().lower() in targets for role in roles
+        isinstance(role, str) and _normalize_role_name(role) in targets
+        for role in roles
     )
 
 
@@ -406,7 +456,7 @@ def is_admin(user_info: Dict[str, Any]) -> bool:
         user_info,
         [
             ADMIN_ROLE_NAME,
-            endpoint_group_role_name("admin"),
+            *endpoint_group_role_names("admin"),
             endpoint_admin_role_name(),
         ],
     )
@@ -421,7 +471,7 @@ def is_writer(user_info: Dict[str, Any]) -> bool:
         return True
     return _has_any_role(
         user_info,
-        [WRITER_ROLE_NAME, endpoint_group_role_name("writer")],
+        [WRITER_ROLE_NAME, *endpoint_group_role_names("writer")],
     )
 
 
@@ -434,7 +484,7 @@ def is_viewer(user_info: Dict[str, Any]) -> bool:
         return True
     return _has_any_role(
         user_info,
-        [VIEWER_ROLE_NAME, endpoint_group_role_name("viewer")],
+        [VIEWER_ROLE_NAME, *endpoint_group_role_names("viewer")],
     )
 
 

--- a/tests/test_authorization_service.py
+++ b/tests/test_authorization_service.py
@@ -684,6 +684,12 @@ class TestRoleTiers:
             ep_uuid=uuid,
         )
 
+    def _patch_group_names(self, group_names):
+        return patch(
+            "api.services.auth_services.authorization_service.swagger_settings",
+            group_names=group_names,
+        )
+
     EP = "11111111-2222-3333-4444-555555555555"
 
     def test_is_admin_via_global_role(self):
@@ -692,6 +698,28 @@ class TestRoleTiers:
     def test_is_admin_via_canonical_per_ep_role(self):
         with self._patch_uuid(self.EP):
             user = {"roles": [f"group:{self.EP}:admin"]}
+            assert is_admin(user) is True
+
+    def test_is_admin_via_keycloak_group_path_role(self):
+        with self._patch_uuid(f"ep-{self.EP}"):
+            user = {"roles": [f"group:ndp_ep/ep-{self.EP}:admin"]}
+            assert is_admin(user) is True
+            assert effective_role(user) == "admin"
+
+    def test_is_admin_via_keycloak_group_path_role_with_bare_uuid_config(self):
+        with self._patch_uuid(self.EP):
+            user = {"roles": [f"group:ndp_ep/ep-{self.EP}:admin"]}
+            assert is_admin(user) is True
+
+    def test_is_admin_via_group_names_without_affinities_uuid(self):
+        with self._patch_uuid(""), self._patch_group_names(f"ndp_ep/ep-{self.EP}"):
+            user = {"roles": [f"group:ndp_ep/ep-{self.EP}:admin"]}
+            assert is_admin(user) is True
+            assert effective_role(user) == "admin"
+
+    def test_is_admin_normalizes_leading_slash_in_group_path_role(self):
+        with self._patch_uuid(f"ndp_ep/ep-{self.EP}"):
+            user = {"roles": [f"group:/ndp_ep/ep-{self.EP}:admin"]}
             assert is_admin(user) is True
 
     def test_is_admin_via_legacy_per_ep_role_is_still_supported(self):
@@ -709,6 +737,7 @@ class TestRoleTiers:
         with self._patch_uuid(self.EP):
             assert is_writer({"roles": [WRITER_ROLE_NAME]}) is True
             assert is_writer({"roles": [f"group:{self.EP}:writer"]}) is True
+            assert is_writer({"roles": [f"group:ndp_ep/{self.EP}:writer"]}) is True
             assert is_writer({"roles": [ADMIN_ROLE_NAME]}) is True
             assert is_writer({"roles": [VIEWER_ROLE_NAME]}) is False
             assert is_writer({"roles": [f"group:{self.EP}:viewer"]}) is False
@@ -718,9 +747,15 @@ class TestRoleTiers:
         with self._patch_uuid(self.EP):
             assert is_viewer({"roles": [VIEWER_ROLE_NAME]}) is True
             assert is_viewer({"roles": [f"group:{self.EP}:viewer"]}) is True
+            assert is_viewer({"roles": [f"group:ndp_ep/{self.EP}:viewer"]}) is True
             assert is_viewer({"roles": [WRITER_ROLE_NAME]}) is True
             assert is_viewer({"roles": [ADMIN_ROLE_NAME]}) is True
             assert is_viewer({"roles": []}) is False
+
+    def test_group_names_roles_cover_writer_and_viewer_without_affinities_uuid(self):
+        with self._patch_uuid(""), self._patch_group_names(f"/ndp_ep/ep-{self.EP}"):
+            assert is_writer({"roles": [f"group:ndp_ep/ep-{self.EP}:writer"]}) is True
+            assert is_viewer({"roles": [f"group:ndp_ep/ep-{self.EP}:viewer"]}) is True
 
     def test_effective_role_returns_highest_tier(self):
         with self._patch_uuid(self.EP):

--- a/tests/test_endpoint_admin_group_path.py
+++ b/tests/test_endpoint_admin_group_path.py
@@ -1,0 +1,48 @@
+"""
+Regression: an endpoint admin whose role uses the Keycloak group path
+(group:ndp_ep/ep-{id}:admin) must be recognized, even when AFFINITIES_EP_UUID
+is unset — the case reported for nlr.ndp.utah.edu.
+"""
+
+from unittest.mock import patch
+
+from api.services.auth_services.authorization_service import effective_role, is_admin
+
+# The exact role from the reported /information response.
+SALEEM = {
+    "roles": [
+        "group:jhub_user:editor",
+        "professor",
+        "group:ndp_ep/ep-6a619d3f8b9242b94b015efb:admin",
+        "default-roles-ndp",
+    ],
+    "groups": [],
+    "sub": "77201bf0-329e-47e9-813a-a67ec967fdb1",
+    "username": "saleem.alharir@utah.edu",
+}
+
+
+def test_group_path_admin_is_recognized_without_affinities_uuid():
+    with (
+        patch("api.services.auth_services.authorization_service.swagger_settings") as s,
+        patch(
+            "api.services.auth_services.authorization_service.affinities_settings"
+        ) as a,
+    ):
+        s.group_names = "ndp_ep/ep-6a619d3f8b9242b94b015efb"
+        a.ep_uuid = ""  # the Federation/installer case
+        assert is_admin(SALEEM) is True
+        assert effective_role(SALEEM) == "admin"
+
+
+def test_leading_slash_in_group_path_still_matches():
+    slashed = {"roles": ["group:/ndp_ep/ep-abc:admin"]}
+    with (
+        patch("api.services.auth_services.authorization_service.swagger_settings") as s,
+        patch(
+            "api.services.auth_services.authorization_service.affinities_settings"
+        ) as a,
+    ):
+        s.group_names = "ndp_ep/ep-abc"
+        a.ep_uuid = ""
+        assert is_admin(slashed) is True


### PR DESCRIPTION
Closes #207

## Problem

A user who administers an endpoint but is not a platform-wide `ndp_admin` was treated as having no role on it — the API reported `effective_role: none` and the UI hid the management areas.

Per-endpoint role recognition was keyed on `AFFINITIES_EP_UUID` (`group:{uuid}:admin`), but the identity provider emits the full Keycloak group path, e.g. `group:ndp_ep/ep-6a619d3f8b9242b94b015efb:admin`. On endpoints registered through the Federation or created by the installer, `AFFINITIES_EP_UUID` is unset, so `is_admin`/`is_writer`/`is_viewer` matched only `ndp_admin` and every endpoint-scoped role was missed.

This was reported on `nlr.ndp.utah.edu` (group `ndp_ep/ep-6a619d3f8b9242b94b015efb`).

## Fix

Roles are now derived from the configured `GROUP_NAMES`, which hold the group paths the provider issues, and compared with group-path normalization (leading slash, case). The `AFFINITIES_EP_UUID` forms keep working for older deployments.

The `authorization_service.py` change and its tests come from @Yutian-Qin and @salharir's `hotfix_auth_pipeline` branch, applied on top of `main`. The rest of that branch (the test-token fix and the UI `effective_role` check) is already on `main` from #201/#203 — and the UI helper moved to `services/roles.js` since — so only the backend piece is taken here to avoid conflicts and regressions.

Note on why 0.33.2 alone didn't fix it: the UI already trusts `effective_role`, but the backend still computed `effective_role: none` for group-path roles, so the UI kept hiding the menus. This corrects the backend so `effective_role` is right.

## Verified

- Full suite: 1164 passed. `black` and `flake8` clean.
- Added `tests/test_endpoint_admin_group_path.py` with the exact reported role: `is_admin` true and `effective_role` == `admin` with `GROUP_NAMES=ndp_ep/ep-6a619d3f8b9242b94b015efb` and `AFFINITIES_EP_UUID` unset.

## Related

- Affects installer-created endpoints too (`GROUP_NAMES` set, `AFFINITIES_ENABLED=False`).
- Separate, tracked elsewhere: `/information` in the AAI returns all of a user's groups/roles across every endpoint; that needs data minimization but lives in `ndp-keycloak-aai-old`.

/cc @Yutian-Qin @salharir