### PR TITLE
Sequence diagram of a registered install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.5] - 2026-08-04
+
+### Added
+- **Sequence diagram of a registered install** ([docs/sequence-diagrams/installing-registered-no-catalog.md](docs/sequence-diagrams/installing-registered-no-catalog.md)). The companion to the standalone one: the same lightest install, but registered with the Federation. It follows the run from the first prompt to the Endpoint reporting metrics, and opens up what the registration itself does on the operator's behalf — a Keycloak client, a group with them as its administrator, a staging-catalog token and an entry in Affinities, across three services none of which a standalone install touches. It says which of those the Endpoint actually uses, lists the `.env` values that differ from a standalone install and where each comes from, and notes that a token minted before the group existed does not carry it.
+
+### Backwards compatibility
+- Documentation only. No API behavior, request/response shapes, or routes change.
+
 ## [0.34.4] - 2026-08-04
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.34.4"
+    swagger_version: str = "0.34.5"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/docs/sequence-diagrams/README.md
+++ b/docs/sequence-diagrams/README.md
@@ -10,6 +10,7 @@ vertical lifeline and time runs downwards.
 | Diagram | Shows |
 |---|---|
 | [Installing a standalone Endpoint with no catalog](installing-standalone-no-catalog.md) | The lightest install: no Federation registration, no local catalog, every answer left at its default, and the `.env` it produces |
+| [Installing an Endpoint registered with the Federation](installing-registered-no-catalog.md) | The same install, registered: what the Federation creates on your behalf in Keycloak, the staging catalog and Affinities, and what of it the Endpoint actually uses |
 
 For the static picture of the system — layers, routes, repositories — see
 [../architecture-diagrams.md](../architecture-diagrams.md). These diagrams

--- a/docs/sequence-diagrams/installing-registered-no-catalog.md
+++ b/docs/sequence-diagrams/installing-registered-no-catalog.md
@@ -1,0 +1,141 @@
+# Installing an Endpoint registered with the Federation
+
+The same lightest install as the [standalone one](installing-standalone-no-catalog.md)
+— no local catalog, every other answer left at its default — but **registered
+with the NDP Federation**, which is what lists it on the platform.
+
+```bash
+./install/install.sh
+```
+
+Answer the prompts by pressing Enter, answer **yes** to *Register this Endpoint
+with the Federation now?*, and paste your NDP access token when asked. You are
+also asked for an organization, a name, a contact email, and whether to be
+listed; the optional features (JupyterHub, streaming, remote execution) stay
+off.
+
+Registering happens **before** anything is installed: the configuration it
+returns is what drives the rest of the install.
+
+## The sequence
+
+The Federation does most of the work, and it does it against three other
+services. That is the part worth reading — the grey box below.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Operator
+    participant Installer as install.sh
+    participant Fed as NDP Federation
+    participant AAI as AAI API (Keycloak)
+    participant Pre as Staging catalog
+    participant Aff as Affinities
+    participant EP as Endpoint container
+
+    Operator->>Installer: ./install/install.sh
+    Note over Installer: Prerequisites: docker, compose, curl, python3
+
+    rect rgb(245, 245, 245)
+    Note over Operator,Installer: Asking — nothing is written yet
+    Installer->>Operator: Configuration id? (blank to skip)
+    Installer->>Operator: Which local catalog? [1] None
+    Installer->>Operator: Register with the Federation now? [Y/n]
+    Operator-->>Installer: yes
+    Installer->>Operator: NDP access token (not shown)
+    Installer->>Operator: Organization, Endpoint name, contact email
+    Installer->>Operator: List this Endpoint on the platform? [Y/n]
+    Installer->>Operator: JupyterHub? Streaming? Remote execution? [y/N]
+    Installer->>Operator: About to register — continue? [Y/n]
+    end
+
+    Installer->>Fed: POST /ep/simple + your access token
+
+    rect rgb(238, 242, 248)
+    Note over Fed,Aff: Inside the registration, on your behalf
+    Fed->>Fed: Store the configuration, credentials still placeholders
+    Fed->>AAI: POST /client/login (its own factory client)
+    AAI-->>Fed: admin token
+    Fed->>AAI: POST /client/create — ep-<config-id>
+    AAI-->>Fed: client id and client secret
+    Note over AAI: A confidential client: it has a secret,<br/>which is why the Endpoint cannot sign<br/>users in through it from a browser
+    Fed->>AAI: POST /group/create — ndp_ep/ep-<config-id>,<br/>with you as its administrator
+    AAI-->>Fed: group created
+    Fed->>Pre: POST ?org=ep-<config-id>, with your access token
+    Pre-->>Fed: staging catalog API token
+    Fed->>Aff: POST /ep — kind ndp-ep, organization, name
+    Aff-->>Fed: affinities uid
+    Fed->>Fed: Update the record with client, group,<br/>staging token and affinities uid
+    end
+
+    Fed-->>Installer: configuration id
+    Installer->>Operator: Keep this id — --config-id reproduces this Endpoint
+
+    Installer->>Operator: Endpoint port? Authentication service URL?
+
+    Installer->>Fed: GET /ep/<config-id>
+    Fed-->>Installer: the configuration just created
+    Note over Installer: Applied: organization, name, group-based access<br/>with that group, listed-on-the-platform, staging<br/>catalog. Streaming and JupyterHub stay off.
+
+    Installer->>Installer: Render .env from example.env (21 values set)
+    Installer->>Operator: Existing .env backed up — overwrite?
+    Installer->>EP: docker compose up -d --build
+    EP-->>Installer: 200 from /health
+    Installer->>Operator: Installed. UI: http://localhost:8003/ui/
+
+    rect rgb(245, 245, 245)
+    Note over EP,Fed: From here on, on its own
+    EP->>Fed: POST /metrics/ every 3300s
+    Fed-->>EP: 201 Created
+    Note over EP,Fed: Because the registration asked to be listed,<br/>IS_PUBLIC is True and the reports go out
+    end
+```
+
+## What the registration created
+
+Four things, in three different services, none of which exist for a standalone
+install:
+
+| What | Where | The Endpoint uses it |
+|---|---|---|
+| A configuration record, keyed by the configuration id | Federation | Yes — re-runs read it with `--config-id` |
+| A Keycloak client `ep-<config-id>`, **confidential** | Identity provider | **No.** Sign-in through it does not work yet; see [configuration.md](../configuration.md) |
+| A group `ndp_ep/ep-<config-id>`, with you as administrator | Identity provider | Yes — it lands in `GROUP_NAMES` and gates every write |
+| An API token for the staging catalog | Staging CKAN | Yes — `PRE_CKAN_API_KEY` |
+| An entry describing this Endpoint | Affinities | Not directly; it is what makes the Endpoint discoverable |
+
+## The `.env` it produces
+
+Only the values that differ from the [standalone install](installing-standalone-no-catalog.md)
+are listed; everything else is identical.
+
+| Variable | Value | Where it comes from |
+|---|---|---|
+| `ORGANIZATION`, `EP_NAME` | `my-org-reg`, `my-ep-reg` | The answers, stored in the registration |
+| `ENABLE_GROUP_BASED_ACCESS` | `True` | Set because the registration produced a group |
+| `GROUP_NAMES` | `ndp_ep/ep-<config-id>` | The group created for this Endpoint |
+| `IS_PUBLIC` | `True` | "List this Endpoint on the platform" — this is what lets the metrics be posted |
+| `PRE_CKAN_ENABLED` | `True` | Set because the registration returned a staging URL and token |
+| `PRE_CKAN_URL`, `PRE_CKAN_API_KEY` | the platform's catalog2, and the minted token | The registration |
+
+`OIDC_ENABLED` stays `False` even though a client was created for this
+Endpoint: its tokens carry no `sub` claim, which is what the authentication
+service looks the user up by, so sign-in through it fails after a successful
+login. The installer does not offer it.
+
+## What this Endpoint does
+
+Everything the standalone one does — authenticate users, search the platform's
+global catalog, serve its UI, answer `/health` and `/ready` — plus:
+
+- **It is listed on the platform.** Metrics go out every 3300 seconds and the
+  Federation records them, so the Endpoint shows as active.
+- **Writes are gated by the group.** With `ENABLE_GROUP_BASED_ACCESS=True`, a
+  user needs to be in `ndp_ep/ep-<config-id>` to write. You are its
+  administrator, but a token minted **before** the group existed does not carry
+  it — copy a fresh one from your user panel after registering.
+
+It still stores nothing: with no local catalog, the registration, update,
+delete and resource routes are not mounted, so there is nothing to write to
+locally and nothing to publish to the staging catalog either, even though the
+credentials for it are configured.


### PR DESCRIPTION
Closes #225.

The companion to the standalone diagram: the same lightest install — no local catalog, defaults everywhere — but registered with the Federation.

The part worth having is what the registration itself does. Answering yes sets off a chain of calls the operator never sees, across three services a standalone install never touches:

- a **Keycloak client** `ep-<config-id>`, confidential;
- a **group** `ndp_ep/ep-<config-id>`, with the registering user as its administrator;
- an **API token for the staging catalog**, minted with that user's own access token;
- an **entry in Affinities**.

The diagram shows each of them, and the page then says which the Endpoint actually uses: the group gates every write through `GROUP_NAMES`, the staging token lands in `PRE_CKAN_API_KEY`, and the client is created but **not** used — its tokens carry no `sub` claim, so sign-in through it fails after a successful login (#219, and why the installer stopped offering it in 0.34.3).

Also: the `.env` values that differ from a standalone install and where each comes from, and the trap that a token minted before the group existed does not carry it — so a fresh one has to be copied after registering, or writes are denied for reasons that look like an Endpoint fault.

## Verified

Drawn from an actual registered install performed today, not from reading the code: the configuration id it printed, the record the Federation holds for it, the rendered `.env` (21 values set), the container answering `/health` and `/ready`, and four metrics reports already accepted with 201. The Mermaid source renders through `mermaid-cli`.