### PR TITLE
Set the staging organization from the registration, and document a service's life

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.8] - 2026-08-09
+
+### Fixed
+- **A registered Endpoint can publish to the staging catalog without being adjusted by hand.** The registration returns a staging URL and token and the installer wrote both, but left `PRE_CKAN_ORGANIZATION` empty — so a promoted dataset kept its local organization (`services`, or whatever the local catalog calls it), which the staging credentials cannot write to. Every publish failed with `Access denied: User <user> not authorized to add dataset to this organization`, an error naming a user rather than the missing setting. The installer now derives it from the configuration id — `ep-<config-id>`, the organization the Federation minted the token for — and asks the staging catalog to confirm it accepts writes there before anything is written, naming the organizations it would accept when it does not.
+
+### Added
+- **Sequence diagram of a service's life** ([docs/sequence-diagrams/registering-and-using-a-service.md](docs/sequence-diagrams/registering-and-using-a-service.md)): registered in the catalog, reached through the Endpoint, and promoted for review. It states the three things that catch people out — `owner_org` must be `services`; the redirect is a proxy rather than a 302, takes no token, and calls the service from inside the Endpoint's container, so an address that works from the operator's shell may not resolve there; and publishing needs an organization the staging catalog accepts.
+
+### Backwards compatibility
+- An Endpoint installed before this keeps its empty `PRE_CKAN_ORGANIZATION` until it is re-installed or the value is set by hand.
+
 ## [0.34.7] - 2026-08-09
 
 ### Added

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.34.7"
+    swagger_version: str = "0.34.8"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/docs/sequence-diagrams/README.md
+++ b/docs/sequence-diagrams/README.md
@@ -12,6 +12,7 @@ vertical lifeline and time runs downwards.
 | [Installing a standalone Endpoint with no catalog](installing-standalone-no-catalog.md) | The lightest install: no Federation registration, no local catalog, every answer left at its default, and the `.env` it produces |
 | [Installing an Endpoint registered with the Federation](installing-registered-no-catalog.md) | The same install, registered: what the Federation creates on your behalf in Keycloak, the staging catalog and Affinities, and what of it the Endpoint actually uses |
 | [Publishing a dataset](publishing-a-dataset.md) | Where a dataset goes — registered locally, promoted to the staging catalog, and why the global one is read-only — with every switch that stops it and the status code it produces |
+| [Registering, reaching and publishing a service](registering-and-using-a-service.md) | A service registered in the catalog, reached through the Endpoint's proxy — which takes no token and calls out from inside the container — and promoted for review |
 
 For the static picture of the system — layers, routes, repositories — see
 [../architecture-diagrams.md](../architecture-diagrams.md). These diagrams

--- a/docs/sequence-diagrams/registering-and-using-a-service.md
+++ b/docs/sequence-diagrams/registering-and-using-a-service.md
@@ -1,0 +1,134 @@
+# Registering, reaching and publishing a service
+
+A service is a dataset that points at something running: an API, a UI, a
+trigger. Registering one puts it in the Endpoint's catalog; the Endpoint can
+then be used to reach it; and promoting it offers it to the platform for
+review.
+
+Drawn against an Endpoint with a local catalog and the staging catalog
+configured — a registered install with MongoDB or CKAN.
+
+## The sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User
+    participant EP as Endpoint API
+    participant AAI as Authentication service
+    participant Local as Local catalog
+    participant Svc as The service itself
+    participant Pre as Staging catalog
+
+    rect rgb(245, 245, 245)
+    Note over User,Local: Registering
+    User->>EP: POST /services + Bearer token
+    Note over User,EP: owner_org must be "services" — the organization the<br/>Endpoint creates for them at startup. Anything else<br/>is refused by the request model
+    EP->>AAI: validate the token
+    AAI-->>EP: identity, groups and roles
+    Note over EP: A write: writer or admin, and the group when<br/>group-based access is on
+    EP->>Local: package_create in "services",<br/>with a resource of format "service" holding the URL
+    Local-->>EP: id
+    EP-->>User: 201 with the id
+    end
+
+    rect rgb(238, 242, 248)
+    Note over User,Svc: Reaching it — a proxy, not a redirect
+    User->>EP: GET /services/redirect/{name}
+    Note over User,EP: No token required: this route has no<br/>authentication of its own
+    EP->>Local: search "services" for that name
+    alt not found
+        Local-->>EP: nothing
+        EP-->>User: 404 — Service '{name}' not found
+    else found
+        Local-->>EP: the dataset, with the service URL
+        EP->>Svc: the same request, forwarded
+        Note over EP,Svc: Sent from inside the Endpoint's container:<br/>a URL that works from your shell may not<br/>resolve from there
+        alt the service answers
+            Svc-->>EP: its response
+            EP-->>User: that response, passed through
+        else it cannot be reached
+            EP-->>User: 502 — Unable to connect to the target service
+        end
+    end
+    Note over User,Svc: /services/redirect/{name}/{path} forwards the<br/>subpath too, for GET, POST, PUT, PATCH and DELETE
+    end
+
+    rect rgb(245, 245, 245)
+    Note over User,Pre: Publishing it for review
+    User->>EP: POST /dataset/{name}/publish + Bearer token
+    Note over EP: PRE_CKAN_ENABLED must be True — otherwise 400
+    EP->>Local: package_show
+    Local-->>EP: the service, resources and extras
+    Note over EP: owner_org is replaced by PRE_CKAN_ORGANIZATION.<br/>Without it the local organization travels along and<br/>the staging catalog refuses the write
+    EP->>Pre: package_create, marked "status: submitted"
+    Pre-->>EP: id
+    EP->>Local: mirror "status: submitted" locally
+    EP-->>User: 201
+    end
+```
+
+## The three things that catch people out
+
+**`owner_org` must be `services`.** Not the Endpoint's organization, not the
+user's. The request model validates it against that exact string, and the
+Endpoint creates that organization for itself at startup. Services live
+together there, which is also how the redirect finds them.
+
+**The redirect is a proxy.** `/services/redirect/{name}` does not answer 302
+and does not send the caller to the service. The Endpoint forwards the request
+and returns what comes back, so the caller only ever talks to the Endpoint. Two
+consequences worth planning for:
+
+- The request leaves from **inside the Endpoint's container**. A service at
+  `http://localhost:8002` — the Endpoint's own published port — is not
+  reachable from there, and the answer is `502 Unable to connect to the target
+  service`. Register the address the container can resolve.
+- The route takes **no token**. Whoever can reach the Endpoint can reach the
+  service through it, whatever the service's own access rules are. If that is
+  not what you want, the service has to enforce its own.
+
+**Publishing needs an organization the staging catalog will accept.** A
+promoted dataset keeps its local organization unless `PRE_CKAN_ORGANIZATION`
+says otherwise, and `services` is not an organization the staging credentials
+own. The failure is an authorization error naming a user, which reads as a
+credentials problem:
+
+```
+Access denied: User <user> not authorized to add dataset to this organization
+```
+
+The installer sets that value from the registration — `ep-<config-id>`, the
+organization the Federation minted the staging token for — and checks with the
+staging catalog that it is accepted before writing anything. An Endpoint
+installed before that, or configured by hand, needs it set.
+
+## What it looks like end to end
+
+```bash
+# 1. Register
+curl -X POST http://localhost:8002/services \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"service_name":"my-service","service_title":"My service",
+       "owner_org":"services","service_url":"https://example.org/api",
+       "service_type":"API"}'
+# 201 {"id":"0300b047-..."}
+
+# 2. Reach it — no token
+curl http://localhost:8002/services/redirect/my-service
+# 200, with whatever the service answered
+
+# 3. Publish it for review
+curl -X POST http://localhost:8002/dataset/my-service/publish \
+  -H "Authorization: Bearer $TOKEN"
+# 201 {"id":"86551d66-...","message":"Dataset published to PRE-CKAN successfully"}
+```
+
+`service_type` is one of **API**, **UI** or **Trigger**, and the service can
+also carry a health-check URL, documentation URL and notes.
+
+## Related
+
+- [Publishing a dataset](publishing-a-dataset.md) — the same promotion, for data
+- [Installing an Endpoint registered with the Federation](installing-registered-no-catalog.md) — where the staging credentials come from
+- [Roles and permissions](../roles-and-permissions.md) — who may register one

--- a/install/install.sh
+++ b/install/install.sh
@@ -888,6 +888,13 @@ PY
     put PRE_CKAN_ENABLED "True"
     put PRE_CKAN_URL "$fed_pre_ckan_url"
     put PRE_CKAN_API_KEY "$fed_pre_ckan_key"
+    # Without this, a promoted dataset keeps the organization it has locally —
+    # 'services', or whatever the local catalog calls it — and the staging
+    # credentials cannot write there, so every publish fails with an
+    # authorization error naming a user rather than the missing setting. The
+    # organization the token can write to is the one the Federation minted it
+    # for, which is this Endpoint's configuration id.
+    put PRE_CKAN_ORGANIZATION "ep-${config_id}"
   else
     put PRE_CKAN_ENABLED "False"
   fi
@@ -1184,6 +1191,35 @@ if [[ "$backend" == "ckan" && "$dry_run" != "true" ]]; then
     esac
   else
     warn "CKAN key not verified: pass --ckan-sysadmin <name> to check it against this CKAN."
+  fi
+fi
+
+# The staging catalog accepts a dataset only in an organization its token may
+# write to. That organization is derived above from the configuration id, so
+# ask the staging catalog whether it agrees — a mismatch here is a publish that
+# fails much later with an authorization error naming a user, which reads as a
+# credentials problem and is not one.
+pre_url="$(grep -E '^PRE_CKAN_URL=' "$target" | head -1 | cut -d= -f2- | tr -d '"')"
+pre_key="$(grep -E '^PRE_CKAN_API_KEY=' "$target" | head -1 | cut -d= -f2- | tr -d '"')"
+pre_org="$(grep -E '^PRE_CKAN_ORGANIZATION=' "$target" | head -1 | cut -d= -f2- | tr -d '"')"
+
+if [[ -n "$pre_url" && -n "$pre_key" && -n "$pre_org" && "$dry_run" != "true" ]]; then
+  writable="$(curl -s -m 20 -H "Authorization: $pre_key" \
+    "${pre_url%/}/api/3/action/organization_list_for_user?permission=create_dataset" \
+    | python3 -c 'import json,sys
+try:
+    print(" ".join(o.get("name","") for o in json.load(sys.stdin).get("result", [])))
+except Exception:
+    print("")' 2>/dev/null || echo "")"
+
+  if [[ -z "$writable" ]]; then
+    warn "Could not ask the staging catalog which organizations its token may write to."
+  elif [[ " $writable " == *" $pre_org "* ]]; then
+    ok "Staging catalog accepts publishing to '$pre_org'"
+  else
+    warn "The staging catalog does not list '$pre_org' among the organizations its"
+    warn "token may write to, so publishing there will be refused. Set"
+    warn "PRE_CKAN_ORGANIZATION to one of: $writable"
   fi
 fi
 

--- a/install/tests/test_render_env.py
+++ b/install/tests/test_render_env.py
@@ -263,3 +263,27 @@ def test_starting_mongodb_does_not_publish_a_database_console():
         f"started without it: {profiles_line.strip()}"
     )
     assert "mongo-express" in profiles_line, "mongo-express has no profile of its own"
+
+
+def test_a_registration_supplies_the_staging_organization():
+    """
+    A promoted dataset keeps its local organization unless
+    PRE_CKAN_ORGANIZATION says otherwise, and the staging credentials cannot
+    write to 'services' or to any organization local to the Endpoint. Without
+    this the staging catalog looks configured and every publish fails with an
+    authorization error naming a user, which reads as a credentials problem.
+
+    The organization is the one the Federation minted the token for, which is
+    derived from the configuration id the installer already has.
+    """
+    install_sh = (Path(__file__).resolve().parents[1] / "install.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert (
+        'put PRE_CKAN_ORGANIZATION "ep-${config_id}"' in install_sh
+    ), "the staging organization is not derived from the registration"
+    assert "organization_list_for_user" in install_sh, (
+        "nothing checks that the staging catalog accepts that organization "
+        "before the configuration is written"
+    )


### PR DESCRIPTION
Closes #231. Closes #232.

Found by walking the whole service flow against a live Endpoint: register a service, reach it through the redirect, publish it.

## The fix

Registering an Endpoint returns a staging-catalog URL and token, and the installer wrote both — but left `PRE_CKAN_ORGANIZATION` empty. A promoted dataset then keeps the organization it has locally, and the staging credentials cannot write there:

```
Access denied: User <user> not authorized to add dataset to this organization
```

An error naming a user, for a missing setting. Asking the staging catalog which organizations its token may write to returns one per registered Endpoint, named `ep-<config-id>` — the name the Federation mints the token for, and something the installer already knows.

So it is derived from the configuration id, and **checked** before anything is written:

```
[ ok ] Staging catalog accepts publishing to 'ep-6a787f097770ef7b55e104b0'
```

When the catalog does not accept it, the installer says so and names the organizations it would accept, rather than leaving it to surface at the first publish.

## The diagram

[docs/sequence-diagrams/registering-and-using-a-service.md](docs/sequence-diagrams/registering-and-using-a-service.md) — a service registered, reached and promoted, with the three things that catch people out:

- **`owner_org` must be `services`**, the organization the Endpoint creates for itself at startup; the request model refuses anything else.
- **The redirect is a proxy, not a 302.** The Endpoint forwards the request and returns the response, so the caller only ever talks to the Endpoint. It takes **no token** — whoever reaches the Endpoint reaches the service through it — and it calls out **from inside the container**, so a service at the Endpoint's own published port answers `502 Unable to connect to the target service`.
- **Publishing needs an organization the staging catalog accepts**, which is what the fix above supplies.

## Verified

Every step run against a live registered Endpoint with a MongoDB catalog:

| Step | Result |
|---|---|
| `POST /services` | 201 with an id |
| `GET /services/redirect/<name>` | 200, the target service's own response, no token |
| Same, unknown name | 404 `Service 'no-existe' not found` |
| Same, unreachable URL | 502 `Unable to connect to the target service` |
| `POST /dataset/<name>/publish`, before the fix | 500, the authorization error above |
| Same, with the organization set | 201, and the service is in the staging catalog under `ep-<config-id>` with `status: submitted`, mirrored onto the local copy |

Re-installing with the existing `--config-id` renders `PRE_CKAN_ORGANIZATION=ep-6a787f097770ef7b55e104b0` and the new check confirms it against the live staging catalog.

1207 tests, `black --check .` clean. The Mermaid source renders through `mermaid-cli`.