### PR TITLE
Offer access requests, install the MongoDB they need, and stop publishing a database console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.7] - 2026-08-09
+
+### Added
+- **Access requests can be enabled at install time, and what they need gets installed.** `ENABLE_ACCESS_REQUESTS` turns on the workflow where a user asks for access to an Endpoint and an administrator approves or rejects it, but the installer never mentioned it, so every installation inherited the `False` from `example.env`. The requests are stored in MongoDB, read through `MONGODB_CONNECTION_STRING` regardless of the catalog backend — so on CKAN or with no catalog at all, the setting pointed at a MongoDB that nothing had stood up. The installer now asks, and answering yes uses the catalog's MongoDB where there is one and installs a MongoDB for it where there is not. `--access-requests` covers the unattended case.
+
+### Backwards compatibility
+- Access requests stay off unless asked for, at the prompt or with the flag, so an existing installation re-run without it is configured exactly as before.
+- Enabling them on a CKAN or no-catalog Endpoint adds the `mongodb` compose profile, which starts a MongoDB container alongside the Endpoint.
+
 ## [0.34.6] - 2026-08-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Access requests can be enabled at install time, and what they need gets installed.** `ENABLE_ACCESS_REQUESTS` turns on the workflow where a user asks for access to an Endpoint and an administrator approves or rejects it, but the installer never mentioned it, so every installation inherited the `False` from `example.env`. The requests are stored in MongoDB, read through `MONGODB_CONNECTION_STRING` regardless of the catalog backend — so on CKAN or with no catalog at all, the setting pointed at a MongoDB that nothing had stood up. The installer now asks, and answering yes uses the catalog's MongoDB where there is one and installs a MongoDB for it where there is not. `--access-requests` covers the unattended case.
 
+### Changed
+- **Starting a MongoDB no longer publishes a database administration console.** `mongo-express` shared the `mongodb` compose profile, so choosing MongoDB as the catalog — and, with the change above, enabling access requests on an Endpoint that has none — brought up a console on port 8082 exposing the whole database, with the demo credentials that are identical in every deployment. It now has a profile of its own and is started only when asked for: `docker compose --profile mongodb --profile mongo-express up -d`. The `full` profile still includes it.
+
 ### Backwards compatibility
 - Access requests stay off unless asked for, at the prompt or with the flag, so an existing installation re-run without it is configured exactly as before.
 - Enabling them on a CKAN or no-catalog Endpoint adds the `mongodb` compose profile, which starts a MongoDB container alongside the Endpoint.
+- A deployment that relied on `mongo-express` coming up with the `mongodb` profile has to add `--profile mongo-express`. A container already running is unaffected until the stack is brought down.
 
 ## [0.34.6] - 2026-08-09
 

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.34.6"
+    swagger_version: str = "0.34.7"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,10 +163,15 @@ services:
   # ==============================================
   # Mongo Express - MongoDB Web UI
   # ==============================================
+  # Web administration console for the MongoDB above. It exposes the whole
+  # database, with credentials that are the same demo pair everywhere, so it
+  # is its own profile: starting a MongoDB — for the catalog or for access
+  # requests — must not publish an admin console nobody asked for. Bring it up
+  # deliberately with --profile mongo-express.
   mongo-express:
     image: mongo-express:latest
     container_name: ndp-mongo-express
-    profiles: ["mongodb", "full"]
+    profiles: ["mongo-express", "full"]
     ports:
       - "8082:8081"
     environment:

--- a/install/README.md
+++ b/install/README.md
@@ -56,7 +56,15 @@ Run it with no arguments and it asks:
 
   Port to publish the Endpoint on [8003]:
   Authentication service (AAI) URL [https://idp.nationaldataplatform.org/temp/information]:
+  Enable access requests? [y/N]:
 ```
+
+**Access requests** are the self-service workflow: someone without access asks
+for it from the login screen, and an administrator approves or rejects it from
+the UI. They are stored in MongoDB, read through `MONGODB_CONNECTION_STRING`,
+whatever the catalog is — so answering yes installs a MongoDB unless the
+catalog already provides one, and points the Endpoint at it. That is the whole
+answer: nothing else has to be arranged.
 
 [docs/sequence-diagrams/installing-standalone-no-catalog.md](../docs/sequence-diagrams/installing-standalone-no-catalog.md)
 follows that run end to end — every prompt, who is contacted, what is started,
@@ -81,6 +89,7 @@ waiting for input.
 | `--federation-url <url>` | defaults to `https://federation.ndp.utah.edu` |
 | `--backend none\|mongodb\|ckan` | local catalog backend, default `none` |
 | `--ep-api-port <port>` | host port for the API, default `8002` |
+| `--access-requests` | enable the access-request workflow, installing MongoDB for it unless the catalog already provides one |
 | `--dry-run` | render the configuration and run the checks, start nothing |
 | `--no-start` | write everything, bring nothing up |
 | `--yes` | do not prompt before overwriting an existing `.env` |

--- a/install/README.md
+++ b/install/README.md
@@ -66,6 +66,15 @@ whatever the catalog is — so answering yes installs a MongoDB unless the
 catalog already provides one, and points the Endpoint at it. That is the whole
 answer: nothing else has to be arranged.
 
+A MongoDB is started on its own. The `mongo-express` administration console
+that ships in the compose file has its own profile and is never started for
+you — it exposes the whole database with credentials that are the same demo
+pair in every deployment. Bring it up deliberately if you want it:
+
+```bash
+docker compose --profile mongodb --profile mongo-express up -d
+```
+
 [docs/sequence-diagrams/installing-standalone-no-catalog.md](../docs/sequence-diagrams/installing-standalone-no-catalog.md)
 follows that run end to end — every prompt, who is contacted, what is started,
 and the `.env` it produces.

--- a/install/install.sh
+++ b/install/install.sh
@@ -85,6 +85,7 @@ ckan_ssl_port="8443"
 ckan_http_port="81"
 ckan_app_port="5000"
 ep_api_port="8002"
+want_access_requests="no"
 dry_run="false"
 start="true"
 assume_yes="false"
@@ -141,6 +142,9 @@ Options:
   --backend <name>        Local catalog backend: none | mongodb | ckan.
                           Default: none
   --ep-api-port <port>    Host port to publish the API on. Default: 8002
+  --access-requests       Let users request access and admins approve it.
+                          Stored in MongoDB: one is installed unless the
+                          catalog already provides one.
 
 With --backend none nothing is stored locally and no catalog is installed. The
 Endpoint authenticates users, searches the platform's global catalog and
@@ -190,6 +194,7 @@ while [[ $# -gt 0 ]]; do
     --ckan-http-port)  ckan_http_port="${2:-}"; shift 2 ;;
     --ckan-app-port)   ckan_app_port="${2:-}"; shift 2 ;;
     --ep-api-port)     ep_api_port="${2:-}"; shift 2 ;;
+    --access-requests) want_access_requests="yes"; shift ;;
     --dry-run)         dry_run="true"; shift ;;
     --no-start)        start="false"; shift ;;
     --yes)             assume_yes="true"; shift ;;
@@ -771,6 +776,15 @@ if [[ -z "$config_id" ]] && interactive; then
   ask auth_api_url "Authentication service (AAI) URL" \
     "https://idp.nationaldataplatform.org/temp/information"
 
+  section "Access requests" \
+    "A self-service workflow: someone without access to this Endpoint asks" \
+    "for it from the login screen, and an administrator approves or rejects" \
+    "it from the UI. Without this, access is arranged outside the Endpoint." \
+    "" \
+    "The requests are stored in MongoDB, whatever the catalog is. One is" \
+    "installed for it unless the catalog already provides one."
+  ask_yes_no want_access_requests "Enable access requests?" "no"
+
 fi
 
 # example.env is written as a demo that shows every setting, so its defaults
@@ -1066,6 +1080,26 @@ else
   # CKAN is served over https with a self-signed certificate.
   put CKAN_VERIFY_SSL "False"
   ckan_url="$ckan_site_url"
+fi
+
+# Access requests are stored in MongoDB, read through
+# MONGODB_CONNECTION_STRING, whatever the catalog backend is — so wanting them
+# means wanting a MongoDB. The catalog provides one on the MongoDB backends;
+# on CKAN or with no catalog at all, one is installed for this alone, which is
+# the part that was missing: the setting existed and nothing stood up what it
+# needs.
+if [[ "$want_access_requests" == "yes" ]]; then
+  put ENABLE_ACCESS_REQUESTS "True"
+
+  if [[ "$backend" == "mongodb" && -n "$mongodb_url" ]]; then
+    ok "Access requests enabled, stored in the MongoDB you provided"
+  elif [[ "$backend" == "mongodb" ]]; then
+    ok "Access requests enabled, stored in the MongoDB installed for the catalog"
+  else
+    profiles+=("mongodb")
+    put MONGODB_CONNECTION_STRING "mongodb://admin:admin123@mongodb:27017"
+    ok "Access requests enabled — installing MongoDB for them (compose profile 'mongodb')"
+  fi
 fi
 
 if [[ "${fed_streaming:-false}" == "true" ]]; then

--- a/install/tests/test_render_env.py
+++ b/install/tests/test_render_env.py
@@ -207,3 +207,35 @@ def test_the_endpoint_is_built_from_the_checkout_being_installed():
         assert (
             "--build" in line
         ), f"the Endpoint is started without --build: {line.strip()}"
+
+
+def test_access_requests_bring_their_own_mongodb():
+    """
+    Access requests are stored in MongoDB, read through
+    MONGODB_CONNECTION_STRING, whatever the catalog backend is. Offering the
+    option without standing up a MongoDB — which is what the setting had
+    before, documented and unreachable — produces an Endpoint that accepts the
+    answer and then cannot serve the feature.
+
+    So enabling it must add the compose profile and a connection string on any
+    backend that does not already provide one.
+    """
+    install_sh = (Path(__file__).resolve().parents[1] / "install.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert (
+        'ask_yes_no want_access_requests "Enable access requests?"' in install_sh
+    ), "the installer never offers access requests"
+    assert "--access-requests)" in install_sh, "there is no flag for an unattended run"
+
+    block_start = install_sh.index('if [[ "$want_access_requests" == "yes" ]]; then')
+    block = install_sh[block_start : install_sh.index("\nfi\n", block_start)]
+
+    assert 'put ENABLE_ACCESS_REQUESTS "True"' in block
+    assert (
+        'profiles+=("mongodb")' in block
+    ), "no MongoDB is installed for a backend that does not provide one"
+    assert (
+        "put MONGODB_CONNECTION_STRING " in block
+    ), "the MongoDB installed for access requests is never pointed at"

--- a/install/tests/test_render_env.py
+++ b/install/tests/test_render_env.py
@@ -239,3 +239,27 @@ def test_access_requests_bring_their_own_mongodb():
     assert (
         "put MONGODB_CONNECTION_STRING " in block
     ), "the MongoDB installed for access requests is never pointed at"
+
+
+def test_starting_mongodb_does_not_publish_a_database_console():
+    """
+    mongo-express exposes the whole database, with the demo credentials that
+    are the same in every deployment. It shared the `mongodb` profile, so
+    choosing MongoDB as the catalog — or, now, enabling access requests on an
+    Endpoint that has no MongoDB — published an admin console on 8082 that
+    nobody asked for.
+    """
+    compose = (Path(__file__).resolve().parents[2] / "docker-compose.yml").read_text(
+        encoding="utf-8"
+    )
+
+    block = compose[compose.index("mongo-express:") :]
+    profiles_line = next(
+        line for line in block.splitlines() if line.strip().startswith("profiles:")
+    )
+
+    assert "mongodb" not in profiles_line, (
+        "mongo-express starts with the mongodb profile, so a MongoDB cannot be "
+        f"started without it: {profiles_line.strip()}"
+    )
+    assert "mongo-express" in profiles_line, "mongo-express has no profile of its own"


### PR DESCRIPTION
Closes #229.

`ENABLE_ACCESS_REQUESTS` turns on the self-service workflow: someone without access asks for it from the login screen, an administrator approves or rejects it from the UI. The installer never mentioned it, so every installation inherited the `False` that `example.env` carries.

Turning it on by hand was not enough either. The requests are stored in MongoDB, read through `MONGODB_CONNECTION_STRING` **regardless of the catalog backend** — and on CKAN, or with no catalog at all, the installer leaves that string empty. The setting was documented and unreachable.

So wanting access requests means wanting a MongoDB, and the installer now treats it that way:

| Catalog | What answering yes does |
|---|---|
| MongoDB, installed by the script | Uses it |
| MongoDB, one you already run | Uses it |
| CKAN, or no catalog | **Installs MongoDB for it**, and points the Endpoint at it |

`--access-requests` covers the unattended case. The question stays off by default, so an existing installation re-run without it is configured exactly as before.

## Verified

All four paths run end to end, checking the rendered `.env` and the compose profiles:

```
--backend none                        → ENABLE_ACCESS_REQUESTS=False, connection string empty
--backend none --access-requests      → True, mongodb://admin:...@mongodb:27017, --profile mongodb
--backend mongodb --access-requests   → True, the catalog's MongoDB, no second profile
--mongodb-url ... --access-requests   → True, the MongoDB provided
```

The interactive path was driven through a pty: the question appears after the authentication service, and answering `y` renders the same result.

Then the feature itself, on an Endpoint with **no catalog** and access requests on, against a real MongoDB: the three `/user/access-requests` routes are present, the listing answers 401 without a token and **200 with an empty list** with one. The same call on an Endpoint with the setting off answers `503 "Access-request workflow is disabled on this deployment."` — which is what every installation produced until now.

1205 tests, `black --check .` and `flake8` clean.