### PR TITLE
Install an Endpoint with no local catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/status` reports the backend as disconnected without attempting a connection when there is no local catalog, instead of logging a failed one every call.
 
 ### Fixed
+- **A container built today starts again.** `requirements.txt` constrained nothing, so a fresh install resolved `mcp` 2.0.0, whose low-level `Server` no longer accepts the positional arguments `fastapi-mcp` 0.4.0 passes it. `FastApiMCP(app)` runs at import time, so the API did not come up at all and CI failed on every branch; images built earlier were unaffected because their dependencies were resolved when they were built. Pinned to `mcp<2.0.0` until `fastapi-mcp` supports it.
 - **An Endpoint with no local catalog keeps reporting to the Federation.** Catalog statistics are collected inside the same `try` as the rest of the metrics payload, so asking for a repository that does not exist left the payload empty and skipped the POST entirely — the Endpoint would have gone silent rather than reporting without dataset counts. With no catalog the counts are reported as zero and the metrics go out as usual.
 
 ### Backwards compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-08-03
+
+### Added
+- **An Endpoint can be installed with no local catalog.** `LOCAL_CATALOG_BACKEND=none` is a deployment that stores nothing locally — no MongoDB, no CKAN, nothing to install. It authenticates users, searches the platform's global catalog, serves its UI and reports to the Federation, which is what most Endpoints are asked to do. The installer offers it as the first answer to the local-catalog question and renders it together with `CKAN_LOCAL_ENABLED=False`, blanking the CKAN and MongoDB settings so nothing points at a service that was not installed. A catalog can be added later by running the installer again with `--backend mongodb` or `--backend ckan`.
+- `catalog_settings.has_local_catalog`, so callers can skip local catalog work instead of asking for a repository that does not exist.
+
+### Changed
+- **The installer's default backend is now `none`.** The lightest install is the one that needs no decisions; asking for MongoDB or CKAN is opting in to more. Runs that relied on the previous default of `mongodb` must now pass `--backend mongodb` explicitly.
+- **The readiness probe no longer checks a local catalog nothing can reach.** `/ready` reported the catalog as `disabled` only for the CKAN backend; with any other backend it probed the catalog even when `CKAN_LOCAL_ENABLED=False` had already unmounted the local catalog routes and made `/search?server=local` answer 400. An Endpoint deliberately configured without a usable local catalog was reported unhealthy with HTTP 503. It is now reported `disabled` whenever the local catalog cannot be reached through the API, on any backend.
+- `/status` reports the backend as disconnected without attempting a connection when there is no local catalog, instead of logging a failed one every call.
+
+### Fixed
+- **An Endpoint with no local catalog keeps reporting to the Federation.** Catalog statistics are collected inside the same `try` as the rest of the metrics payload, so asking for a repository that does not exist left the payload empty and skipped the POST entirely — the Endpoint would have gone silent rather than reporting without dataset counts. With no catalog the counts are reported as zero and the metrics go out as usual.
+
+### Backwards compatibility
+- Existing deployments are unaffected: `ckan` and `mongodb` behave exactly as before, and the new behaviour applies only to `LOCAL_CATALOG_BACKEND=none`.
+- The one behaviour change for existing setups is the readiness probe: a deployment running with `CKAN_LOCAL_ENABLED=False` and a MongoDB backend was answering 503 and now answers 200 with the catalog reported `disabled`.
+- Unattended installer runs that did not pass `--backend` used to get MongoDB and now get no catalog. Add `--backend mongodb` to keep the previous result.
+
 ## [0.33.5] - 2026-07-27
 
 ### Fixed

--- a/api/config/catalog_settings.py
+++ b/api/config/catalog_settings.py
@@ -22,7 +22,10 @@ class CatalogSettings(BaseSettings):
     Attributes
     ----------
     local_catalog_backend : str
-        Backend type for local catalog: "ckan" or "mongodb" (default: "ckan")
+        Backend type for local catalog: "ckan", "mongodb" or "none"
+        (default: "ckan"). "none" means this Endpoint stores nothing
+        locally: it serves the global NDP catalog and its own
+        authentication, and no local catalog is expected to exist.
     mongodb_connection_string : str
         MongoDB connection URI (default: "mongodb://localhost:27017")
     mongodb_database : str
@@ -43,6 +46,22 @@ class CatalogSettings(BaseSettings):
     }
 
     @property
+    def has_local_catalog(self) -> bool:
+        """
+        Whether this Endpoint has a local catalog at all.
+
+        LOCAL_CATALOG_BACKEND="none" is a deployment that stores nothing
+        locally. Callers use this to skip local catalog work rather than
+        letting `local_catalog` raise.
+
+        Returns
+        -------
+        bool
+            False when LOCAL_CATALOG_BACKEND is "none", True otherwise
+        """
+        return self.local_catalog_backend.lower() != "none"
+
+    @property
     def local_catalog(self) -> DataCatalogRepository:
         """
         Get the repository for the local catalog.
@@ -58,11 +77,18 @@ class CatalogSettings(BaseSettings):
         Raises
         ------
         ValueError
-            If an unsupported backend type is specified
+            If no local catalog is configured, or an unsupported backend
+            type is specified
         """
         backend = self.local_catalog_backend.lower()
 
-        if backend == "mongodb":
+        if backend == "none":
+            raise ValueError(
+                "This Endpoint has no local catalog "
+                "(LOCAL_CATALOG_BACKEND=none). Set it to 'ckan' or 'mongodb' "
+                "to store datasets locally."
+            )
+        elif backend == "mongodb":
             return MongoDBRepository(
                 connection_string=self.mongodb_connection_string,
                 database_name=self.mongodb_database,
@@ -72,7 +98,7 @@ class CatalogSettings(BaseSettings):
         else:
             raise ValueError(
                 f"Unsupported catalog backend: {backend}. "
-                f"Supported backends: 'ckan', 'mongodb'"
+                f"Supported backends: 'ckan', 'mongodb', 'none'"
             )
 
     @property

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.33.5"
+    swagger_version: str = "0.34.0"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/main.py
+++ b/api/main.py
@@ -16,6 +16,7 @@ import api.routes as routes
 from api.middleware import CorrelationIdMiddleware
 from api.exceptions import register_exception_handlers
 from api.config import ckan_settings, swagger_settings
+from api.config.catalog_settings import catalog_settings
 from api.config.minio_settings import s3_settings
 from api.routes.update_routes.put_dataset import router as dataset_update_router
 from api.tasks.metrics_task import record_system_metrics
@@ -50,11 +51,20 @@ root_logger.addHandler(file_handler)
 root_logger.addHandler(console_handler)
 
 
+# The local catalog is in play only when a backend provides one and the master
+# switch is on. LOCAL_CATALOG_BACKEND=none is an Endpoint that stores nothing
+# locally: mounting the routes that write to a catalog would offer operations
+# that cannot work.
+local_catalog_enabled = (
+    ckan_settings.ckan_local_enabled and catalog_settings.has_local_catalog
+)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Run tasks on startup and handle shutdown."""
     # Ensure 'services' organization exists
-    if ckan_settings.ckan_local_enabled:
+    if local_catalog_enabled:
         try:
             from api.services.organization_services.list_organization import (
                 list_organization,
@@ -133,13 +143,13 @@ register_exception_handlers(app)
 
 app.include_router(routes.default_router, include_in_schema=False)
 app.include_router(routes.health_router, tags=["Health"])
-if ckan_settings.ckan_local_enabled:
+if local_catalog_enabled:
     app.include_router(routes.register_router, tags=["Registration"])
 app.include_router(routes.search_router, tags=["Search"])
-if ckan_settings.ckan_local_enabled:
+if local_catalog_enabled:
     app.include_router(routes.update_router, tags=["Update"])
     app.include_router(dataset_update_router, tags=["Update"])
-if ckan_settings.ckan_local_enabled:
+if local_catalog_enabled:
     app.include_router(routes.delete_router, tags=["Delete"])
     app.include_router(routes.resource_router, tags=["Resources"])
     app.include_router(routes.resource_search_router, tags=["Resources"])

--- a/api/routes/health_routes/ready.py
+++ b/api/routes/health_routes/ready.py
@@ -43,8 +43,18 @@ def _check_local_catalog() -> Dict[str, Any]:
     """Check local catalog (CKAN or MongoDB) connection."""
     backend = catalog_settings.local_catalog_backend.lower()
 
-    if backend == "ckan" and not ckan_settings.ckan_local_enabled:
-        return {"status": "disabled", "backend": "ckan"}
+    # No local catalog at all: there is nothing to be unavailable, so the
+    # Endpoint is ready without one.
+    if not catalog_settings.has_local_catalog:
+        return {"status": "disabled", "backend": backend}
+
+    # CKAN_LOCAL_ENABLED is the master switch for the local catalog on every
+    # backend: with it off the local catalog routes are not mounted and
+    # /search rejects server=local, so nothing can reach the catalog. Probing
+    # it would report a dependency the Endpoint never uses as down, and answer
+    # 503 for a deployment running exactly as configured.
+    if not ckan_settings.ckan_local_enabled:
+        return {"status": "disabled", "backend": backend}
 
     try:
         repo = catalog_settings.local_catalog

--- a/api/services/status_services/check_api_status.py
+++ b/api/services/status_services/check_api_status.py
@@ -20,8 +20,13 @@ def check_backend_connection() -> bool:
     Returns
     -------
     bool
-        True if backend is connected and healthy, False otherwise
+        True if backend is connected and healthy, False otherwise.
+        False, without attempting a connection, when this Endpoint has no
+        local catalog (LOCAL_CATALOG_BACKEND=none).
     """
+    if not catalog_settings.has_local_catalog:
+        return False
+
     try:
         # Get the local catalog repository based on current configuration
         repository = catalog_settings.local_catalog

--- a/api/tasks/metrics_task.py
+++ b/api/tasks/metrics_task.py
@@ -76,11 +76,18 @@ async def record_system_metrics():
             public_ip = get_public_ip()
             cpu, mem_used, mem_total, disk_used, disk_total = get_system_metrics()
 
-            # Get catalog statistics
-            catalog_repo = catalog_settings.local_catalog
-            num_datasets = get_num_datasets(catalog_repo)
-            num_services = get_num_services(catalog_repo)
-            services_titles = get_services_titles(catalog_repo)
+            # Get catalog statistics. An Endpoint with no local catalog has
+            # nothing to count; asking for the repository would raise and cost
+            # the whole report, including the POST to the Federation.
+            if catalog_settings.has_local_catalog:
+                catalog_repo = catalog_settings.local_catalog
+                num_datasets = get_num_datasets(catalog_repo)
+                num_services = get_num_services(catalog_repo)
+                services_titles = get_services_titles(catalog_repo)
+            else:
+                num_datasets = 0
+                num_services = 0
+                services_titles = []
 
             # Generate timestamp
             timestamp = datetime.utcnow().isoformat() + "Z"

--- a/docs/sequence-diagrams/README.md
+++ b/docs/sequence-diagrams/README.md
@@ -1,0 +1,16 @@
+# Sequence Diagrams
+
+Each file here follows one process from beginning to end: who talks to whom, in
+what order, and what is written or started along the way. One process per file.
+
+The diagrams are [Mermaid](https://mermaid.js.org/syntax/sequenceDiagram.html)
+`sequenceDiagram` blocks, which GitHub renders in place — every actor gets a
+vertical lifeline and time runs downwards.
+
+| Diagram | Shows |
+|---|---|
+| [Installing a standalone Endpoint with no catalog](installing-standalone-no-catalog.md) | The lightest install: no Federation registration, no local catalog, every answer left at its default, and the `.env` it produces |
+
+For the static picture of the system — layers, routes, repositories — see
+[../architecture-diagrams.md](../architecture-diagrams.md). These diagrams
+complement it with the order things happen in.

--- a/docs/sequence-diagrams/installing-standalone-no-catalog.md
+++ b/docs/sequence-diagrams/installing-standalone-no-catalog.md
@@ -1,0 +1,212 @@
+# Installing a standalone Endpoint with no catalog
+
+The lightest install there is, and the one to start from:
+
+- **no Federation registration** — the Endpoint is not listed on the platform,
+- **no local catalog** — no MongoDB, no CKAN, nothing stored here,
+- **every answer left at its default**.
+
+```bash
+./install/install.sh
+```
+
+Answer the prompts by pressing Enter, except *Register this Endpoint with the
+Federation now?*, which is answered `n`. The unattended equivalent is:
+
+```bash
+./install/install.sh --backend none --yes
+```
+
+## The sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Operator
+    participant Installer as install.sh
+    participant Render as render_env.py
+    participant Docker as Docker Compose
+    participant EP as Endpoint container
+    participant AAI as Authentication service
+    participant Fed as NDP Federation
+
+    Operator->>Installer: ./install/install.sh
+
+    rect rgb(245, 245, 245)
+    Note over Installer: Checking prerequisites
+    Installer->>Docker: docker info, compose version
+    Docker-->>Installer: available
+    Note over Installer: example.env must be present
+    end
+
+    rect rgb(245, 245, 245)
+    Note over Operator,Installer: Asking — nothing is written yet
+    Installer->>Operator: Configuration id? (blank to skip)
+    Operator-->>Installer: (blank)
+    Installer->>Operator: Which local catalog? [1] None
+    Operator-->>Installer: 1
+    Installer->>Operator: Register with the Federation now? [Y/n]
+    Operator-->>Installer: n
+    Installer->>Operator: Organization? [My-Organization]
+    Operator-->>Installer: (Enter)
+    Installer->>Operator: Endpoint name? [my_endpoint]
+    Operator-->>Installer: (Enter)
+    Installer->>Operator: Port to publish on? [8002, first one free]
+    Operator-->>Installer: (Enter)
+    Installer->>Operator: Authentication service URL? [NDP AAI]
+    Operator-->>Installer: (Enter)
+    Installer->>Operator: Identity-provider sign-in? [y/N]
+    Operator-->>Installer: (Enter)
+    end
+
+    Note over Installer,Fed: No configuration id and no registration:<br/>the Federation is never contacted here
+
+    rect rgb(245, 245, 245)
+    Note over Installer: Selecting the local catalog backend
+    Note over Installer: LOCAL_CATALOG_BACKEND=none, CKAN_LOCAL_ENABLED=False,<br/>CKAN and MongoDB settings blanked, no compose profile added
+    end
+
+    alt A .env already exists
+        Installer->>Operator: saved a timestamped .env.backup — overwrite?
+        Operator-->>Installer: y
+    end
+
+    Installer->>Render: example.env + the answers
+    Render-->>Installer: .env (13 values set)
+    Note over Render: Every variable comes from example.env,<br/>so nothing new is missed
+
+    Installer->>AAI: POST with an invalid token
+    AAI-->>Installer: 400 — reachable, as expected
+    Note over Installer,AAI: Read back from the rendered file,<br/>so a mistake surfaces here and not at runtime
+
+    Installer->>Docker: EP_API_PORT=8002 docker compose up -d
+    Docker->>EP: start ndp-ep-api (API + UI, no other container)
+    EP-->>Docker: running
+
+    loop up to 30 times, every 2s
+        Installer->>EP: GET /health
+    end
+    EP-->>Installer: 200 healthy
+    Installer->>Operator: Installed. UI: http://localhost:8002/ui/
+
+    rect rgb(245, 245, 245)
+    Note over EP,Fed: From here on, on its own
+    EP->>Fed: POST /metrics/ every 3300s
+    Fed-->>EP: 201 Created
+    Note over EP,Fed: IS_PUBLIC defaults to True, so an Endpoint that<br/>never registered still reports its metrics
+    end
+```
+
+## The `.env` it produces
+
+`.env` is rendered from `example.env`, so it keeps every comment and every
+variable the Endpoint documents. Stripped of comments, this is the whole file:
+
+```ini
+ROOT_PATH=
+ORGANIZATION=My-Organization
+EP_NAME=my_endpoint
+IS_PUBLIC=True
+METRICS_INTERVAL_SECONDS=3300
+METRICS_ENDPOINT=https://federation.ndp.utah.edu/metrics/
+NETBIRD_ENABLED=False
+NETBIRD_IP=
+NETBIRD_GROUP=
+ENABLE_GROUP_BASED_ACCESS=False
+GROUP_NAMES=
+ENABLE_ACCESS_REQUESTS=False
+ACCESS_REQUESTS_COLLECTION=access_requests
+LOCAL_CATALOG_BACKEND=none
+CKAN_LOCAL_ENABLED=False
+CKAN_URL=
+CKAN_API_KEY=
+CKAN_VERIFY_SSL=True
+MONGODB_CONNECTION_STRING=
+MONGODB_DATABASE=ndp_local_catalog
+PRE_CKAN_ENABLED=False
+PRE_CKAN_URL=
+PRE_CKAN_API_KEY=
+PRE_CKAN_VERIFY_SSL=True
+PRE_CKAN_ORGANIZATION=
+KAFKA_CONNECTION=False
+KAFKA_HOST=kafka
+KAFKA_PORT=9093
+TEST_TOKEN=testing_token
+AUTH_API_URL=https://idp.nationaldataplatform.org/temp/information
+OIDC_ENABLED=False
+USE_JUPYTERLAB=False
+JUPYTER_URL=http://jupyterlab:8888
+S3_ENABLED=False
+S3_ENDPOINT=minio:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin123
+S3_SECURE=False
+S3_REGION=us-east-1
+PELICAN_ENABLED=False
+PELICAN_FEDERATION_URL=
+PELICAN_DIRECT_READS=False
+REXEC_CONNECTION=False
+REXEC_DEPLOYMENT_API_URL=
+AFFINITIES_ENABLED=False
+AFFINITIES_URL=
+AFFINITIES_EP_UUID=
+AFFINITIES_TIMEOUT=30
+```
+
+The thirteen values the installer set are the ones that differ from
+`example.env`'s demo defaults:
+
+| Variable | Value | Why |
+|---|---|---|
+| `ORGANIZATION`, `EP_NAME` | `My-Organization`, `my_endpoint` | The answers given at the prompt |
+| `AUTH_API_URL` | NDP AAI | Where login tokens are validated |
+| `LOCAL_CATALOG_BACKEND` | `none` | No local catalog |
+| `CKAN_LOCAL_ENABLED` | `False` | Leaves the routes that write to a local catalog unmounted |
+| `CKAN_URL`, `CKAN_API_KEY`, `MONGODB_CONNECTION_STRING` | empty | Nothing must point at a service that was not installed |
+| `KAFKA_CONNECTION`, `S3_ENABLED`, `USE_JUPYTERLAB`, `PELICAN_ENABLED`, `AFFINITIES_ENABLED`, `REXEC_CONNECTION`, `PRE_CKAN_ENABLED`, `OIDC_ENABLED` | `False` | `example.env` is a demo with every integration on; a fresh install provisions none of them |
+
+Everything else is `example.env`'s documented default, untouched. Two of those
+defaults are worth knowing:
+
+- **`IS_PUBLIC=True`** with `METRICS_ENDPOINT` pointing at the Federation. The
+  Endpoint was never registered, but it does report its metrics. Set
+  `IS_PUBLIC=False` to keep it entirely to itself.
+- **`TEST_TOKEN=testing_token`** is a development convenience. Change it, or
+  clear it, on anything reachable by others.
+
+## What this Endpoint does, and does not
+
+**It does**: authenticate users against the NDP AAI, search the platform's
+global catalog, serve its UI at `/ui/`, answer `/health` and `/ready`, redirect
+to services and report metrics to the Federation.
+
+`/ready` reports the local catalog as `disabled`, not as down:
+
+```json
+{"status": "healthy",
+ "checks": {"local_catalog": {"status": "disabled", "backend": "none"},
+            "pre_ckan": {"status": "disabled"},
+            "minio": {"status": "disabled"},
+            "kafka": {"status": "disabled"}}}
+```
+
+**It does not**: store anything. The registration, update, delete and resource
+routes are not mounted at all — they are absent from `/docs` rather than
+failing when called — and `/search?server=local` answers `400 Local CKAN is
+disabled and cannot be used`. Publishing to the staging catalog is off too,
+since it travels through the same routes.
+
+## Adding to it later
+
+Re-running the installer reconfigures the same Endpoint, so nothing here is a
+dead end:
+
+```bash
+./install/install.sh --backend mongodb          # add a local catalog
+./install/install.sh --config-id <id>           # apply a Federation registration
+```
+
+The existing `.env` is copied to `.env.backup.<timestamp>` first, every time.
+Registering is what creates this Endpoint's Keycloak client and group, so it is
+also what makes identity-provider sign-in possible — see
+[../../install/README.md](../../install/README.md).

--- a/docs/sequence-diagrams/installing-standalone-no-catalog.md
+++ b/docs/sequence-diagrams/installing-standalone-no-catalog.md
@@ -195,18 +195,3 @@ routes are not mounted at all — they are absent from `/docs` rather than
 failing when called — and `/search?server=local` answers `400 Local CKAN is
 disabled and cannot be used`. Publishing to the staging catalog is off too,
 since it travels through the same routes.
-
-## Adding to it later
-
-Re-running the installer reconfigures the same Endpoint, so nothing here is a
-dead end:
-
-```bash
-./install/install.sh --backend mongodb          # add a local catalog
-./install/install.sh --config-id <id>           # apply a Federation registration
-```
-
-The existing `.env` is copied to `.env.backup.<timestamp>` first, every time.
-Registering is what creates this Endpoint's Keycloak client and group, so it is
-also what makes identity-provider sign-in possible — see
-[../../install/README.md](../../install/README.md).

--- a/example.env
+++ b/example.env
@@ -74,8 +74,14 @@ ACCESS_REQUESTS_COLLECTION=access_requests
 # LOCAL CATALOG CONFIGURATION
 # ==============================================
 
-# Backend for local catalog: "ckan" or "mongodb"
+# Backend for local catalog: "ckan", "mongodb" or "none"
 # Global and Pre-CKAN always use CKAN regardless of this setting
+#
+# "none" is an Endpoint with no local catalog: nothing is stored locally and
+# no MongoDB or CKAN is needed. It still authenticates users, searches the
+# platform's global catalog and reports to the Federation. Set
+# CKAN_LOCAL_ENABLED to False alongside it, so the routes that write to a
+# local catalog are not offered.
 LOCAL_CATALOG_BACKEND=mongodb
 
 # ==============================================
@@ -91,7 +97,8 @@ LOCAL_CATALOG_BACKEND=mongodb
 # - Updating and deleting catalog entries
 # - All write operations to the local catalog
 #
-# Set to False for read-only access to the local catalog.
+# Set to False for read-only access to the local catalog, and necessarily so
+# when LOCAL_CATALOG_BACKEND is "none": there is no catalog to write to.
 #
 # Note: The variable name contains "CKAN" for historical reasons, but it applies
 # to all local catalog backends (CKAN, MongoDB, etc.)

--- a/install/README.md
+++ b/install/README.md
@@ -48,10 +48,11 @@ Run it with no arguments and it asks:
   Endpoint name [my_endpoint]:
 
   Which local catalog should this Endpoint use?
-    1) MongoDB, installed alongside the Endpoint
-    2) MongoDB, one I already have
-    3) CKAN, installed by this script (takes several minutes)
-    4) CKAN, one I already have
+    1) None — nothing is stored locally (quickest)
+    2) MongoDB, installed alongside the Endpoint
+    3) MongoDB, one I already have
+    4) CKAN, installed by this script (takes several minutes)
+    5) CKAN, one I already have
   Choice [1]:
 
   Port to publish the Endpoint on [8003]:
@@ -76,7 +77,7 @@ waiting for input.
 |---|---|
 | `--config-id <id>` | Federation configuration id |
 | `--federation-url <url>` | defaults to `https://federation.ndp.utah.edu` |
-| `--backend mongodb\|ckan` | local catalog backend, default `mongodb` |
+| `--backend none\|mongodb\|ckan` | local catalog backend, default `none` |
 | `--ep-api-port <port>` | host port for the API, default `8002` |
 | `--dry-run` | render the configuration and run the checks, start nothing |
 | `--no-start` | write everything, bring nothing up |
@@ -85,10 +86,29 @@ waiting for input.
 `--dry-run` is the quickest way to see what a registration would produce. It
 never installs anything, including CKAN.
 
+### No local catalog
+
+The default, and the quickest Endpoint to stand up:
+
+```bash
+./install/install.sh --backend none
+```
+
+Nothing is installed and nothing is stored here. The Endpoint authenticates
+users, searches the platform's global catalog, serves its UI and reports to the
+Federation, which is all most Endpoints are asked to do. It renders
+`LOCAL_CATALOG_BACKEND=none` and `CKAN_LOCAL_ENABLED=False`, which leaves the
+routes that write to a local catalog unmounted — nothing can be published,
+including to the staging catalog. Re-running the installer with `--backend
+mongodb` or `--backend ckan` adds a catalog later.
+
+`/ready` reports the local catalog as `disabled` rather than down, so an
+Endpoint with no catalog is healthy rather than perpetually 503.
+
 ### MongoDB
 
-The default backend. The installer starts a MongoDB alongside the Endpoint,
-unless you point at one you already run:
+The installer starts a MongoDB alongside the Endpoint, unless you point at one
+you already run:
 
 ```bash
 ./install/install.sh --backend mongodb --mongodb-url mongodb://your-host:27017

--- a/install/README.md
+++ b/install/README.md
@@ -60,6 +60,10 @@ Run it with no arguments and it asks:
   Offer sign-in through the identity provider? [y/N]:
 ```
 
+[docs/sequence-diagrams/installing-standalone-no-catalog.md](../docs/sequence-diagrams/installing-standalone-no-catalog.md)
+follows that run end to end — every prompt, who is contacted, what is started,
+and the `.env` it produces.
+
 Enter accepts the value in brackets. Suggested ports are picked from what is
 actually free on the machine, so the defaults do not collide with whatever is
 already running. Nothing is written or downloaded until the answers are

--- a/install/install.sh
+++ b/install/install.sh
@@ -68,7 +68,11 @@ CKAN_REPO_DEFAULT="https://github.com/sci-ndp/pop-ckan-docker.git"
 
 config_id=""
 federation_url="$FEDERATION_URL_DEFAULT"
-backend="mongodb"
+# The lightest Endpoint there is: no catalog to install, nothing to store, and
+# every optional integration off. It authenticates users, searches the
+# platform's global catalog and reports to the Federation. Asking for MongoDB
+# or CKAN is opting in to more.
+backend="none"
 mongodb_url=""
 ckan_url=""
 ckan_api_key=""
@@ -134,8 +138,13 @@ Usage:
 Options:
   --config-id <id>        Federation configuration id for this Endpoint.
   --federation-url <url>  Default: $FEDERATION_URL_DEFAULT
-  --backend <name>        Local catalog backend: mongodb | ckan. Default: mongodb
+  --backend <name>        Local catalog backend: none | mongodb | ckan.
+                          Default: none
   --ep-api-port <port>    Host port to publish the API on. Default: 8002
+
+With --backend none nothing is stored locally and no catalog is installed. The
+Endpoint authenticates users, searches the platform's global catalog and
+reports to the Federation. It is the quickest Endpoint to stand up.
 
 With --backend mongodb, the bundled MongoDB is started unless you point at one
 you already have:
@@ -189,8 +198,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ "$backend" == "mongodb" || "$backend" == "ckan" ]] \
-  || fail "--backend must be mongodb or ckan (got: $backend)"
+[[ "$backend" == "none" || "$backend" == "mongodb" || "$backend" == "ckan" ]] \
+  || fail "--backend must be none, mongodb or ckan (got: $backend)"
 
 banner
 
@@ -683,23 +692,30 @@ if [[ -z "$config_id" ]] && interactive; then
   # catalog before you have said which one you want.
   section "Local catalog" \
     "Choose what this Endpoint uses as its local data catalog — where the" \
-    "datasets published to it are stored."
+    "datasets published to it are stored." \
+    "" \
+    "With no local catalog nothing is installed or stored here: the Endpoint" \
+    "authenticates users, searches the platform's global catalog and is" \
+    "listed in the Federation. It is the quickest one to stand up, and a" \
+    "catalog can be added later by running this again."
   choose backend_choice "Which local catalog should this Endpoint use?" 1 \
+    "None — nothing is stored locally (quickest)" \
     "MongoDB, installed alongside the Endpoint" \
     "MongoDB, one I already have" \
     "CKAN, installed by this script (takes several minutes)" \
     "CKAN, one I already have"
   case "$backend_choice" in
-    1) backend="mongodb"; mongodb_url="" ;;
-    2) backend="mongodb"
+    1) backend="none"; mongodb_url=""; ckan_url="" ;;
+    2) backend="mongodb"; mongodb_url="" ;;
+    3) backend="mongodb"
        section "Existing MongoDB" \
          "Connect to a MongoDB you already run, instead of installing one." \
          "Give its connection string, reachable from the Endpoint container."
        ask mongodb_url "MongoDB connection string" \
          "mongodb://host.docker.internal:27017"
        ;;
-    3) backend="ckan"; ckan_url="" ;;
-    4) backend="ckan"
+    4) backend="ckan"; ckan_url="" ;;
+    5) backend="ckan"
        section "Existing CKAN" \
          "Connect to a CKAN you already run. The key is verified before" \
          "anything is written."
@@ -911,7 +927,20 @@ profiles=()
 # writes for ANY backend — it gates the registration, update, delete and
 # resource routes (see api/main.py). It must be True for MongoDB too, or the
 # Endpoint comes up read-only and datasets cannot be registered.
-if [[ "$backend" == "mongodb" && -n "$mongodb_url" ]]; then
+if [[ "$backend" == "none" ]]; then
+  # No local catalog. Nothing is installed and nothing is stored here, so no
+  # compose profile is added. CKAN_LOCAL_ENABLED must be False to match: it is
+  # what leaves the routes that write to a local catalog unmounted, and with it
+  # on the Endpoint would offer operations with nowhere to go. The CKAN and
+  # MongoDB settings are blanked so nothing points at a service that is absent.
+  put CKAN_LOCAL_ENABLED "False"
+  put CKAN_URL ""
+  put CKAN_API_KEY ""
+  put MONGODB_CONNECTION_STRING ""
+  ok "No local catalog — nothing is stored on this Endpoint"
+  info "It authenticates users, searches the global catalog and reports to the Federation."
+  info "Run this again with --backend mongodb or --backend ckan to add one later."
+elif [[ "$backend" == "mongodb" && -n "$mongodb_url" ]]; then
   # Pointing at a MongoDB that already exists — do not start the bundled one.
   put CKAN_LOCAL_ENABLED "True"
   put MONGODB_CONNECTION_STRING "$mongodb_url"

--- a/install/tests/test_render_env.py
+++ b/install/tests/test_render_env.py
@@ -102,6 +102,33 @@ def test_real_example_env_renders():
     assert "ORGANIZATION=Tarragona" in text
 
 
+def test_an_endpoint_with_no_local_catalog_renders():
+    """
+    The lightest install: no catalog, nothing stored locally. Every value it
+    writes must be documented in example.env, and the rendered file must say
+    plainly that there is no catalog rather than leaving a stale backend.
+    """
+    example_path = Path(__file__).resolve().parents[2] / "example.env"
+    text, applied, unknown = render(
+        example_path.read_text(encoding="utf-8"),
+        {
+            "LOCAL_CATALOG_BACKEND": "none",
+            "CKAN_LOCAL_ENABLED": "False",
+            "CKAN_URL": "",
+            "CKAN_API_KEY": "",
+            "MONGODB_CONNECTION_STRING": "",
+        },
+    )
+
+    assert unknown == []
+    assert "LOCAL_CATALOG_BACKEND=none" in text
+    assert "CKAN_LOCAL_ENABLED=False" in text
+    # Nothing may be left pointing at a MongoDB or CKAN that was not installed.
+    assert "MONGODB_CONNECTION_STRING=\n" in text
+    assert "CKAN_URL=\n" in text
+    assert "CKAN_API_KEY=\n" in text
+
+
 def test_every_variable_the_installer_sets_is_documented():
     """
     Guard against the drift that broke the previous installer: every variable

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,11 @@ minio==7.2.16
 pymongo>=4.0.0
 mongomock>=4.1.0
 fastapi-mcp
+# fastapi-mcp 0.4.0 calls the low-level Server positionally, which mcp 2.0.0
+# no longer accepts. FastApiMCP(app) runs at import time, so an unconstrained
+# resolution builds a container that does not start. Lift this once
+# fastapi-mcp supports mcp 2.
+mcp<2.0.0
 pelicanfs>=0.1.0
 # OpenTelemetry (optional - for distributed tracing)
 opentelemetry-api>=1.20.0

--- a/tests/test_no_local_catalog.py
+++ b/tests/test_no_local_catalog.py
@@ -1,0 +1,173 @@
+# tests/test_no_local_catalog.py
+"""
+An Endpoint with no local catalog (LOCAL_CATALOG_BACKEND=none).
+
+The lightest deployment there is: no MongoDB, no CKAN, nothing stored locally.
+It authenticates users, searches the global catalog and reports to the
+Federation, so it must come up, report itself ready and keep sending metrics
+even though there is no catalog to talk to.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.config.catalog_settings import CatalogSettings
+from api.routes.health_routes.ready import _check_local_catalog
+from api.services.status_services.check_api_status import check_backend_connection
+from api.tasks.metrics_task import record_system_metrics
+
+
+class TestCatalogSettings:
+    """LOCAL_CATALOG_BACKEND=none as a first-class setting."""
+
+    def test_none_means_there_is_no_local_catalog(self):
+        assert CatalogSettings(local_catalog_backend="none").has_local_catalog is False
+
+    def test_case_is_not_significant(self):
+        assert CatalogSettings(local_catalog_backend="None").has_local_catalog is False
+
+    @pytest.mark.parametrize("backend", ["ckan", "mongodb"])
+    def test_a_real_backend_has_a_local_catalog(self, backend):
+        assert CatalogSettings(local_catalog_backend=backend).has_local_catalog is True
+
+    def test_asking_for_the_repository_says_there_is_none(self):
+        """
+        Callers that ask anyway get an explanation, not a backend-not-supported
+        message that reads like a typo in the configuration.
+        """
+        settings = CatalogSettings(local_catalog_backend="none")
+
+        with pytest.raises(ValueError) as error:
+            settings.local_catalog
+
+        assert "no local catalog" in str(error.value).lower()
+
+
+class TestReadiness:
+    """/ready must not report a catalog that was never meant to exist."""
+
+    @patch("api.routes.health_routes.ready.ckan_settings")
+    @patch("api.routes.health_routes.ready.catalog_settings")
+    def test_no_catalog_is_disabled_not_down(self, mock_catalog, mock_ckan):
+        mock_catalog.local_catalog_backend = "none"
+        mock_catalog.has_local_catalog = False
+        mock_ckan.ckan_local_enabled = False
+
+        result = _check_local_catalog()
+
+        assert result == {"status": "disabled", "backend": "none"}
+
+    @patch("api.routes.health_routes.ready.ckan_settings")
+    @patch("api.routes.health_routes.ready.catalog_settings")
+    def test_a_disabled_mongodb_catalog_is_not_probed(self, mock_catalog, mock_ckan):
+        """
+        With the master switch off the local catalog routes are not mounted for
+        any backend, so nothing can reach MongoDB. Probing it reported a
+        dependency the Endpoint never uses as down, and answered 503.
+        """
+        mock_catalog.local_catalog_backend = "mongodb"
+        mock_catalog.has_local_catalog = True
+        mock_ckan.ckan_local_enabled = False
+
+        result = _check_local_catalog()
+
+        assert result["status"] == "disabled"
+        assert result["backend"] == "mongodb"
+        mock_catalog.local_catalog.check_health.assert_not_called()
+
+    @patch("api.routes.health_routes.ready.ckan_settings")
+    @patch("api.routes.health_routes.ready.catalog_settings")
+    def test_an_enabled_catalog_is_still_checked(self, mock_catalog, mock_ckan):
+        mock_catalog.local_catalog_backend = "mongodb"
+        mock_catalog.has_local_catalog = True
+        mock_ckan.ckan_local_enabled = True
+        mock_catalog.local_catalog.check_health.return_value = True
+
+        result = _check_local_catalog()
+
+        assert result["status"] == "up"
+        assert result["backend"] == "mongodb"
+
+
+class TestStatus:
+    """/status reports the backend without trying to connect to nothing."""
+
+    @patch("api.services.status_services.check_api_status.catalog_settings")
+    def test_backend_is_reported_disconnected_without_an_attempt(self, mock_catalog):
+        mock_catalog.has_local_catalog = False
+
+        assert check_backend_connection() is False
+        mock_catalog.local_catalog.check_health.assert_not_called()
+
+
+class TestMetrics:
+    """
+    Metrics collection and the catalog counts share one try/except: an
+    exception there leaves the payload empty and skips the POST, so an
+    Endpoint with no catalog would silently stop reporting to the Federation.
+    """
+
+    @pytest.mark.asyncio
+    @patch("api.tasks.metrics_task.httpx.AsyncClient")
+    @patch("api.tasks.metrics_task.swagger_settings")
+    @patch("api.tasks.metrics_task.kafka_settings")
+    @patch("api.tasks.metrics_task.s3_settings")
+    @patch("api.tasks.metrics_task.ckan_settings")
+    @patch("api.tasks.metrics_task.catalog_settings")
+    @patch("api.tasks.metrics_task.get_system_metrics")
+    @patch("api.tasks.metrics_task.get_public_ip")
+    async def test_metrics_are_still_reported_without_a_catalog(
+        self,
+        mock_ip,
+        mock_system,
+        mock_catalog,
+        mock_ckan,
+        mock_s3,
+        mock_kafka,
+        mock_swagger,
+        mock_httpx,
+    ):
+        mock_ip.return_value = "1.2.3.4"
+        mock_system.return_value = (25.0, 4.0, 16.0, 100.0, 500.0)
+
+        # No catalog: the repository is never asked for, so the counts come
+        # from nowhere and the report still goes out.
+        mock_catalog.has_local_catalog = False
+
+        mock_swagger.swagger_version = "1.0.0"
+        mock_swagger.organization = "test-org"
+        mock_swagger.ep_name = "Test EP"
+        mock_swagger.use_jupyterlab = False
+        mock_swagger.is_public = True
+        mock_swagger.metrics_endpoint = "http://metrics.example.com"
+        mock_swagger.metrics_interval_seconds = 0.1
+
+        mock_kafka.kafka_connection = False
+        mock_s3.s3_enabled = False
+        mock_ckan.pre_ckan_enabled = False
+        mock_ckan.ckan_url = ""
+        mock_ckan.ckan_api_key = ""
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_httpx.return_value = mock_client
+
+        task = asyncio.create_task(record_system_metrics())
+        await asyncio.sleep(0.15)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        mock_client.post.assert_called()
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["num_datasets"] == 0
+        assert payload["num_services"] == 0
+        assert payload["services"] == []


### PR DESCRIPTION
Closes #214.

The lightest Endpoint there is — nothing installed, nothing stored locally, every optional integration off — could not be chosen. The installer's local-catalog question had four answers and all four configured a catalog, and no combination of environment variables produced a working Endpoint without one.

## What this adds

`LOCAL_CATALOG_BACKEND=none` is now a deployment that stores nothing locally: no MongoDB, no CKAN. It authenticates users, searches the platform's global catalog, serves its UI and reports to the Federation.

The installer offers it as the first answer and as the default for `--backend`:

```
  Which local catalog should this Endpoint use?
    1) None — nothing is stored locally (quickest)
    2) MongoDB, installed alongside the Endpoint
    3) MongoDB, one I already have
    4) CKAN, installed by this script (takes several minutes)
    5) CKAN, one I already have
  Choice [1]:
```

It renders `LOCAL_CATALOG_BACKEND=none` with `CKAN_LOCAL_ENABLED=False` and blanks `CKAN_URL`, `CKAN_API_KEY` and `MONGODB_CONNECTION_STRING`, so nothing is left pointing at a service that was not installed. Running the installer again with `--backend mongodb` or `--backend ckan` adds a catalog later.

## Why the API needed changing too

Switching the local catalog off was not enough on its own:

- The readiness probe reported the catalog as `disabled` only for the CKAN backend. With any other backend it probed the catalog even though `CKAN_LOCAL_ENABLED=False` had already unmounted the local catalog routes and made `/search?server=local` answer 400 — so an Endpoint configured deliberately without a usable catalog answered HTTP 503 and looked broken to any orchestrator.
- Catalog statistics are collected inside the same `try` as the rest of the metrics payload. Asking for a repository that does not exist left the payload empty and skipped the POST, so the Endpoint would have stopped reporting to the Federation altogether rather than reporting without dataset counts.
- The routes that write to a local catalog were mounted on the master switch alone, without asking whether a backend provided one.

## Verified

- Full suite in the built image: 1199 passed. Installer render tests: 16 passed. `black --check .` and `flake8` clean.
- A real no-catalog install: the installer rendered the configuration, the Endpoint came up, `/health` and `/ready` answered 200 with `local_catalog: {status: disabled, backend: none}`, the UI served, `/search?server=global` answered 200, `/search?server=local` answered 400 with "Local CKAN is disabled and cannot be used", the registration/update/delete/resource routes were absent from the OpenAPI schema, and metrics posted to the Federation successfully.

## Backwards compatibility

`ckan` and `mongodb` behave exactly as before. Two changes affect existing setups:

- A deployment running with `CKAN_LOCAL_ENABLED=False` and a MongoDB backend was answering 503 on `/ready` and now answers 200 with the catalog reported `disabled`.
- Unattended installer runs that did not pass `--backend` used to get MongoDB and now get no catalog; add `--backend mongodb` to keep the previous result.