### PR TITLE
Keep an unregistered Endpoint private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.1] - 2026-08-03
+
+### Fixed
+- **An Endpoint installed without a Federation registration no longer reports to it.** The installer wrote `IS_PUBLIC` only when a registration was fetched, so declining to register left the `True` that `example.env` carries as a demo default, with `METRICS_ENDPOINT` still pointing at the Federation. A deliberately standalone Endpoint posted its public IP, organization, endpoint name, system usage and catalog counts to a platform it had not joined — and the Federation accepted them. `IS_PUBLIC` is now switched off with the rest of the defaults and turned back on only by a registration that asks to be listed. Metrics are still collected and logged locally; nothing leaves the Endpoint.
+
+### Backwards compatibility
+- Only new installations are affected. An existing `.env` keeps whatever `IS_PUBLIC` it has; set it to `False` by hand on an Endpoint that should not be reporting.
+- Installing with `--config-id`, or answering yes to the registration prompt, is unchanged: the registration decides, as before.
+
 ## [0.34.0] - 2026-08-03
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.34.0"
+    swagger_version: str = "0.34.1"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/docs/sequence-diagrams/installing-standalone-no-catalog.md
+++ b/docs/sequence-diagrams/installing-standalone-no-catalog.md
@@ -91,9 +91,8 @@ sequenceDiagram
 
     rect rgb(245, 245, 245)
     Note over EP,Fed: From here on, on its own
-    EP->>Fed: POST /metrics/ every 3300s
-    Fed-->>EP: 201 Created
-    Note over EP,Fed: IS_PUBLIC defaults to True, so an Endpoint that<br/>never registered still reports its metrics
+    Note over EP: The metrics task collects every 3300s<br/>and logs the result
+    Note over EP,Fed: Nothing is posted: IS_PUBLIC is False without a<br/>registration, and posting is gated on it
     end
 ```
 
@@ -106,7 +105,7 @@ variable the Endpoint documents. Stripped of comments, this is the whole file:
 ROOT_PATH=
 ORGANIZATION=My-Organization
 EP_NAME=my_endpoint
-IS_PUBLIC=True
+IS_PUBLIC=False
 METRICS_INTERVAL_SECONDS=3300
 METRICS_ENDPOINT=https://federation.ndp.utah.edu/metrics/
 NETBIRD_ENABLED=False
@@ -153,8 +152,8 @@ AFFINITIES_EP_UUID=
 AFFINITIES_TIMEOUT=30
 ```
 
-The thirteen values the installer set are the ones that differ from
-`example.env`'s demo defaults:
+The values the installer set are the ones that differ from `example.env`'s
+demo defaults:
 
 | Variable | Value | Why |
 |---|---|---|
@@ -163,22 +162,21 @@ The thirteen values the installer set are the ones that differ from
 | `LOCAL_CATALOG_BACKEND` | `none` | No local catalog |
 | `CKAN_LOCAL_ENABLED` | `False` | Leaves the routes that write to a local catalog unmounted |
 | `CKAN_URL`, `CKAN_API_KEY`, `MONGODB_CONNECTION_STRING` | empty | Nothing must point at a service that was not installed |
+| `IS_PUBLIC` | `False` | No registration, so nothing is reported to the Federation |
 | `KAFKA_CONNECTION`, `S3_ENABLED`, `USE_JUPYTERLAB`, `PELICAN_ENABLED`, `AFFINITIES_ENABLED`, `REXEC_CONNECTION`, `PRE_CKAN_ENABLED`, `OIDC_ENABLED` | `False` | `example.env` is a demo with every integration on; a fresh install provisions none of them |
 
-Everything else is `example.env`'s documented default, untouched. Two of those
-defaults are worth knowing:
+Everything else is `example.env`'s documented default, untouched. One of those
+defaults is worth knowing: **`TEST_TOKEN=testing_token`** is a development
+convenience. Change it, or clear it, on anything reachable by others.
 
-- **`IS_PUBLIC=True`** with `METRICS_ENDPOINT` pointing at the Federation. The
-  Endpoint was never registered, but it does report its metrics. Set
-  `IS_PUBLIC=False` to keep it entirely to itself.
-- **`TEST_TOKEN=testing_token`** is a development convenience. Change it, or
-  clear it, on anything reachable by others.
+`METRICS_ENDPOINT` still points at the Federation, but it is never used:
+posting is gated on `IS_PUBLIC`, which a registration is what turns on.
 
 ## What this Endpoint does, and does not
 
 **It does**: authenticate users against the NDP AAI, search the platform's
-global catalog, serve its UI at `/ui/`, answer `/health` and `/ready`, redirect
-to services and report metrics to the Federation.
+global catalog, serve its UI at `/ui/`, answer `/health` and `/ready` and
+redirect to services.
 
 `/ready` reports the local catalog as `disabled`, not as down:
 
@@ -190,8 +188,10 @@ to services and report metrics to the Federation.
             "kafka": {"status": "disabled"}}}
 ```
 
-**It does not**: store anything. The registration, update, delete and resource
-routes are not mounted at all — they are absent from `/docs` rather than
-failing when called — and `/search?server=local` answers `400 Local CKAN is
-disabled and cannot be used`. Publishing to the staging catalog is off too,
-since it travels through the same routes.
+**It does not**: store anything, or tell anyone about itself. The registration,
+update, delete and resource routes are not mounted at all — they are absent
+from `/docs` rather than failing when called — and `/search?server=local`
+answers `400 Local CKAN is disabled and cannot be used`. Publishing to the
+staging catalog is off too, since it travels through the same routes. Nothing
+is posted to the Federation: the Endpoint never registered, so it is not
+public, and metrics stay local to its logs.

--- a/example.env
+++ b/example.env
@@ -17,6 +17,10 @@ EP_NAME="EP-DEMO"
 # Whether this Endpoint presents itself as publicly listed. Documented in
 # docs/configuration.md and read by the API, but previously missing from this
 # file, so a deployment generated from it never set it.
+#
+# It also decides whether the periodic metrics are posted to METRICS_ENDPOINT:
+# with False they are collected and logged, and nothing leaves the Endpoint.
+# An Endpoint not registered with the Federation should keep it False.
 IS_PUBLIC=True
 
 # ==============================================

--- a/install/install.sh
+++ b/install/install.sh
@@ -796,6 +796,12 @@ fi
 # Endpoint pointing at Kafka, MinIO, JupyterLab and Pelican that nothing has
 # provisioned. Everything optional starts off here, and is switched back on
 # further down only when something actually provides it.
+# IS_PUBLIC is what allows the metrics task to post to the Federation. An
+# Endpoint that never registered has no business reporting to a platform it is
+# not part of, and example.env's demo default of True made it do exactly that.
+# A registration decides it further down, from the answer given while
+# registering; without one it stays off.
+put IS_PUBLIC "False"
 put KAFKA_CONNECTION "False"
 put USE_JUPYTERLAB "False"
 put S3_ENABLED "False"

--- a/install/tests/test_render_env.py
+++ b/install/tests/test_render_env.py
@@ -129,6 +129,33 @@ def test_an_endpoint_with_no_local_catalog_renders():
     assert "CKAN_API_KEY=\n" in text
 
 
+def test_an_install_without_a_registration_is_not_public():
+    """
+    IS_PUBLIC is what lets the metrics task post to the Federation. It used to
+    be written only when a registration was fetched, so declining to register
+    left example.env's demo default of True and the Endpoint reported to a
+    platform it had deliberately not joined.
+
+    The installer must switch it off with the rest of the defaults, before the
+    registration block gets its chance to turn it back on.
+    """
+    import re
+
+    install_sh = (Path(__file__).resolve().parents[1] / "install.sh").read_text(
+        encoding="utf-8"
+    )
+
+    default_off = re.search(r'^\s*put IS_PUBLIC "False"', install_sh, re.M)
+    from_registration = re.search(r"^\s*put IS_PUBLIC \"\$\(", install_sh, re.M)
+
+    assert default_off, 'install.sh never sets IS_PUBLIC "False" by default'
+    assert from_registration, "install.sh no longer sets IS_PUBLIC from a registration"
+    assert default_off.start() < from_registration.start(), (
+        "the default must come first, or a registration asking to be listed "
+        "would be overridden by it"
+    )
+
+
 def test_every_variable_the_installer_sets_is_documented():
     """
     Guard against the drift that broke the previous installer: every variable


### PR DESCRIPTION
Closes #217.

Answering no to *Register this Endpoint with the Federation now?* is supposed to produce a standalone Endpoint. It was not one: `IS_PUBLIC` was written only when a registration was fetched, so declining left the `True` that `example.env` carries as a demo default, with `METRICS_ENDPOINT` still pointing at the Federation.

The Endpoint then posted its public IP, organization, endpoint name, system usage and catalog counts every 3300 seconds to a platform it had deliberately not joined — and the Federation accepted them with `201 Created`.

## The fix

`IS_PUBLIC=False` now goes in with the rest of the defaults, before the registration block, which is the only thing that turns it back on and does so from the answer given while registering. Installing with `--config-id`, or answering yes, behaves exactly as before.

`example.env` now says that `IS_PUBLIC` is what allows metrics to be posted, which was documented nowhere.

## Verified

- A full install with no registration renders `IS_PUBLIC=False`, and the Endpoint running with that `.env` posted nothing: zero matches for a metrics POST in its logs after startup, while the metrics task kept collecting and logging locally.
- 1203 tests pass, `black --check .` and `flake8` clean.
- The sequence diagram claimed the old behaviour explicitly; it has been corrected, and re-rendered to check it still draws.

## Backwards compatibility

Only new installations are affected. An existing `.env` keeps whatever `IS_PUBLIC` it has — set it to `False` by hand on an Endpoint that should not be reporting.