### PR TITLE
Stop offering identity-provider sign-in in the installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.3] - 2026-08-04
+
+### Changed
+- **The installer no longer offers identity-provider sign-in.** It asked whether to offer it and then asked for a client id, but there is no client an Endpoint can use: the ones a Federation registration creates are confidential, so the browser's code exchange is refused with "Invalid client or Invalid client credentials", and their tokens carry no `sub` claim — which `AUTH_API_URL` looks the user up by, so validation answers 500 even once the exchange succeeds. The scope that supplies `sub` cannot be requested from the Endpoint. Answering yes could only produce a login button that fails after a successful sign-in, which reads as a credentials problem and is not one. The question is gone until how this is meant to work is settled with whoever administers the identity provider.
+
+### Backwards compatibility
+- The `OIDC_*` settings are unchanged, still documented in `example.env` and `docs/configuration.md`, and still read by the API and the UI. A deployment with a working client switches sign-in on by editing `.env`; the installer simply never turns it on.
+- An Endpoint already running with sign-in enabled is unaffected until it is re-installed. Re-running the installer renders a fresh `.env` with `OIDC_ENABLED=False`, as it did before this change whenever the question was answered no, so those three values have to be put back by hand — the previous file is kept as `.env.backup.<timestamp>`.
+
 ## [0.34.2] - 2026-08-04
 
 ### Fixed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.34.2"
+    swagger_version: str = "0.34.3"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/install/README.md
+++ b/install/README.md
@@ -14,9 +14,8 @@ those on top of the documented defaults and brings the stack up.
 ## Registering
 
 Without a configuration id, the installer offers to register the Endpoint for
-you. Registration is what creates this Endpoint's **Keycloak client and
-group**, so it is also what makes identity-provider sign-in possible without
-an administrator having to set anything up by hand. It also fetches a
+you. Registration creates this Endpoint's **Keycloak client and group**, which
+is what the group-based access control is keyed on. It also fetches a
 staging-catalog token and registers the Endpoint in Affinities.
 
 It needs your NDP access token, from your user panel on the platform. The user
@@ -57,7 +56,6 @@ Run it with no arguments and it asks:
 
   Port to publish the Endpoint on [8003]:
   Authentication service (AAI) URL [https://idp.nationaldataplatform.org/temp/information]:
-  Offer sign-in through the identity provider? [y/N]:
 ```
 
 [docs/sequence-diagrams/installing-standalone-no-catalog.md](../docs/sequence-diagrams/installing-standalone-no-catalog.md)
@@ -221,9 +219,15 @@ are what gets tested.
 - **Kafka and JupyterHub are not provisioned.** A registration that asks for
   streaming or JupyterHub configures the Endpoint for them but does not stand
   them up.
-- **Identity-provider sign-in is left off**, even when the registration
-  carries a `client_id`. The registration names the realm but not the
-  identity provider's host, and `OIDC_ISSUER` has to agree with
-  `AUTH_API_URL`; guessing one from the other would fail at the last step of a
-  login, which looks like a credentials problem and is not. See
+- **Identity-provider sign-in is not offered**, and the installer no longer
+  asks about it. There is no client an Endpoint can sign in through: the ones
+  a registration creates are confidential, so the browser's code exchange is
+  refused with "Invalid client or Invalid client credentials", and their
+  tokens carry no `sub` claim — which `AUTH_API_URL` looks the user up by, so
+  it answers 500 even once the exchange succeeds. The scope that supplies
+  `sub` is not assignable from this side. Until that is settled with whoever
+  administers the identity provider, offering the option could only produce a
+  button that fails after a successful login. The `OIDC_*` settings remain
+  documented and are read by the API, so a deployment with a working client
+  can switch it on by hand. See
   [docs/configuration.md](../docs/configuration.md).

--- a/install/install.sh
+++ b/install/install.sh
@@ -668,9 +668,6 @@ PY
 organization=""
 ep_name=""
 auth_api_url=""
-oidc_issuer=""
-oidc_client_id=""
-want_oidc="no"
 
 if [[ -z "$config_id" ]] && interactive; then
   echo
@@ -774,21 +771,6 @@ if [[ -z "$config_id" ]] && interactive; then
   ask auth_api_url "Authentication service (AAI) URL" \
     "https://idp.nationaldataplatform.org/temp/information"
 
-  section "Identity-provider sign-in" \
-    "Optional. Adds a button that signs users in through the identity" \
-    "provider's own page (CILogon, EarthScope, ORCID). Needs a client id" \
-    "registered for this Endpoint; the Federation registration creates one." \
-    "The access-token and username/password logins work either way."
-  ask_yes_no want_oidc "Offer sign-in through the identity provider?" "no"
-  if [[ "$want_oidc" == "yes" ]]; then
-    ask oidc_issuer    "Identity provider realm URL" \
-      "https://idp.nationaldataplatform.org/realms/NDP"
-    ask oidc_client_id "Client id registered for this Endpoint" ""
-    if [[ -z "$oidc_client_id" ]]; then
-      warn "No client id: sign-in will stay off. See docs/configuration.md."
-      want_oidc="no"
-    fi
-  fi
 fi
 
 # example.env is written as a demo that shows every setting, so its defaults
@@ -898,13 +880,12 @@ PY
 
   put IS_PUBLIC "$([[ "$fed_public" == "true" ]] && echo True || echo False)"
 
-  # The registration names the realm but not the identity provider host, and
-  # the Endpoint must validate tokens against the same provider that issues
-  # them. Deriving one from the other is guesswork, so identity-provider
-  # sign-in is left switched off for the operator to configure deliberately.
+  # The client the registration creates is confidential and its tokens carry no
+  # `sub`, which AUTH_API_URL looks the user up by — so it cannot be used for
+  # sign-in as it stands. The installer says it exists and stops there; see
+  # docs/configuration.md.
   if [[ -n "$fed_client_id" ]]; then
     info "Registration includes client id '$fed_client_id' for realm '$fed_realm'."
-    info "Identity-provider sign-in is left off; see docs/configuration.md to enable it."
   fi
 elif [[ "${already_warned:-false}" != "true" ]]; then
   warn "No --config-id given: installing without a Federation registration."
@@ -919,12 +900,6 @@ step "Selecting the local catalog backend"
 [[ -n "$organization" ]]  && put ORGANIZATION "$organization"
 [[ -n "$ep_name" ]]       && put EP_NAME "$ep_name"
 [[ -n "$auth_api_url" ]]  && put AUTH_API_URL "$auth_api_url"
-
-if [[ "$want_oidc" == "yes" && -n "$oidc_client_id" ]]; then
-  put OIDC_ENABLED "True"
-  put OIDC_ISSUER "$oidc_issuer"
-  put OIDC_CLIENT_ID "$oidc_client_id"
-fi
 
 put LOCAL_CATALOG_BACKEND "$backend"
 


### PR DESCRIPTION
Closes #223.

The installer asked whether to offer sign-in through the identity provider, then asked for a client id. No answer leads anywhere:

- The clients a Federation registration creates are **confidential** (`publicClient: False`, client-secret authenticator), so the browser's code exchange is refused with `unauthorized_client` / "Invalid client or Invalid client credentials" — after a successful login, which reads as a credentials problem and is not one.
- The platform's own client is confidential too, and its secret is not an Endpoint's to have.
- Even with the exchange moved off the browser, the tokens these clients mint carry **no `sub` claim**, and `AUTH_API_URL` looks the user up by `sub`: it answers `500 {"error": "Failed to retrieve user details", "details": "Role query failed"}`. Requesting the scope that would supply it answers `invalid_scope`, since it is assigned to those clients neither by default nor optionally.

So the question is removed. The prompts are now:

```
  Configuration id (blank to skip):
  Which local catalog should this Endpoint use?
  Register this Endpoint with the Federation now? [Y/n]:
  Organization name [My-Organization]:
  Endpoint name [my_endpoint]:
  Port to publish the Endpoint on [8003]:
  Authentication service (AAI) URL [...]:
```

The `OIDC_*` settings are untouched: still documented in `example.env` and `docs/configuration.md`, still read by the API and the UI. A deployment that has a working client switches sign-in on by editing `.env`; the installer simply never turns it on. `install/README.md` now says why, in place of the older explanation that no longer describes the real obstacle.

## Verified

- An interactive run driven through a pty asks the seven questions above and no more, and renders `OIDC_ENABLED=False`.
- 1204 tests, `black --check .` and `flake8` clean.