### PR TITLE
Report NetBird and CKAN deployment metadata in metrics (no secrets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.4] - 2026-07-27
+
+### Added
+- **Deployment metadata in the metrics report.** The periodic metrics the Endpoint sends to the Federation now include its NetBird connectivity (enablement, address, group — from `NETBIRD_ENABLED`/`NETBIRD_IP`/`NETBIRD_GROUP`), the CKAN URL it publishes to, and a boolean saying whether a CKAN API key is configured. This lets the platform see an Endpoint's connectivity and catalog wiring at a glance. No secret or secret-derived value is ever sent — only the "configured" boolean. Based on a change from @salharir, with the CKAN API key and its fingerprint dropped from the payload (a metrics endpoint is not a place for secrets).
+
+### Backwards compatibility
+- Additive only. The extra fields appear in the metrics payload; no routes or request/response shapes change.
+
 ## [0.33.3] - 2026-07-27
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.33.3"
+    swagger_version: str = "0.33.4"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/tasks/metrics_task.py
+++ b/api/tasks/metrics_task.py
@@ -4,6 +4,7 @@ import asyncio
 from datetime import datetime
 import json
 import logging
+import os
 
 import httpx
 
@@ -21,6 +22,43 @@ from api.services.status_services import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _is_enabled(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def add_deployment_metrics(metrics_payload):
+    """
+    Add deployment metadata to the Federation metrics payload.
+
+    Reports connectivity and catalog wiring an operator needs to see an
+    Endpoint's setup at a glance: NetBird enablement/address/group (from the
+    installer-provided environment), the CKAN URL, and whether a CKAN API key
+    is configured.
+
+    No secret or secret-derived value is sent — only a boolean saying a CKAN
+    API key is present. The metrics endpoint is not a place for secrets.
+    """
+    netbird_enabled = _is_enabled(os.getenv("NETBIRD_ENABLED", ""))
+    netbird_ip = os.getenv("NETBIRD_IP", "").strip()
+    netbird_group = os.getenv("NETBIRD_GROUP", "").strip()
+
+    if netbird_enabled or netbird_ip or netbird_group:
+        metrics_payload["netbird_enabled"] = netbird_enabled
+        if netbird_ip:
+            metrics_payload["netbird_ip"] = netbird_ip
+        if netbird_group:
+            metrics_payload["netbird_group"] = netbird_group
+
+    ckan_url = (ckan_settings.ckan_url or "").strip()
+    if ckan_url:
+        metrics_payload["ckan_url"] = ckan_url
+
+    ckan_api_key = (ckan_settings.ckan_api_key or "").strip()
+    metrics_payload["ckan_api_key_configured"] = bool(
+        ckan_api_key and ckan_api_key != "your-api-key"
+    )
 
 
 async def record_system_metrics():
@@ -65,6 +103,7 @@ async def record_system_metrics():
                 "s3_enabled": s3_settings.s3_enabled,
                 "pre_ckan_enabled": ckan_settings.pre_ckan_enabled,
             }
+            add_deployment_metrics(metrics_payload)
 
             # Add URLs/details for enabled infrastructure services
             if swagger_settings.use_jupyterlab:

--- a/example.env
+++ b/example.env
@@ -29,6 +29,14 @@ METRICS_INTERVAL_SECONDS=3300
 # Endpoint the periodic metrics report is POSTed to.
 # Leave the default unless the NDP team gives you a different collector URL.
 METRICS_ENDPOINT=https://federation.ndp.utah.edu/metrics/
+
+# Optional deployment metadata included in the metrics report, so the platform
+# can see this Endpoint's NetBird connectivity. All optional; empty means not
+# reported. Only a boolean saying whether a CKAN API key is configured is
+# reported — never the key itself.
+NETBIRD_ENABLED=False
+NETBIRD_IP=
+NETBIRD_GROUP=
 # ==============================================
 # ACCESS CONTROL (Optional)
 # ==============================================

--- a/tests/test_metrics_task.py
+++ b/tests/test_metrics_task.py
@@ -319,3 +319,70 @@ class TestRecordSystemMetrics:
             await task
         except asyncio.CancelledError:
             pass
+
+
+class TestAddDeploymentMetrics:
+    """Tests for add_deployment_metrics — deployment metadata, no secrets."""
+
+    def test_reports_netbird_and_ckan_metadata(self):
+        from api.tasks.metrics_task import add_deployment_metrics
+
+        with (
+            patch("api.tasks.metrics_task.ckan_settings") as ckan,
+            patch.dict(
+                "os.environ",
+                {
+                    "NETBIRD_ENABLED": "true",
+                    "NETBIRD_IP": "100.64.0.5",
+                    "NETBIRD_GROUP": "ndp",
+                },
+                clear=False,
+            ),
+        ):
+            ckan.ckan_url = "https://ckan.example.org"
+            ckan.ckan_api_key = "a-real-key"
+            payload = {}
+            add_deployment_metrics(payload)
+
+        assert payload["netbird_enabled"] is True
+        assert payload["netbird_ip"] == "100.64.0.5"
+        assert payload["netbird_group"] == "ndp"
+        assert payload["ckan_url"] == "https://ckan.example.org"
+        assert payload["ckan_api_key_configured"] is True
+
+    def test_never_includes_the_api_key_or_a_derivative(self):
+        from api.tasks.metrics_task import add_deployment_metrics
+
+        with (
+            patch("api.tasks.metrics_task.ckan_settings") as ckan,
+            patch.dict(
+                "os.environ",
+                {"REPORT_CKAN_API_KEY_IN_METRICS": "true"},  # must be ignored
+                clear=False,
+            ),
+        ):
+            ckan.ckan_url = "https://ckan.example.org"
+            ckan.ckan_api_key = "super-secret-key"
+            payload = {}
+            add_deployment_metrics(payload)
+
+        serialized = str(payload)
+        assert "super-secret-key" not in serialized
+        assert "ckan_api_key" not in payload
+        assert "ckan_api_key_fingerprint" not in payload
+        assert payload["ckan_api_key_configured"] is True
+
+    def test_placeholder_key_counts_as_not_configured(self):
+        from api.tasks.metrics_task import add_deployment_metrics
+
+        with (
+            patch("api.tasks.metrics_task.ckan_settings") as ckan,
+            patch.dict("os.environ", {}, clear=False),
+        ):
+            ckan.ckan_url = ""
+            ckan.ckan_api_key = "your-api-key"
+            payload = {}
+            add_deployment_metrics(payload)
+
+        assert payload["ckan_api_key_configured"] is False
+        assert "ckan_url" not in payload


### PR DESCRIPTION
Closes #209. Extracts the useful part of #198 onto `main`.

## What

The periodic metrics the Endpoint sends to the Federation now include deployment context:
- NetBird enablement/address/group (`NETBIRD_ENABLED` / `NETBIRD_IP` / `NETBIRD_GROUP`)
- the CKAN URL it publishes to
- a boolean, `ckan_api_key_configured`

So the platform can see an Endpoint's connectivity and catalog wiring at a glance.

## Difference from #198

This is @salharir's `feature/netbird-ckan-metrics` change, isolated:
- Dropped the branch's bundled auth changes — they're already on `main` (#201/#203, and #208 for the group-path fix), which is why #198 conflicts.
- **Dropped the CKAN API key and its fingerprint from the payload.** #198 reported a sha256 fingerprint and, behind `REPORT_CKAN_API_KEY_IN_METRICS`, the full key. A metrics endpoint is not a place for a secret or a secret-derived value — especially since the Federation's stored data is served without authentication elsewhere. The `ckan_api_key_configured` boolean gives operators the "is it set" signal without exposing anything.

Tests assert the metadata is reported **and** that the key/fingerprint never appear, even with `REPORT_CKAN_API_KEY_IN_METRICS=true`.

## Verified
- Full suite 1170 passed; installer tests 15 passed; `black`/`flake8` clean.
- `NETBIRD_*` documented in `example.env`.

Once this merges, #198 can be closed as superseded.

/cc @salharir