### PR TITLE
Stop reporting auth-service failures as invalid tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.5] - 2026-07-27
+
+### Fixed
+- **Authentication-service failures are no longer reported as invalid tokens.** `get_current_user` raised `HTTPException(502)` for an unreachable or misbehaving auth service inside a `try` whose trailing `except Exception` rewrote everything as `401 "Authentication failed"` — so an auth service that was down, returning 500, or answering an unexpected status looked exactly like a mistyped token. Deliberately-raised statuses now propagate unchanged (`except HTTPException: raise`), an unreachable service and unexpected errors return `502`, and only a token the service actually rejects returns `401`.
+
+### Backwards compatibility
+- A genuinely invalid token still returns `401`. Cases that were previously mislabelled `401` (auth service down, 500, unexpected status) now correctly return `502`.
+
 ## [0.33.4] - 2026-07-27
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.33.4"
+    swagger_version: str = "0.33.5"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/services/auth_services/get_current_user.py
+++ b/api/services/auth_services/get_current_user.py
@@ -101,7 +101,13 @@ def get_current_user(token_data=Depends(security)) -> Dict[str, Any]:
         data = response.json()
 
         if "error" in data:
-            raise Exception(f"Token validation failed: {data['error']}")
+            # The authentication service accepted the request but rejected the
+            # token — a genuine 401, not an internal failure.
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=f"Invalid token: {data['error']}",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
 
         # Ensure 'sub' field is always present
         if "sub" not in data:
@@ -113,15 +119,26 @@ def get_current_user(token_data=Depends(security)) -> Dict[str, Any]:
 
         return data
 
+    except HTTPException:
+        # Statuses this function deliberately raised (a 401 for a bad token, a
+        # 502 for an unreachable or misbehaving auth service) must reach the
+        # caller unchanged. Without this, the generic handler below would
+        # rewrite every one of them as 401 "Authentication failed", so an auth
+        # service that is down looked exactly like a mistyped token.
+        raise
     except requests.exceptions.RequestException as e:
+        # Could not reach the auth service at all — a gateway problem, not a
+        # bad token.
+        logger.error(f"Auth service unreachable: {e}")
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"Auth service unavailable: {str(e)}",
-            headers={"WWW-Authenticate": "Bearer"},
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authentication service is unavailable.",
         )
     except Exception as e:
+        # An unexpected failure while validating (e.g. a malformed response).
+        # It is not the caller's token that is at fault, so it is not a 401.
+        logger.error(f"Unexpected error validating token: {e}")
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"Authentication failed: {str(e)}",
-            headers={"WWW-Authenticate": "Bearer"},
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authentication service returned an unexpected error.",
         )

--- a/tests/test_get_current_user_errors.py
+++ b/tests/test_get_current_user_errors.py
@@ -1,0 +1,98 @@
+"""
+Auth-service failures must not be reported as invalid tokens (issue #195).
+
+get_current_user validates against an external service. A 401 from that
+service is a bad token; anything else (unreachable, 500, unexpected status,
+malformed body) is an infrastructure problem and must not be flattened into
+401 "Authentication failed".
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from fastapi import HTTPException, status
+
+from api.services.auth_services.get_current_user import get_current_user
+
+
+class _Creds:
+    def __init__(self, token):
+        self.credentials = token
+
+
+def _call(token="a-token"):
+    with patch(
+        "api.services.auth_services.get_current_user.swagger_settings"
+    ) as settings:
+        settings.test_token = "the-test-token"
+        settings.auth_api_url = "https://aai.example.org/information"
+        return get_current_user(token_data=_Creds(token))
+
+
+def _resp(status_code, json_body=None):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_body if json_body is not None else {}
+    r.text = str(json_body)
+    return r
+
+
+def test_auth_service_500_is_502_not_401():
+    with patch(
+        "api.services.auth_services.get_current_user.requests.post",
+        return_value=_resp(500),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            _call()
+    assert exc.value.status_code == status.HTTP_502_BAD_GATEWAY
+
+
+def test_auth_service_unexpected_status_is_502_not_401():
+    with patch(
+        "api.services.auth_services.get_current_user.requests.post",
+        return_value=_resp(418),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            _call()
+    assert exc.value.status_code == status.HTTP_502_BAD_GATEWAY
+
+
+def test_auth_service_unreachable_is_502_not_401():
+    with patch(
+        "api.services.auth_services.get_current_user.requests.post",
+        side_effect=requests.exceptions.ConnectionError("no route"),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            _call()
+    assert exc.value.status_code == status.HTTP_502_BAD_GATEWAY
+
+
+def test_invalid_token_is_still_401():
+    with patch(
+        "api.services.auth_services.get_current_user.requests.post",
+        return_value=_resp(401),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            _call()
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_error_in_body_is_401():
+    with patch(
+        "api.services.auth_services.get_current_user.requests.post",
+        return_value=_resp(200, {"error": "token expired"}),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            _call()
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert "token expired" in exc.value.detail
+
+
+def test_valid_token_returns_user_info():
+    with patch(
+        "api.services.auth_services.get_current_user.requests.post",
+        return_value=_resp(200, {"roles": ["ndp_admin"], "sub": "abc"}),
+    ):
+        info = _call()
+    assert info["sub"] == "abc"


### PR DESCRIPTION
Closes #195

## Problem

`get_current_user` raised `HTTPException(502)` for an unreachable or misbehaving authentication service inside a `try` whose trailing `except Exception` rewrote everything as `401 "Authentication failed"`. Since `HTTPException` is an `Exception`, those deliberate 502s were caught and flattened — so an auth service that was down, returning 500, or answering an unexpected status looked exactly like a mistyped token.

This cost real diagnosis time earlier: the AAI returned 500 for a token without a `sub` claim, and the UI reported invalid credentials.

## Fix

- `except HTTPException: raise` before the generic handler, so deliberately-raised statuses reach the caller unchanged.
- An unreachable service (`RequestException`) and unexpected internal errors return `502`, not `401`.
- A response body carrying an `error` field is a real token rejection → `401` with a clear message.
- A genuinely invalid token still returns `401`.

## Verified

New `tests/test_get_current_user_errors.py`: auth-service 500 / unexpected status / unreachable all return 502; invalid token and error-in-body return 401; a valid token returns the user info. Full suite 1176 passed; `black`/`flake8` clean.