### PR TITLE
Build the image from the checkout being installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.2] - 2026-08-04
+
+### Fixed
+- **Re-running the installer no longer keeps the previously built image.** The stack was started with `docker compose up -d`, which builds only when no image exists, so on any machine that had run an Endpoint before, the container came back from the image built the first time and the current checkout was never compiled in. The install reported success while running old code — a route added since answered 404, and the UI served was the one built then — while `.env`, regenerated on every run, was current, which made the mismatch read as a configuration problem rather than a stale build. It is now started with `--build`, as the CKAN stack already was. Unchanged sources come from the layer cache.
+
+### Backwards compatibility
+- Installs take longer when sources changed since the last run, because the image is rebuilt rather than silently reused. Nothing else changes.
+
 ## [0.34.1] - 2026-08-03
 
 ### Fixed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.34.1"
+    swagger_version: str = "0.34.2"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/install/install.sh
+++ b/install/install.sh
@@ -1193,7 +1193,7 @@ step "Starting the Endpoint"
 # --------------------------------------------------------------
 if [[ "$start" != "true" ]]; then
   info "--no-start given; bring it up yourself with:"
-  echo "    cd $REPO_ROOT && EP_API_PORT=$ep_api_port ${COMPOSE[*]} ${profiles[*]/#/--profile } up -d"
+  echo "    cd $REPO_ROOT && EP_API_PORT=$ep_api_port ${COMPOSE[*]} ${profiles[*]/#/--profile } up -d --build"
   exit 0
 fi
 
@@ -1210,7 +1210,14 @@ for profile in "${profiles[@]:-}"; do
 done
 
 cd "$REPO_ROOT"
-EP_API_PORT="$ep_api_port" "${COMPOSE[@]}" "${profile_args[@]}" up -d
+
+# --build, or compose reuses whatever image was built the first time this
+# machine ran an Endpoint and the checkout is never compiled in: the install
+# reports success while running old code, with the freshly rendered .env
+# making the mismatch look like a configuration problem. Unchanged sources
+# come from the layer cache, so this costs little after the first run.
+info "Building the image from this checkout; the first run takes a few minutes."
+EP_API_PORT="$ep_api_port" "${COMPOSE[@]}" "${profile_args[@]}" up -d --build
 
 # --------------------------------------------------------------
 step "Verifying the Endpoint answers"

--- a/install/tests/test_render_env.py
+++ b/install/tests/test_render_env.py
@@ -180,3 +180,30 @@ def test_every_variable_the_installer_sets_is_documented():
         "install.sh sets variables that example.env does not document: "
         f"{undocumented}"
     )
+
+
+def test_the_endpoint_is_built_from_the_checkout_being_installed():
+    """
+    `compose up -d` builds only when no image exists, so on a machine that has
+    run an Endpoint before, the container comes back from the image built the
+    first time and the checkout is never compiled in. The install then reports
+    success while running old code — a route added today answers 404 — and the
+    freshly rendered .env makes it look like a configuration problem.
+    """
+    install_sh = (Path(__file__).resolve().parents[1] / "install.sh").read_text(
+        encoding="utf-8"
+    )
+
+    # The command is written with ${COMPOSE[@]}, since compose is either
+    # `docker compose` or `docker-compose` depending on the machine.
+    endpoint_ups = [
+        line
+        for line in install_sh.splitlines()
+        if "up -d" in line and "EP_API_PORT=" in line
+    ]
+
+    assert endpoint_ups, "no 'compose up' for the Endpoint found in install.sh"
+    for line in endpoint_ups:
+        assert (
+            "--build" in line
+        ), f"the Endpoint is started without --build: {line.strip()}"


### PR DESCRIPTION
Closes #221.

The installer starts the stack with `docker compose up -d`, which builds an image only when none exists. On any machine that has run an Endpoint before, the container is recreated from the image built the first time and the current checkout is never compiled in.

The install reports success while running old code. It stays invisible until something depends on a change — a route added since answers 404, and the UI served is the one built then — and `.env`, regenerated on every run, is current, so the mismatch reads as a configuration problem rather than a stale build. This cost a full debugging session on an Endpoint that was running an image two weeks old.

Started with `--build` now, which is what the installer already does for the CKAN stack. Unchanged sources come from the layer cache, so the cost after the first run is small, and the step says the first build takes a few minutes.

## Verified

- A rebuild of an Endpoint whose image predated a new API route: before, `/openapi.json` did not contain the route and the container kept serving the older UI; after `--build`, the route is present and answers.
- 18 installer tests, one new, asserting every `compose up` for the Endpoint carries `--build`.
- `black --check .` clean.