### PR TITLE
Let a service require its callers to be authenticated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **A service can require its callers to be authenticated.** The proxy at `/services/redirect/{name}` carries no authentication of its own: whoever reaches the Endpoint reaches the service through it. A service that should not be open now says so with a `requires_auth` extra, and the Endpoint validates the caller's bearer token before forwarding anything — an anonymous caller gets `401` with a `WWW-Authenticate` challenge and the service is never contacted. Subpaths are covered too, so `/services/redirect/{name}/anything` is not a way around it. `True`, `true`, `1`, `yes` and `on` all mean protected.
+- A decision flowchart, **Who gets through**, alongside the sequence diagram: what registering decides once, and the order of questions every call is then answered by — service found, protection asked for, token presented, token accepted, service reachable — with the status each dead end produces.
 - The service sequence diagram documents it, including what it does *not* do: the check is authentication, not authorization — it does not look at groups or roles — and the `Authorization` header still reaches the service, so whoever registers one receives the tokens of everyone who uses it.
 
 ### Backwards compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.9] - 2026-08-09
+
+### Added
+- **A service can require its callers to be authenticated.** The proxy at `/services/redirect/{name}` carries no authentication of its own: whoever reaches the Endpoint reaches the service through it. A service that should not be open now says so with a `requires_auth` extra, and the Endpoint validates the caller's bearer token before forwarding anything — an anonymous caller gets `401` with a `WWW-Authenticate` challenge and the service is never contacted. Subpaths are covered too, so `/services/redirect/{name}/anything` is not a way around it. `True`, `true`, `1`, `yes` and `on` all mean protected.
+- The service sequence diagram documents it, including what it does *not* do: the check is authentication, not authorization — it does not look at groups or roles — and the `Authorization` header still reaches the service, so whoever registers one receives the tokens of everyone who uses it.
+
+### Backwards compatibility
+- **A service without that extra is exactly as open as before**, which is every service registered until now. The behaviour changes only for services that ask for it.
+- `get_service_url` keeps its signature and its callers; the access rule comes from a new `get_service_access`, which it delegates to, so both are answered by a single catalog search.
+
 ## [0.34.8] - 2026-08-09
 
 ### Fixed

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.34.8"
+    swagger_version: str = "0.34.9"
     root_path: str = ""  # API root path prefix (e.g., "/test" or "")
     is_public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"

--- a/api/routes/redirect_routes/service_redirect.py
+++ b/api/routes/redirect_routes/service_redirect.py
@@ -4,13 +4,50 @@ import logging
 from typing import Optional
 
 import httpx
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import Response
+from fastapi.security import HTTPAuthorizationCredentials
 
-from api.services.service_services.redirect_service import get_service_url
+from api.services.auth_services.get_current_user import get_current_user
+from api.services.service_services.redirect_service import (
+    get_service_access,
+    get_service_url,  # noqa: F401  (kept importable for callers and tests)
+)
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+
+def require_valid_token(request: Request) -> None:
+    """
+    Let through only callers this Endpoint can authenticate.
+
+    Applied per service, when its ``requires_auth`` extra says so — the proxy
+    itself carries no authentication, and a service that does not ask for it
+    stays reachable by anyone who can reach the Endpoint.
+
+    The token is validated exactly as everywhere else, so an authentication
+    service that is down answers 502 rather than being mistaken for a bad
+    token.
+
+    Raises
+    ------
+    HTTPException
+        401 when no bearer token is presented, or the token is rejected.
+    """
+    header = request.headers.get("authorization", "")
+    scheme, _, token = header.partition(" ")
+
+    if scheme.lower() != "bearer" or not token.strip():
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="This service requires authentication. Provide a bearer token.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    get_current_user(
+        HTTPAuthorizationCredentials(scheme="Bearer", credentials=token.strip())
+    )
 
 
 async def proxy_request(
@@ -139,10 +176,13 @@ async def proxy_to_service_functional(service_identifier: str, request: Request)
     This endpoint actually performs the proxy functionality but is hidden
     from Swagger UI to avoid CORS issues.
     """
-    service_url, error = await get_service_url(service_identifier)
+    service_url, requires_auth, error = await get_service_access(service_identifier)
 
     if error:
         raise HTTPException(status_code=404, detail=error)
+
+    if requires_auth:
+        require_valid_token(request)
 
     return await proxy_request(request, service_url)
 
@@ -161,10 +201,13 @@ async def proxy_to_service_with_path_functional(
     This endpoint actually performs the proxy functionality but is hidden
     from Swagger UI to avoid CORS issues.
     """
-    service_url, error = await get_service_url(service_identifier)
+    service_url, requires_auth, error = await get_service_access(service_identifier)
 
     if error:
         raise HTTPException(status_code=404, detail=error)
+
+    if requires_auth:
+        require_valid_token(request)
 
     return await proxy_request(request, service_url, path)
 

--- a/api/services/service_services/redirect_service.py
+++ b/api/services/service_services/redirect_service.py
@@ -1,28 +1,56 @@
 # api/services/service_services/redirect_service.py
 
-from typing import Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from api.services.datasource_services.search_datasource import search_datasource
 
+# The extra a service sets to be reached only by callers the Endpoint can
+# authenticate. Absent means open, which is how every service registered so
+# far behaves and must keep behaving.
+REQUIRES_AUTH_EXTRA = "requires_auth"
 
-async def get_service_url(
-    service_identifier: str, server: str = "local"
-) -> Tuple[Optional[str], Optional[str]]:
+_TRUTHY = {"true", "1", "yes", "on"}
+
+
+def _requires_auth(extras: Optional[Dict[str, Any]]) -> bool:
     """
-    Get service URL by service name.
+    Whether a service asks the Endpoint to authenticate callers first.
+
+    Extras arrive as strings from CKAN and as whatever was posted from
+    MongoDB, so a real boolean and the usual spellings are both accepted.
+    Anything else — including the extra being absent — means open.
+    """
+    if not extras:
+        return False
+
+    value = extras.get(REQUIRES_AUTH_EXTRA)
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in _TRUTHY
+
+
+async def get_service_access(
+    service_identifier: str, server: str = "local"
+) -> Tuple[Optional[str], bool, Optional[str]]:
+    """
+    Get a service's URL and whether reaching it requires authentication.
+
+    One catalog search answers both: the URL the proxy forwards to, and the
+    ``requires_auth`` extra the Endpoint checks before forwarding anything.
 
     Parameters
     ----------
     service_identifier : str
         Service name to search for.
     server : str
-        CKAN server to search on ('local', 'global', 'pre_ckan').
+        Catalog to search on ('local', 'global', 'pre_ckan').
 
     Returns
     -------
-    Tuple[Optional[str], Optional[str]]
-        Tuple of (service_url, error_message). If successful, returns
-        (url, None). If failed, returns (None, error_message).
+    Tuple[Optional[str], bool, Optional[str]]
+        (service_url, requires_auth, error_message). On success the error is
+        None; on failure the URL is None, ``requires_auth`` is False and
+        unused, and the message says why.
     """
     try:
         # Search for service by name in the 'services' organization
@@ -34,7 +62,7 @@ async def get_service_url(
 
         # If no results found, return error
         if not search_results:
-            return None, f"Service '{service_identifier}' not found"
+            return None, False, f"Service '{service_identifier}' not found"
 
         # Get the first matching service (names should be unique)
         service_dataset = search_results[0]
@@ -52,12 +80,38 @@ async def get_service_url(
 
         # If still no URL found, return error
         if service_url is None:
-            return None, f"Service URL not found for '{service_identifier}'"
+            return None, False, f"Service URL not found for '{service_identifier}'"
 
-        return service_url, None
+        return service_url, _requires_auth(service_dataset.extras), None
 
     except Exception as exc:
         error_msg = str(exc)
         if "No scheme supplied" in error_msg:
-            return None, "Server is not configured or unreachable."
-        return None, f"Error retrieving service: {error_msg}"
+            return None, False, "Server is not configured or unreachable."
+        return None, False, f"Error retrieving service: {error_msg}"
+
+
+async def get_service_url(
+    service_identifier: str, server: str = "local"
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Get service URL by service name.
+
+    Kept for callers that only need the URL; the access rule comes from
+    ``get_service_access``, which this delegates to.
+
+    Parameters
+    ----------
+    service_identifier : str
+        Service name to search for.
+    server : str
+        CKAN server to search on ('local', 'global', 'pre_ckan').
+
+    Returns
+    -------
+    Tuple[Optional[str], Optional[str]]
+        Tuple of (service_url, error_message). If successful, returns
+        (url, None). If failed, returns (None, error_message).
+    """
+    service_url, _, error = await get_service_access(service_identifier, server=server)
+    return service_url, error

--- a/docs/sequence-diagrams/registering-and-using-a-service.md
+++ b/docs/sequence-diagrams/registering-and-using-a-service.md
@@ -35,13 +35,17 @@ sequenceDiagram
     rect rgb(238, 242, 248)
     Note over User,Svc: Reaching it — a proxy, not a redirect
     User->>EP: GET /services/redirect/{name}
-    Note over User,EP: No token required: this route has no<br/>authentication of its own
     EP->>Local: search "services" for that name
     alt not found
         Local-->>EP: nothing
         EP-->>User: 404 — Service '{name}' not found
     else found
-        Local-->>EP: the dataset, with the service URL
+        Local-->>EP: the dataset, its URL and its extras
+        opt the service sets requires_auth
+            Note over EP: The proxy has no authentication of its own —<br/>this is the service asking for one
+            EP->>AAI: validate the caller's token
+            AAI-->>EP: identity — or 401, and the service is never contacted
+        end
         EP->>Svc: the same request, forwarded
         Note over EP,Svc: Sent from inside the Endpoint's container:<br/>a URL that works from your shell may not<br/>resolve from there
         alt the service answers
@@ -84,9 +88,10 @@ consequences worth planning for:
   `http://localhost:8002` — the Endpoint's own published port — is not
   reachable from there, and the answer is `502 Unable to connect to the target
   service`. Register the address the container can resolve.
-- The route takes **no token**. Whoever can reach the Endpoint can reach the
-  service through it, whatever the service's own access rules are. If that is
-  not what you want, the service has to enforce its own.
+- The route takes **no token by default**. Whoever can reach the Endpoint
+  reaches the service through it. A service that should not be open sets the
+  `requires_auth` extra, and the Endpoint then authenticates the caller before
+  forwarding anything — see below.
 
 **Publishing needs an organization the staging catalog will accept.** A
 promoted dataset keeps its local organization unless `PRE_CKAN_ORGANIZATION`
@@ -102,6 +107,44 @@ The installer sets that value from the registration — `ep-<config-id>`, the
 organization the Federation minted the staging token for — and checks with the
 staging catalog that it is accepted before writing anything. An Endpoint
 installed before that, or configured by hand, needs it set.
+
+## Protecting a service
+
+A service is open unless it says otherwise. To have the Endpoint authenticate
+callers first, set the `requires_auth` extra when registering it:
+
+```bash
+curl -X POST http://localhost:8002/services \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"service_name":"private-service","service_title":"Private service",
+       "owner_org":"services","service_url":"https://example.org/api",
+       "service_type":"API","extras":{"requires_auth":"true"}}'
+```
+
+From then on the proxy refuses anonymous callers, and the service is never
+contacted for them:
+
+```
+GET /services/redirect/private-service
+401  This service requires authentication. Provide a bearer token.
+     WWW-Authenticate: Bearer
+```
+
+Subpaths are covered too, so `/services/redirect/private-service/anything` is
+not a way around it. `True`, `true`, `1`, `yes` and `on` all mean protected;
+anything else, including the extra being absent, means open — so every service
+registered before this stays exactly as reachable as it was.
+
+What this checks is that the caller holds a token this Endpoint can validate.
+It is authentication, not authorization: it does not ask which groups or roles
+the user has. A service that needs finer rules still has to apply them itself,
+and it can — the proxy forwards the `Authorization` header, so the token
+reaches the service.
+
+That forwarding cuts both ways: whoever registers a service receives the
+tokens of everyone who reaches it through the proxy. Registering requires a
+writer role, so this is not open to anonymous callers, but it is worth knowing
+before pointing a service at somewhere you do not control.
 
 ## What it looks like end to end
 

--- a/docs/sequence-diagrams/registering-and-using-a-service.md
+++ b/docs/sequence-diagrams/registering-and-using-a-service.md
@@ -146,6 +146,48 @@ tokens of everyone who reaches it through the proxy. Registering requires a
 writer role, so this is not open to anonymous callers, but it is worth knowing
 before pointing a service at somewhere you do not control.
 
+## Who gets through
+
+Registering decides it once; every call is then answered by the same
+questions, in this order.
+
+```mermaid
+flowchart TD
+    R["POST /services<br/>owner_org must be services"] --> RA{"extras.requires_auth<br/>set to a truthy value?"}
+    RA -->|"no, or absent"| OPEN["Registered open<br/>— every service until now"]
+    RA -->|"yes"| PROT["Registered protected"]
+
+    C(["A caller: GET /services/redirect/name"]) --> F{"Service found in<br/>the services organization?"}
+    F -->|"no"| E404["404<br/>Service 'name' not found"]
+    F -->|"yes"| Q{"Does the service<br/>require authentication?"}
+
+    Q -->|"no"| FWD
+    Q -->|"yes"| H{"Bearer token<br/>presented?"}
+    H -->|"no"| E401["401 + WWW-Authenticate<br/>the service is never contacted"]
+    H -->|"yes"| V{"Does the authentication<br/>service accept it?"}
+    V -->|"no"| E4XX["Refused, and today<br/>reported as 502 — see below"]
+    V -->|"yes"| FWD["Forward the request,<br/>Authorization header included"]
+
+    FWD --> S{"Is the service<br/>reachable from the<br/>Endpoint's container?"}
+    S -->|"no"| E502["502<br/>Unable to connect to the target service"]
+    S -->|"yes"| OK["The service's own response,<br/>passed back unchanged"]
+
+    OPEN -.-> C
+    PROT -.-> C
+```
+
+Two things this picture makes plain. The check is on **the caller's identity,
+not their permissions** — any token the Endpoint can validate gets through,
+whichever groups or roles it carries. And a refused caller costs the service
+nothing: the Endpoint answers 401 without contacting it at all.
+
+One wrinkle, and it is not confined to services: a token the authentication
+service *rejects* currently arrives as **502**, not 401. That service answers
+`400` for a token it will not accept, and the Endpoint maps statuses it does
+not recognise to 502 on the assumption that the service is misbehaving. So a
+mistyped token reads as an Endpoint fault. A missing token is a clean 401; it
+is only a wrong one that misreports.
+
 ## What it looks like end to end
 
 ```bash

--- a/tests/test_redirect_routes.py
+++ b/tests/test_redirect_routes.py
@@ -229,14 +229,14 @@ class TestProxyToServiceFunctional:
 
     @pytest.mark.asyncio
     @patch("api.routes.redirect_routes.service_redirect.proxy_request")
-    @patch("api.routes.redirect_routes.service_redirect.get_service_url")
+    @patch("api.routes.redirect_routes.service_redirect.get_service_access")
     async def test_proxy_success(self, mock_get_url, mock_proxy):
         """Test successful proxy to service."""
         from api.routes.redirect_routes.service_redirect import (
             proxy_to_service_functional,
         )
 
-        mock_get_url.return_value = ("https://api.example.com", None)
+        mock_get_url.return_value = ("https://api.example.com", False, None)
         mock_proxy.return_value = MagicMock(status_code=200)
 
         request = MagicMock()
@@ -246,14 +246,14 @@ class TestProxyToServiceFunctional:
         mock_proxy.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("api.routes.redirect_routes.service_redirect.get_service_url")
+    @patch("api.routes.redirect_routes.service_redirect.get_service_access")
     async def test_proxy_service_not_found(self, mock_get_url):
         """Test proxy with service not found."""
         from api.routes.redirect_routes.service_redirect import (
             proxy_to_service_functional,
         )
 
-        mock_get_url.return_value = (None, "Service not found")
+        mock_get_url.return_value = (None, False, "Service not found")
 
         with pytest.raises(HTTPException) as exc_info:
             await proxy_to_service_functional("missing-service", MagicMock())
@@ -266,14 +266,14 @@ class TestProxyToServiceWithPath:
 
     @pytest.mark.asyncio
     @patch("api.routes.redirect_routes.service_redirect.proxy_request")
-    @patch("api.routes.redirect_routes.service_redirect.get_service_url")
+    @patch("api.routes.redirect_routes.service_redirect.get_service_access")
     async def test_proxy_with_path_success(self, mock_get_url, mock_proxy):
         """Test successful proxy with path."""
         from api.routes.redirect_routes.service_redirect import (
             proxy_to_service_with_path_functional,
         )
 
-        mock_get_url.return_value = ("https://api.example.com", None)
+        mock_get_url.return_value = ("https://api.example.com", False, None)
         mock_proxy.return_value = MagicMock(status_code=200)
 
         request = MagicMock()
@@ -287,14 +287,14 @@ class TestProxyToServiceWithPath:
         )
 
     @pytest.mark.asyncio
-    @patch("api.routes.redirect_routes.service_redirect.get_service_url")
+    @patch("api.routes.redirect_routes.service_redirect.get_service_access")
     async def test_proxy_with_path_not_found(self, mock_get_url):
         """Test proxy with path service not found."""
         from api.routes.redirect_routes.service_redirect import (
             proxy_to_service_with_path_functional,
         )
 
-        mock_get_url.return_value = (None, "Service not found")
+        mock_get_url.return_value = (None, False, "Service not found")
 
         with pytest.raises(HTTPException) as exc_info:
             await proxy_to_service_with_path_functional(

--- a/tests/test_service_redirect_auth.py
+++ b/tests/test_service_redirect_auth.py
@@ -1,0 +1,159 @@
+# tests/test_service_redirect_auth.py
+"""
+Protecting a service behind the Endpoint's proxy.
+
+The proxy carries no authentication of its own: whoever reaches the Endpoint
+reaches the service through it. A service can now ask for callers to be
+authenticated first, with a ``requires_auth`` extra — and, crucially, a
+service that does not ask stays exactly as open as it was, because every
+service registered before this has no such extra.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.redirect_routes.service_redirect import (
+    proxy_to_service_functional,
+    proxy_to_service_with_path_functional,
+    require_valid_token,
+)
+from api.services.service_services.redirect_service import _requires_auth
+
+
+def _request(authorization=None):
+    request = MagicMock()
+    request.headers = {"authorization": authorization} if authorization else {}
+    return request
+
+
+class TestTheExtra:
+    """What counts as asking for authentication."""
+
+    def test_absent_extras_leave_the_service_open(self):
+        assert _requires_auth(None) is False
+        assert _requires_auth({}) is False
+
+    def test_an_unrelated_extra_leaves_it_open(self):
+        assert _requires_auth({"service_type": "API"}) is False
+
+    @pytest.mark.parametrize("value", [True, "true", "True", "1", "yes", "on"])
+    def test_the_usual_spellings_all_mean_protected(self, value):
+        # Extras come back as strings from CKAN and as posted from MongoDB.
+        assert _requires_auth({"requires_auth": value}) is True
+
+    @pytest.mark.parametrize("value", [False, "false", "no", "0", "", "maybe"])
+    def test_anything_else_means_open(self, value):
+        assert _requires_auth({"requires_auth": value}) is False
+
+
+class TestTheGate:
+    """require_valid_token, on its own."""
+
+    def test_no_token_is_refused_with_a_challenge(self):
+        with pytest.raises(HTTPException) as error:
+            require_valid_token(_request())
+
+        assert error.value.status_code == 401
+        assert error.value.headers["WWW-Authenticate"] == "Bearer"
+
+    def test_a_non_bearer_authorization_is_refused(self):
+        with pytest.raises(HTTPException) as error:
+            require_valid_token(_request("Basic dXNlcjpwYXNz"))
+
+        assert error.value.status_code == 401
+
+    @patch("api.routes.redirect_routes.service_redirect.get_current_user")
+    def test_a_bearer_token_is_validated_the_usual_way(self, get_user):
+        get_user.return_value = {"sub": "someone"}
+
+        require_valid_token(_request("Bearer a-token"))
+
+        credentials = get_user.call_args[0][0]
+        assert credentials.credentials == "a-token"
+
+    @patch("api.routes.redirect_routes.service_redirect.get_current_user")
+    def test_the_validators_own_failure_is_not_rewritten(self, get_user):
+        # An authentication service that is down answers 502 there; turning
+        # that into a 401 here would blame the caller's credentials.
+        get_user.side_effect = HTTPException(status_code=502, detail="AAI down")
+
+        with pytest.raises(HTTPException) as error:
+            require_valid_token(_request("Bearer a-token"))
+
+        assert error.value.status_code == 502
+
+
+class TestTheProxy:
+    """The two functional routes."""
+
+    @pytest.mark.asyncio
+    @patch("api.routes.redirect_routes.service_redirect.proxy_request")
+    @patch("api.routes.redirect_routes.service_redirect.get_service_access")
+    async def test_an_open_service_needs_no_token(self, access, proxy):
+        access.return_value = ("https://api.example.org", False, None)
+        proxy.return_value = MagicMock(status_code=200)
+
+        result = await proxy_to_service_functional("open-service", _request())
+
+        assert result.status_code == 200
+        proxy.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("api.routes.redirect_routes.service_redirect.proxy_request")
+    @patch("api.routes.redirect_routes.service_redirect.get_service_access")
+    async def test_a_protected_service_refuses_an_anonymous_caller(self, access, proxy):
+        access.return_value = ("https://api.example.org", True, None)
+        proxy.return_value = AsyncMock()
+
+        with pytest.raises(HTTPException) as error:
+            await proxy_to_service_functional("closed-service", _request())
+
+        assert error.value.status_code == 401
+        # The service must not be contacted at all.
+        proxy.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("api.routes.redirect_routes.service_redirect.get_current_user")
+    @patch("api.routes.redirect_routes.service_redirect.proxy_request")
+    @patch("api.routes.redirect_routes.service_redirect.get_service_access")
+    async def test_a_protected_service_lets_an_authenticated_caller_through(
+        self, access, proxy, get_user
+    ):
+        access.return_value = ("https://api.example.org", True, None)
+        proxy.return_value = MagicMock(status_code=200)
+        get_user.return_value = {"sub": "someone"}
+
+        result = await proxy_to_service_functional(
+            "closed-service", _request("Bearer a-token")
+        )
+
+        assert result.status_code == 200
+        proxy.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("api.routes.redirect_routes.service_redirect.proxy_request")
+    @patch("api.routes.redirect_routes.service_redirect.get_service_access")
+    async def test_subpaths_are_protected_too(self, access, proxy):
+        # Otherwise the gate is a formality: /svc is closed and /svc/anything
+        # reaches the same service.
+        access.return_value = ("https://api.example.org", True, None)
+
+        with pytest.raises(HTTPException) as error:
+            await proxy_to_service_with_path_functional(
+                "closed-service", "admin/users", _request()
+            )
+
+        assert error.value.status_code == 401
+        proxy.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("api.routes.redirect_routes.service_redirect.get_service_access")
+    async def test_an_unknown_service_is_still_a_404(self, access):
+        access.return_value = (None, False, "Service 'nope' not found")
+
+        with pytest.raises(HTTPException) as error:
+            await proxy_to_service_functional("nope", _request())
+
+        assert error.value.status_code == 404


### PR DESCRIPTION
The proxy at `/services/redirect/{name}` has no authentication of its own. Whoever can reach the Endpoint can reach every registered service through it, whatever the service's own access rules are.

A service can now ask for callers to be authenticated first:

```bash
curl -X POST http://localhost:8002/services \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"service_name":"private-service", ..., "extras":{"requires_auth":"true"}}'
```

From then on the Endpoint validates the caller's bearer token — the same validation as everywhere else — before forwarding anything.

**A service without that extra is exactly as open as before**, which is every service registered until now. Per service rather than a global switch, so an Endpoint can offer public and protected services side by side.

## What it is, and is not

It checks that the caller holds a token this Endpoint can validate. It is authentication, not authorization: it does not look at groups or roles. A service needing finer rules still applies them itself, and can — the proxy forwards the `Authorization` header, so the token reaches it.

That forwarding is worth stating plainly, and the diagram now does: whoever registers a service receives the tokens of everyone who reaches it through the proxy. Registering requires a writer role, so it is not open to anonymous callers, but it matters when pointing a service at somewhere you do not control.

## Verified

Against a live Endpoint, with a service registered carrying the extra:

| Request | Result |
|---|---|
| Protected, no token | **401** `This service requires authentication. Provide a bearer token.`, `WWW-Authenticate: Bearer` |
| Protected, valid token | **200**, the service's own response |
| Protected, subpath, no token | **401** |
| Open service, no token | **200**, unchanged |
| Unknown service | **404**, unchanged |

Plus 23 new unit tests covering the extra's spellings, the gate on its own — including that a 502 from the authentication service is not rewritten into a 401 — and both proxy routes, asserting the service is never contacted when the caller is refused. 1230 tests in total, `black --check .` and `flake8` clean.

## Found while testing, not fixed here

A token that is simply wrong answers **502**, everywhere in the API, not just here: the authentication service answers `400` for a token it rejects and `get_current_user` maps unrecognised statuses to 502. So a mistyped token is reported as the authentication service being broken. Filed as #234.